### PR TITLE
Fix spike like event support code

### DIFF
--- a/lib/include/modelSpec.h
+++ b/lib/include/modelSpec.h
@@ -29,6 +29,7 @@ Part of the code generation and generated code sections.
 #include "synapseModels.h"
 #include "postSynapseModels.h"
 
+#include <set>
 #include <string>
 #include <vector>
 
@@ -119,7 +120,7 @@ public:
   vector<bool> neuronNeedTrueSpk; //!< Whether spike-like events from a group are required
   vector<bool> neuronNeedSpkEvnt; //!< Whether spike-like events from a group are required
   vector<vector<bool> > neuronVarNeedQueue; //!< Whether a neuron variable needs queueing for syn code
-  vector<string> neuronSpkEvntCondition; //!< Will contain the spike event condition code when spike events are used
+  vector<set<pair<string, string>>> neuronSpkEvntCondition; //!< Will contain the spike event condition code when spike events are used
   vector<unsigned int> neuronDelaySlots; //!< The number of slots needed in the synapse delay queues of a neuron group
   vector<int> neuronHostID; //!< The ID of the cluster node which the neuron groups are computed on
   vector<int> neuronDeviceID; //!< The ID of the CUDA device which the neuron groups are comnputed on

--- a/lib/src/generateCPU.cc
+++ b/lib/src/generateCPU.cc
@@ -212,7 +212,7 @@ void genNeuronFunction(const NNmodel &model, //!< Model description
         // look for spike type events first.
         if (model.neuronNeedSpkEvnt[i]) {
             // Create local variable
-            os << "bool spikeLikeEvent = false" << ENDL;
+            os << "bool spikeLikeEvent = false;" << ENDL;
 
             // Loop through outgoing synapse populations that will contribute to event condition code
             for(const auto &spkEventCond : model.neuronSpkEvntCondition[i]) {

--- a/lib/src/generateCPU.cc
+++ b/lib/src/generateCPU.cc
@@ -211,24 +211,46 @@ void genNeuronFunction(const NNmodel &model, //!< Model description
 
         // look for spike type events first.
         if (model.neuronNeedSpkEvnt[i]) {
-            string eCode= model.neuronSpkEvntCondition[i];
-            // code substitutions ----
-            substitute(eCode, "$(id)", "n");
-            substitute(eCode, "$(t)", "t");
-            extended_name_substitutions(eCode, "l", nModels[model.neuronType[i]].varNames, "_pre", "");
-            name_substitutions(eCode, "", nModels[model.neuronType[i]].extraGlobalNeuronKernelParameters, model.neuronName[i]);
-            eCode= ensureFtype(eCode, model.ftype);
-            checkUnreplacedVariables(eCode, "neuronSpkEvntCondition");
-            // end code substitutions ----
-            os << "// test for and register a spike-like event" << ENDL;
-            os << "if (" + eCode + ")" << OB(30);
+            // Create local variable
+            os << "bool spikeLikeEvent = false" << ENDL;
+
+            // Loop through outgoing synapse populations that will contribute to event condition code
+            for(const auto &spkEventCond : model.neuronSpkEvntCondition[i]) {
+                // Replace of parameters, derived parameters and extraglobalsynapse parameters
+                string eCode = spkEventCond.first;
+                
+                // code substitutions ----
+                substitute(eCode, "$(id)", "n");
+                substitute(eCode, "$(t)", "t");
+                extended_name_substitutions(eCode, "l", nModels[model.neuronType[i]].varNames, "_pre", "");
+                name_substitutions(eCode, "", nModels[model.neuronType[i]].extraGlobalNeuronKernelParameters, model.neuronName[i]);
+                eCode = ensureFtype(eCode, model.ftype);
+                checkUnreplacedVariables(eCode, "neuronSpkEvntCondition");
+
+                // Open scope for spike-like event test
+                os << OB(31);
+
+                // Use synapse population support code namespace if required
+                if (!spkEventCond.second.empty()) {
+                    os << " using namespace " << spkEventCond.second << ";" << ENDL;
+                }
+
+                // Combine this event threshold test with
+                os << "spikeLikeEvent |= (" << eCode << ");" << ENDL;
+
+                // Close scope for spike-like event test
+                os << CB(31);
+              }
+
+            os << "// register a spike-like event" << ENDL;
+            os << "if (spikeLikeEvent)" << OB(30);
             os << "glbSpkEvnt" << model.neuronName[i] << "[" << queueOffset << "glbSpkCntEvnt" << model.neuronName[i];
             if (model.neuronDelaySlots[i] > 1) { // WITH DELAY
                 os << "[spkQuePtr" << model.neuronName[i] << "]++] = n;" << ENDL;
             }
             else { // NO DELAY
                 os << "[0]++] = n;" << ENDL;
-	    }
+            }
             os << CB(30);
         }
 

--- a/lib/src/modelSpec.cc
+++ b/lib/src/modelSpec.cc
@@ -262,7 +262,7 @@ void NNmodel::initLearnGrps()
                 bool used= false;
 
                 // Loop through event conditions going outward from source
-                for(const auto &spkEventCond : neuronSpkEvntCondition[i]) {
+                for(const auto &spkEventCond : neuronSpkEvntCondition[src]) {
                     // If the event threshold code contains this parameter
                     // (in it's non-uniquified form), set flag and stop searching
                     if(spkEventCond.first.find(pnamefull) != string::npos) {


### PR DESCRIPTION
Turns out some combination of the two fixes discussed in #123 seems the best idea. However I have encountered a couple of problems/questions:

1. How the 'retest' mechanism implemented in modelSpec.cc worked. I think the **intention** was to set the retest flag if there was more than one non-identical condition but it was a bit unclear. I've reimplemented neuronSpkEvntCondition as a set of code strings and namespace names which should mean identical tests don't get generated at all and the retest flag is only set if this set contains more than 1 element.
2. More seriously, how was the whole support code mechanism supposed to work in CUDA? If I don't decorate the functions I define in support code with ``__global__`` or whatever it complains about calling from GPU to CPU code mid-kernel which makes sense. However if I add the decoration it complains about kernels not being registered (and presumably also won't compile in CPU mode)