### PR TITLE
Fixed makefile issue when linking obj file

### DIFF
--- a/lib/include/makefile_common.mk
+++ b/lib/include/makefile_common.mk
@@ -77,7 +77,7 @@ obj/%.cpp.o: %.cpp
 
 obj/%.cu.o: %.cu
 	mkdir -p $(ROOTDIR)/obj
-	$(NVCC) $(NVCCFLAGS) $(GENCODE_FLAGS) $(INCLUDE_FLAGS) -o $@ -c $< &> /dev/null
+	$(NVCC) $(NVCCFLAGS) $(GENCODE_FLAGS) $(INCLUDE_FLAGS) -o $@ -c $< 1> /dev/null 2> /dev/null
 
 $(EXECUTABLE): $(OBJECTS)
 	$(NVCC) $(NVCCFLAGS) -o $@ $+ $(LINK_FLAGS) 


### PR DESCRIPTION
The makefile appears to treat the &> syntax as an instruction to run in the background rather than redirect all to file. This may only be an issue with some flavours of Linux
