### PR TITLE
Fixup support code

### DIFF
--- a/lib/include/stringUtils.h
+++ b/lib/include/stringUtils.h
@@ -62,27 +62,11 @@ void extended_value_substitutions(string &code, const vector<string> &names, con
 
 
 //--------------------------------------------------------------------------
-/*! \brief This function converts code to contain only explicit single precision (float) function calls (C99 standard)
- */
-//--------------------------------------------------------------------------
-
-void ensureMathFunctionFtype(string &code, const string &type);
-
-
-//--------------------------------------------------------------------------
-/*! \brief This function is part of the parser that converts any floating point constant in a code snippet to a floating point constant with an explicit precision (by appending "f" or removing it). 
- */
-//--------------------------------------------------------------------------
-
-void doFinal(string &code, unsigned int i, const string &type, unsigned int &state);
-
-
-//--------------------------------------------------------------------------
 /*! \brief This function implements a parser that converts any floating point constant in a code snippet to a floating point constant with an explicit precision (by appending "f" or removing it). 
  */
 //--------------------------------------------------------------------------
 
-string ensureFtype(string oldcode, string type);
+string ensureFtype(const string &oldcode, const string &type);
 
 
 //--------------------------------------------------------------------------

--- a/lib/src/generateRunner.cc
+++ b/lib/src/generateRunner.cc
@@ -177,6 +177,13 @@ void genRunner(const NNmodel &model, //!< Model description
     os << "}" << ENDL;
     os << "#endif" << ENDL;
     os << ENDL;
+#else
+    // define CUDA device and function type qualifiers
+    os << "#define __device__" << ENDL;
+    os << "#define __global__" << ENDL;
+    os << "#define __host__" << ENDL;
+    os << "#define __constant__" << ENDL;
+    os << "#define __shared__" << ENDL;
 #endif // CPU_ONLY
 
     // write DT macro

--- a/lib/src/generateRunner.cc
+++ b/lib/src/generateRunner.cc
@@ -621,29 +621,29 @@ void genRunner(const NNmodel &model, //!< Model description
     for (int i= 0; i < model.neuronGrpN; i++) {
         if (!nModels[model.neuronType[i]].supportCode.empty()) {
             os << "namespace " << model.neuronName[i] << "_neuron" << OB(11) << ENDL;
-            os << nModels[model.neuronType[i]].supportCode << ENDL;
+            os << ensureFtype(nModels[model.neuronType[i]].supportCode, model.ftype) << ENDL;
             os << CB(11) << " // end of support code namespace " << model.neuronName[i] << ENDL;
         }
     }
     for (int i= 0; i < model.synapseGrpN; i++) {
         if (!weightUpdateModels[model.synapseType[i]].simCode_supportCode.empty()) {
             os << "namespace " << model.synapseName[i] << "_weightupdate_simCode " << OB(11) << ENDL;
-            os << weightUpdateModels[model.synapseType[i]].simCode_supportCode << ENDL;
+            os << ensureFtype(weightUpdateModels[model.synapseType[i]].simCode_supportCode, model.ftype) << ENDL;
             os << CB(11) << " // end of support code namespace " << model.synapseName[i] << "_weightupdate_simCode " << ENDL;
         }
         if (!weightUpdateModels[model.synapseType[i]].simLearnPost_supportCode.empty()) {
             os << "namespace " << model.synapseName[i] << "_weightupdate_simLearnPost " << OB(11) << ENDL;
-            os << weightUpdateModels[model.synapseType[i]].simLearnPost_supportCode << ENDL;
+            os << ensureFtype(weightUpdateModels[model.synapseType[i]].simLearnPost_supportCode, model.ftype) << ENDL;
             os << CB(11) << " // end of support code namespace " << model.synapseName[i] << "_weightupdate_simLearnPost " << ENDL;
         }
         if (!weightUpdateModels[model.synapseType[i]].synapseDynamics_supportCode.empty()) {
             os << "namespace " << model.synapseName[i] << "_weightupdate_synapseDynamics " << OB(11) << ENDL;
-            os << weightUpdateModels[model.synapseType[i]].synapseDynamics_supportCode << ENDL;
+            os << ensureFtype(weightUpdateModels[model.synapseType[i]].synapseDynamics_supportCode, model.ftype) << ENDL;
             os << CB(11) << " // end of support code namespace " << model.synapseName[i] << "_weightupdate_synapseDynamics " << ENDL;
         }
         if (!postSynModels[model.postSynapseType[i]].supportCode.empty()) {
             os << "namespace " << model.synapseName[i] << "_postsyn " << OB(11) << ENDL;
-            os << postSynModels[model.postSynapseType[i]].supportCode << ENDL;
+            os << ensureFtype(postSynModels[model.postSynapseType[i]].supportCode, model.ftype) << ENDL;
             os << CB(11) << " // end of support code namespace " << model.synapseName[i] << "_postsyn " << ENDL;
         }
 

--- a/lib/src/stringUtils.cc
+++ b/lib/src/stringUtils.cc
@@ -9,64 +9,11 @@
 #include <regex>
 #endif
 
-
 //--------------------------------------------------------------------------
-//! \brief Tool for substituting strings in the neuron code strings or other templates
+// Anonymous namespace
 //--------------------------------------------------------------------------
-
-void substitute(string &s, const string &trg, const string &rep)
+namespace
 {
-    size_t found= s.find(trg);
-    while (found != string::npos) {
-        s.replace(found,trg.length(),rep);
-        found= s.find(trg);
-    }
-}
-
-//--------------------------------------------------------------------------
-//! \brief This function performs a list of name substitutions for variables in code snippets.
-//--------------------------------------------------------------------------
-
-void name_substitutions(string &code, const string &prefix, const vector<string> &names, const string &postfix)
-{
-    for (int k = 0, l = names.size(); k < l; k++) {
-        substitute(code, "$(" + names[k] + ")", prefix + names[k] + postfix);
-    }
-}
-
-//--------------------------------------------------------------------------
-//! \brief This function performs a list of value substitutions for parameters in code snippets.
-//--------------------------------------------------------------------------
-
-void value_substitutions(string &code, const vector<string> &names, const vector<double> &values)
-{
-    for (int k = 0, l = names.size(); k < l; k++) {
-        substitute(code, "$(" + names[k] + ")", "(" + to_string(values[k]) + ")");
-    }
-}
-
-//--------------------------------------------------------------------------
-//! \brief This function performs a list of name substitutions for variables in code snippets where the variables have an extension in their names (e.g. "_pre").
-//--------------------------------------------------------------------------
-
-void extended_name_substitutions(string &code, const string &prefix, const vector<string> &names, const string &ext, const string &postfix)
-{
-    for (int k = 0, l = names.size(); k < l; k++) {
-        substitute(code, "$(" + names[k] + ext + ")", prefix + names[k] + postfix);
-    }
-}
-
-//--------------------------------------------------------------------------
-//! \brief This function performs a list of value substitutions for parameters in code snippets where the parameters have an extension in their names (e.g. "_pre").
-//--------------------------------------------------------------------------
-
-void extended_value_substitutions(string &code, const vector<string> &names, const string &ext, const vector<double> &values)
-{
-    for (int k = 0, l = names.size(); k < l; k++) {
-        substitute(code, "$(" + names[k] + ext + ")", "(" + to_string(values[k]) + ")");
-    }
-}
-
 const string digits= string("0123456789");
 const string op= string("+-*/(<>= ,;")+string("\n")+string("\t");
 
@@ -189,12 +136,10 @@ const char *__fnames[__mathFN]= {
     "fmaf"
 };
 
-
 //--------------------------------------------------------------------------
 /*! \brief This function converts code to contain only explicit single precision (float) function calls (C99 standard)
  */
 //--------------------------------------------------------------------------
-
 void ensureMathFunctionFtype(string &code, const string &type)
 {
     if (type == string("double")) {
@@ -209,12 +154,10 @@ void ensureMathFunctionFtype(string &code, const string &type)
     }
 }
 
-
 //--------------------------------------------------------------------------
-/*! \brief This function is part of the parser that converts any floating point constant in a code snippet to a floating point constant with an explicit precision (by appending "f" or removing it). 
+/*! \brief This function is part of the parser that converts any floating point constant in a code snippet to a floating point constant with an explicit precision (by appending "f" or removing it).
  */
 //--------------------------------------------------------------------------
-
 void doFinal(string &code, unsigned int i, const string &type, unsigned int &state)
 {
     if (code[i] == 'f') {
@@ -237,13 +180,70 @@ void doFinal(string &code, unsigned int i, const string &type, unsigned int &sta
     }
 }
 
+}
+//--------------------------------------------------------------------------
+//! \brief Tool for substituting strings in the neuron code strings or other templates
+//--------------------------------------------------------------------------
+
+void substitute(string &s, const string &trg, const string &rep)
+{
+    size_t found= s.find(trg);
+    while (found != string::npos) {
+        s.replace(found,trg.length(),rep);
+        found= s.find(trg);
+    }
+}
+
+//--------------------------------------------------------------------------
+//! \brief This function performs a list of name substitutions for variables in code snippets.
+//--------------------------------------------------------------------------
+
+void name_substitutions(string &code, const string &prefix, const vector<string> &names, const string &postfix)
+{
+    for (int k = 0, l = names.size(); k < l; k++) {
+        substitute(code, "$(" + names[k] + ")", prefix + names[k] + postfix);
+    }
+}
+
+//--------------------------------------------------------------------------
+//! \brief This function performs a list of value substitutions for parameters in code snippets.
+//--------------------------------------------------------------------------
+
+void value_substitutions(string &code, const vector<string> &names, const vector<double> &values)
+{
+    for (int k = 0, l = names.size(); k < l; k++) {
+        substitute(code, "$(" + names[k] + ")", "(" + to_string(values[k]) + ")");
+    }
+}
+
+//--------------------------------------------------------------------------
+//! \brief This function performs a list of name substitutions for variables in code snippets where the variables have an extension in their names (e.g. "_pre").
+//--------------------------------------------------------------------------
+
+void extended_name_substitutions(string &code, const string &prefix, const vector<string> &names, const string &ext, const string &postfix)
+{
+    for (int k = 0, l = names.size(); k < l; k++) {
+        substitute(code, "$(" + names[k] + ext + ")", prefix + names[k] + postfix);
+    }
+}
+
+//--------------------------------------------------------------------------
+//! \brief This function performs a list of value substitutions for parameters in code snippets where the parameters have an extension in their names (e.g. "_pre").
+//--------------------------------------------------------------------------
+
+void extended_value_substitutions(string &code, const vector<string> &names, const string &ext, const vector<double> &values)
+{
+    for (int k = 0, l = names.size(); k < l; k++) {
+        substitute(code, "$(" + names[k] + ext + ")", "(" + to_string(values[k]) + ")");
+    }
+}
 
 //--------------------------------------------------------------------------
 /*! \brief This function implements a parser that converts any floating point constant in a code snippet to a floating point constant with an explicit precision (by appending "f" or removing it). 
  */
 //--------------------------------------------------------------------------
 
-string ensureFtype(string oldcode, string type) 
+string ensureFtype(const string &oldcode, const string &type)
 {
 //    cerr << "entering ensure" << endl;
 //    cerr << oldcode << endl;


### PR DESCRIPTION
This should solve the issues with CUDA constructs in support code
- In CPU_ONLY mode all the CUDA qualifiers are #defined to nothing (as @kernfel suggested)
- Support code is run through ensureFType