### PR TITLE
Fix syntax for nested template use

### DIFF
--- a/lib/include/modelSpec.h
+++ b/lib/include/modelSpec.h
@@ -120,7 +120,7 @@ public:
   vector<bool> neuronNeedTrueSpk; //!< Whether spike-like events from a group are required
   vector<bool> neuronNeedSpkEvnt; //!< Whether spike-like events from a group are required
   vector<vector<bool> > neuronVarNeedQueue; //!< Whether a neuron variable needs queueing for syn code
-  vector<set<pair<string, string>>> neuronSpkEvntCondition; //!< Will contain the spike event condition code when spike events are used
+  vector<set<pair<string, string> > > neuronSpkEvntCondition; //!< Will contain the spike event condition code when spike events are used
   vector<unsigned int> neuronDelaySlots; //!< The number of slots needed in the synapse delay queues of a neuron group
   vector<int> neuronHostID; //!< The ID of the cluster node which the neuron groups are computed on
   vector<int> neuronDeviceID; //!< The ID of the CUDA device which the neuron groups are comnputed on


### PR DESCRIPTION
The commit a1d23010 changed line 123 of `modelSpec.h` from
```C++
vector<string> neuronSpkEvntCondition;
```
to
```C++
vector<set<pair<string, string>>> neuronSpkEvntCondition;
```
My compiler (g++ 5.4) does not seem to like this:
```
error: ‘>>’ should be ‘> >’ within a nested template argument list
```
Adding spaces to the closing angular brackets does indeed solve the problem for me.