### PR TITLE
Parallel code with OpenMP

### DIFF
--- a/lib/src/generateCPU.cc
+++ b/lib/src/generateCPU.cc
@@ -77,7 +77,6 @@ void genNeuronFunction(NNmodel &model, //!< Model description
 	string queueOffsetTrueSpk = (model.neuronNeedTrueSpk[i] ? queueOffset : "");
 
 	os << "// neuron group " << model.neuronName[i] << ENDL;
-	os << OB(55);
 
 	// increment spike queue pointer and reset spike count
 	if (model.neuronDelaySlots[i] > 1) { // with delay

--- a/lib/src/generateCPU.cc
+++ b/lib/src/generateCPU.cc
@@ -615,12 +615,12 @@ void genSynapseFunction(NNmodel &model, //!< Model description
 	}
     }
 	
+    os << model.ftype << " addtoinSyn;" << ENDL;  
+    os << ENDL;
+
 //	os << "#pragma omp parallel num_threads(4)" << ENDL;
     os << "#pragma omp parallel" << ENDL;
     os << OB(55);
-
-    os << model.ftype << " addtoinSyn;" << ENDL;  
-    os << ENDL;
 
 	// Each section runs on a different CPU core
 	os << "#pragma omp sections" << ENDL;

--- a/lib/src/generateCPU.cc
+++ b/lib/src/generateCPU.cc
@@ -106,6 +106,11 @@ void genNeuronFunction(NNmodel &model, //!< Model description
 	}
 	os << ENDL;
 
+//	os << "#pragma omp parallel num_threads(4)" << ENDL;
+	os << "#pragma omp parallel" << ENDL;
+	os << OB(55); // parallel section starts
+    	os << "#pragma omp for" << ENDL; // parallelising for
+
 	os << "for (int n = 0; n < " <<  model.neuronN[i] << "; n++)" << OB(10);
 	for (int k = 0; k < nModels[nt].varNames.size(); k++) {
 	    os << nModels[nt].varTypes[k] << " l" << nModels[nt].varNames[k] << " = ";
@@ -613,6 +618,15 @@ void genSynapseFunction(NNmodel &model, //!< Model description
     os << model.ftype << " addtoinSyn;" << ENDL;  
     os << ENDL;
 
+//	os << "#pragma omp parallel num_threads(4)" << ENDL;
+	os << "#pragma omp parallel" << ENDL;
+	
+	os << OB(55);
+
+	// Each section runs on a different CPU core
+	os << "#pragma omp sections" << ENDL;
+	os << OB(666);
+
     for (int i = 0; i < model.synapseGrpN; i++) {
 	src = model.synapseSource[i];
 	trg = model.synapseTarget[i];
@@ -620,6 +634,7 @@ void genSynapseFunction(NNmodel &model, //!< Model description
 	inSynNo = model.synapseInSynNo[i];
 
 	os << "// synapse group " << model.synapseName[i] << ENDL;
+	os << "#pragma omp section" << ENDL;
 	os << OB(1006);
 
 	if (model.neuronDelaySlots[src] > 1) {
@@ -641,6 +656,9 @@ void genSynapseFunction(NNmodel &model, //!< Model description
 	os << CB(1006);
 	os << ENDL;
     }
+
+    os << CB(666); // close omp sections
+    os << CB(55);  // close omp parallel
     os << CB(1001);
     os << ENDL;
 

--- a/lib/src/generateCPU.cc
+++ b/lib/src/generateCPU.cc
@@ -614,13 +614,13 @@ void genSynapseFunction(NNmodel &model, //!< Model description
 	    break;
 	}
     }
+	
+//	os << "#pragma omp parallel num_threads(4)" << ENDL;
+    os << "#pragma omp parallel" << ENDL;
+    os << OB(55);
+
     os << model.ftype << " addtoinSyn;" << ENDL;  
     os << ENDL;
-
-//	os << "#pragma omp parallel num_threads(4)" << ENDL;
-	os << "#pragma omp parallel" << ENDL;
-	
-	os << OB(55);
 
 	// Each section runs on a different CPU core
 	os << "#pragma omp sections" << ENDL;

--- a/lib/src/generateRunner.cc
+++ b/lib/src/generateRunner.cc
@@ -669,6 +669,7 @@ void genRunner(NNmodel &model, //!< Model description
     os << "#include <cassert>" << ENDL;
     os << "#include <stdint.h>" << ENDL;
     os << ENDL;
+    os << "#include <omp.h>"<< ENDL << ENDL; // for parallel (pragma openmp omp)
 
 
     //-----------------
@@ -2422,7 +2423,7 @@ void genMakefile(NNmodel &model, //!< Model description
 #else // UNIX
 
 #ifdef CPU_ONLY
-    string cxxFlags = "-c -DCPU_ONLY";
+    string cxxFlags = "-c -DCPU_ONLY -fopenmp"; // -fopenmp flag for OpenMP parallelising
     if (GENN_PREFERENCES::optimizeCode) cxxFlags += " -O3 -ffast-math";
     if (GENN_PREFERENCES::debugCode) cxxFlags += " -O0 -g";
 

--- a/userproject/Izh_sparse_project/model/GNUmakefile
+++ b/userproject/Izh_sparse_project/model/GNUmakefile
@@ -16,7 +16,7 @@ SOURCES            :=$(EXECUTABLE).cc
 ifndef CPU_ONLY
     SOURCES        += $(GENN_PATH)/userproject/include/GeNNHelperKrnls.cu
 endif
-OPTIMIZATIONFLAGS  :=-O3
+OPTIMIZATIONFLAGS  :=-O3 -fopenmp
 
 include	$(GENN_PATH)/userproject/include/makefile_common_gnu.mk
 

--- a/userproject/Izh_sparse_project/model/Izh_sparse_sim.h
+++ b/userproject/Izh_sparse_project/model/Izh_sparse_sim.h
@@ -31,7 +31,7 @@ using namespace std;
 //----------------------------------------------------------------------
 // other stuff:
 #define T_REPORT_TME 5000.0
-#define TOTAL_TME 1000.0
+#define TOTAL_TME 100000.0
 
 CStopWatch timer;
 


### PR DESCRIPTION
I have done some changes for the parallelisation of the code, mainly when using a Raspberry Pi 3, of course without CUDA.
A (not so) strange behaviour when benchmarking in a i7 CPU_ONLY is that the caches perform a lot better when in monothread.

Nevertheless, on RPi3 the system is faster by far, which is what I wanted :-)
To disable OpenMP remove the `-fopenmp` flag from `lib/src/generateRunner.cc` and `userproject/Izh_sparse_project/model/GNUmakefile`

Thank you!!!!!
### Benchmarks

**Raspberry Pi 3:**

NO OpenMP:
    1600 neurons in total, 100s simulation, Elapsed time is 114.0927 
With OpenMP:
    1600 neurons in total, one hundred seconds, Elapsed time is 92.1728

**PC i7:**
    MonoP:
        14k neurons in total, 10k sinapses Elapsed time is 175.2692     (100 seconds)  
    MP (4 cores):
        14k neurons in total, Elapsed time is 342.4771
    MP (8 cores):
        14k neurons in total, Elapsed time is 458.3932
