### PR TITLE
Zero copy

### DIFF
--- a/lib/include/generateRunner.h
+++ b/lib/include/generateRunner.h
@@ -29,20 +29,6 @@ using namespace std;
 
 
 //--------------------------------------------------------------------------
-//! \brief This fucntion generates host and device variable definitions, of the given type and name.
-//--------------------------------------------------------------------------
-
-void variable_def(ofstream &os, const string &type, const string &name);
-
-
-//--------------------------------------------------------------------------
-//! \brief This fucntion generates host extern variable definitions, of the given type and name.
-//--------------------------------------------------------------------------
-
-void extern_variable_def(ofstream &os, const string &type, const string &name);
-
-
-//--------------------------------------------------------------------------
 /*!
   \brief A function that generates predominantly host-side code.
 

--- a/lib/include/modelSpec.h
+++ b/lib/include/modelSpec.h
@@ -128,6 +128,10 @@ public:
   vector<unsigned int> neuronDelaySlots; //!< The number of slots needed in the synapse delay queues of a neuron group
   vector<int> neuronHostID; //!< The ID of the cluster node which the neuron groups are computed on
   vector<int> neuronDeviceID; //!< The ID of the CUDA device which the neuron groups are comnputed on
+  vector<bool> neuronSpikeZeroCopy; //!< Whether spikes from neuron group should use zero-copied memory
+  vector<bool> neuronSpikeEventZeroCopy; //!< Whether spike-like events from neuron group should use zero-copied memory
+  vector<bool> neuronSpikeTimeZeroCopy; //!< Whether spike times from neuron group should use zero-copied memory
+  vector<set<string>> neuronInitValZeroCopy;   //!< Whether indidividual state variables of a neuron group should use zero-copied memory
 
 
   // PUBLIC SYNAPSE VARIABLES
@@ -218,6 +222,7 @@ public:
   void setPopulationSums(); //!< Set the accumulated sums of lowest multiple of kernel block size >= group sizes for all simulated groups.
   void finalize(); //!< Declare that the model specification is finalised in modelDefinition().
 
+  bool zeroCopyInUse() const;
 
   // PUBLIC NEURON FUNCTIONS
   //========================
@@ -248,12 +253,23 @@ public:
       neuronNeedSpkEvnt.push_back(false);
       neuronDelaySlots.push_back(1);
 
+      // By default zero-copy should be disabled
+      neuronSpikeZeroCopy.push_back(false);
+      neuronSpikeEventZeroCopy.push_back(false);
+      neuronSpikeTimeZeroCopy.push_back(false);
+      neuronInitValZeroCopy.push_back(set<string>());
+
       // initially set neuron group indexing variables to device 0 host 0
       neuronDeviceID.push_back(0);
       neuronHostID.push_back(0);
   }
 
   void setNeuronClusterIndex(const string &neuronGroup, int hostID, int deviceID); //!< Function for setting which host and which device a neuron group will be simulated on
+  void setNeuronSpikeZeroCopy(const string &neuronGroup);   //!< Function to specify that neuron group should use zero-copied memory for its spikes - May improve IO performance at the expense of kernel performance
+  void setNeuronSpikeEventZeroCopy(const string &neuronGroup);   //!< Function to specify that neuron group should use zero-copied memory for its spike-like events - May improve IO performance at the expense of kernel performance
+  void setNeuronSpikeTimeZeroCopy(const string &neuronGroup);   //!< Function to specify that neuron group should use zero-copied memory for its spike times - May improve IO performance at the expense of kernel performance
+  void setNeuronInitValZeroCopy(const string &neuronGroup, const string &var);   //!< Function to specify that neuron group should use zero-copied memory for a particular state variable - May improve IO performance at the expense of kernel performance
+
   void activateDirectInput(const string&, unsigned int type); //! This function has been deprecated in GeNN 2.2
   void setConstInp(const string&, double);
   unsigned int findNeuronGrp(const string&) const; //!< Find the the ID number of a neuron group by its name

--- a/lib/include/modelSpec.h
+++ b/lib/include/modelSpec.h
@@ -171,7 +171,8 @@ public:
   vector<unsigned int> padSumSynDynN; //!< Padded summed neuron numbers of synapse dynamics group source populations
   vector<int> synapseHostID; //!< The ID of the cluster node which the synapse groups are computed on
   vector<int> synapseDeviceID; //!< The ID of the CUDA device which the synapse groups are comnputed on
-
+  vector<set<string>> synapseInitValZeroCopy; //!< Whether indidividual weight update model state variables of a synapse group should use zero-copied memory
+  vector<set<string>> postSynapseInitValZeroCopy; //!< Whether indidividual post synapse model state variables of a synapse group should use zero-copied memory
 
   // PUBLIC KERNEL PARAMETER VARIABLES
   //==================================
@@ -327,6 +328,10 @@ public:
       maxConn.push_back(neuronN[trgNumber]);
       synapseSpanType.push_back(0);
 
+      // By default zero-copy should be disabled
+      synapseInitValZeroCopy.push_back(set<string>());
+      postSynapseInitValZeroCopy.push_back(set<string>());
+
       // initially set synapase group indexing variables to device 0 host 0
       synapseDeviceID.push_back(0);
       synapseHostID.push_back(0);
@@ -336,6 +341,9 @@ public:
   void setMaxConn(const string&, unsigned int); //< Set maximum connections per neuron for the given group (needed for optimization by sparse connectivity)
   void setSpanTypeToPre(const string&); //!< Method for switching the execution order of synapses to pre-to-post
   void setSynapseClusterIndex(const string &synapseGroup, int hostID, int deviceID); //!< Function for setting which host and which device a synapse group will be simulated on
+  void setSynapseWeightUpdateInitValZeroCopy(const string &synapseGroup, const string &var);   //!< Function to specify that synapse group should use zero-copied memory for a particular weight update model state variable - May improve IO performance at the expense of kernel performance
+  void setSynapsePostsynapticInitValZeroCopy(const string &synapseGroup, const string &var);   //!< Function to specify that synapse group should use zero-copied memory for a particular postsynaptic model state variable - May improve IO performance at the expense of kernel performance
+
   void initLearnGrps();
   unsigned int findSynapseGrp(const string&) const; //< Find the the ID number of a synapse group by its name
  

--- a/lib/include/modelSpec.h
+++ b/lib/include/modelSpec.h
@@ -141,14 +141,14 @@ public:
   vector<const WeightUpdateModels::Base*> synapseModel; //!< Types of synapses
   vector<SynapseConnType> synapseConnType; //!< Connectivity type of synapses
   vector<SynapseGType> synapseGType; //!< Type of specification method for synaptic conductance
-  vector<unsigned int> synapseSpanType; //!< Execution order of synapses in the kernel. It determines whether synapses are executed in parallel for every postsynaptic neuron (0, default), or for every presynaptic neuron (1). 
+  vector<unsigned int> synapseSpanType; //!< Execution order of synapses in the kernel. It determines whether synapses are executed in parallel for every postsynaptic neuron (0, default), or for every presynaptic neuron (1).
   vector<unsigned int> synapseSource; //!< Presynaptic neuron groups
   vector<unsigned int> synapseTarget; //!< Postsynaptic neuron groups
   vector<unsigned int> synapseInSynNo; //!< IDs of the target neurons' incoming synapse variables for each synapse group
   vector<unsigned int> synapseOutSynNo; //!< The target neurons' outgoing synapse for each synapse group
   vector<bool> synapseUsesTrueSpikes; //!< Defines if synapse update is done after detection of real spikes (only one point after threshold)
   vector<bool> synapseUsesSpikeEvents; //!< Defines if synapse update is done after detection of spike events (every point above threshold)
-  vector<bool> synapseUsesPostLearning; //!< Defines if anything is done in case of postsynaptic neuron spiking before presynaptic neuron (punishment in STDP etc.) 
+  vector<bool> synapseUsesPostLearning; //!< Defines if anything is done in case of postsynaptic neuron spiking before presynaptic neuron (punishment in STDP etc.)
   vector<bool> synapseUsesSynapseDynamics; //!< Defines if there is any continuos synapse dynamics defined
   vector<bool> needEvntThresholdReTest; //!< Defines whether the Evnt Threshold needs to be retested in the synapse kernel due to multiple non-identical events in the pre-synaptic neuron population
   vector<vector<double> > synapsePara; //!< parameters of synapses
@@ -180,31 +180,19 @@ public:
   vector<string> simLearnPostKernelParameterTypes;
   vector<string> synapseDynamicsKernelParameters;
   vector<string> synapseDynamicsKernelParameterTypes;
-    
+
 private:
 
 
   // PRIVATE NEURON FUNCTIONS
   //=========================
 
-  void setNeuronName(unsigned int, const string); //!< Never used
-  void setNeuronN(unsigned int, unsigned int); //!< Never used
-  void setNeuronType(unsigned int, unsigned int); //!< Never used
-  void setNeuronPara(unsigned int, double*); //!< Never used
-  void setNeuronIni(unsigned int, double*); //!< Never used
   void initDerivedNeuronPara(); //!< Method for calculating the values of derived neuron parameters.
 
 
   // PRIVATE SYNAPSE FUNCTIONS
   //==========================
 
-  void setSynapseName(unsigned int, const string); //!< Never used
-  void setSynapseType(unsigned int, unsigned int); //!< Never used
-  void setSynapseSource(unsigned int, unsigned int); //!< Never used
-  void setSynapseTarget(unsigned int, unsigned int); //!< Never used
-  void setSynapsePara(unsigned int, double*); //!< Never used
-  void setSynapseConnType(unsigned int, unsigned int); //!< Never used
-  void setSynapseGType(unsigned int, unsigned int); //!< Never used
   void initDerivedSynapsePara(); //!< Method for calculating the values of derived synapse parameters.
   void initDerivedPostSynapsePara(); //!< Method for calculating the values of derived postsynapse parameters.
   void registerSynapsePopulation(unsigned int); //!< Method to register a new synapse population with the inSyn list of the target neuron population

--- a/lib/include/modelSpec.h
+++ b/lib/include/modelSpec.h
@@ -115,15 +115,15 @@ public:
   vector<unsigned int> padSumNeuronN; //!< Padded summed neuron numbers
   vector<unsigned int> neuronPostSyn; //! Postsynaptic methods to the neuron
   vector<const NeuronModels::Base*> neuronModel;  //!< Neuron models
-  vector<vector<double> > neuronPara; //!< Parameters of neurons
-  vector<vector<double> > dnp; //!< Derived neuron parameters
-  vector<vector<double> > neuronIni; //!< Initial values of neurons
-  vector<vector<unsigned int> > inSyn; //!< The ids of the incoming synapse groups
-  vector<vector<unsigned int> > outSyn; //!< The ids of the outgoing synapse groups
+  vector<vector<double>> neuronPara; //!< Parameters of neurons
+  vector<vector<double>> dnp; //!< Derived neuron parameters
+  vector<vector<double>> neuronIni; //!< Initial values of neurons
+  vector<vector<unsigned int>> inSyn; //!< The ids of the incoming synapse groups
+  vector<vector<unsigned int>> outSyn; //!< The ids of the outgoing synapse groups
   vector<bool> neuronNeedSt; //!< Whether last spike time needs to be saved for a group
   vector<bool> neuronNeedTrueSpk; //!< Whether spike-like events from a group are required
   vector<bool> neuronNeedSpkEvnt; //!< Whether spike-like events from a group are required
-  vector<vector<bool> > neuronVarNeedQueue; //!< Whether a neuron variable needs queueing for syn code
+  vector<vector<bool>> neuronVarNeedQueue; //!< Whether a neuron variable needs queueing for syn code
   vector<set<pair<string, string>>> neuronSpkEvntCondition; //!< Will contain the spike event condition code when spike events are used
   vector<unsigned int> neuronDelaySlots; //!< The number of slots needed in the synapse delay queues of a neuron group
   vector<int> neuronHostID; //!< The ID of the cluster node which the neuron groups are computed on
@@ -151,13 +151,13 @@ public:
   vector<bool> synapseUsesPostLearning; //!< Defines if anything is done in case of postsynaptic neuron spiking before presynaptic neuron (punishment in STDP etc.)
   vector<bool> synapseUsesSynapseDynamics; //!< Defines if there is any continuos synapse dynamics defined
   vector<bool> needEvntThresholdReTest; //!< Defines whether the Evnt Threshold needs to be retested in the synapse kernel due to multiple non-identical events in the pre-synaptic neuron population
-  vector<vector<double> > synapsePara; //!< parameters of synapses
-  vector<vector<double> > synapseIni; //!< Initial values of synapse variables
-  vector<vector<double> > dsp_w;  //!< Derived synapse parameters (weightUpdateModel only)
+  vector<vector<double>> synapsePara; //!< parameters of synapses
+  vector<vector<double>> synapseIni; //!< Initial values of synapse variables
+  vector<vector<double>> dsp_w;  //!< Derived synapse parameters (weightUpdateModel only)
   vector<const PostsynapticModels::Base*> postSynapseModel; //!< Types of post-synaptic model
-  vector<vector<double> > postSynapsePara; //!< parameters of postsynapses
-  vector<vector<double> > postSynIni; //!< Initial values of postsynaptic variables
-  vector<vector<double> > dpsp;  //!< Derived postsynapse parameters
+  vector<vector<double>> postSynapsePara; //!< parameters of postsynapses
+  vector<vector<double>> postSynIni; //!< Initial values of postsynaptic variables
+  vector<vector<double>> dpsp;  //!< Derived postsynapse parameters
   unsigned int lrnGroups; //!< Number of synapse groups with learning
   vector<unsigned int> padSumLearnN; //!< Padded summed neuron numbers of learn group source populations
   vector<unsigned int> lrnSynGrp; //!< Enumeration of the IDs of synapse groups that learn

--- a/lib/include/newModels.h
+++ b/lib/include/newModels.h
@@ -11,7 +11,7 @@
 //----------------------------------------------------------------------------
 // Macros
 //----------------------------------------------------------------------------
-#define DECLARE_MODEL(TYPE, NUM_PARAMS, NUM_INIT_VALUES)       \
+#define DECLARE_MODEL(TYPE, NUM_PARAMS, NUM_VARS)              \
 private:                                                       \
     static TYPE *s_Instance;                                   \
 public:                                                        \
@@ -24,14 +24,14 @@ public:                                                        \
         return s_Instance;                                     \
     }                                                          \
     typedef NewModels::ValueBase<NUM_PARAMS> ParamValues;      \
-    typedef NewModels::ValueBase<NUM_INIT_VALUES> InitValues;
+    typedef NewModels::ValueBase<NUM_VARS> VarValues;
 
 
 #define IMPLEMENT_MODEL(TYPE) TYPE *TYPE::s_Instance = NULL
 
 #define SET_PARAM_NAMES(...) virtual std::vector<std::string> GetParamNames() const{ return __VA_ARGS__; }
 #define SET_DERIVED_PARAMS(...) virtual std::vector<std::pair<std::string, DerivedParamFunc>> GetDerivedParams() const{ return __VA_ARGS__; }
-#define SET_INIT_VALS(...) virtual std::vector<std::pair<std::string, std::string>> GetInitVals() const{ return __VA_ARGS__; }
+#define SET_VARS(...) virtual std::vector<std::pair<std::string, std::string>> GetVars() const{ return __VA_ARGS__; }
 
 //----------------------------------------------------------------------------
 // NewModels::ValueBase
@@ -111,7 +111,7 @@ public:
     //----------------------------------------------------------------------------
     virtual std::vector<std::string> GetParamNames() const{ return {}; }
     virtual std::vector<std::pair<std::string, DerivedParamFunc>> GetDerivedParams() const{ return {}; }
-    virtual std::vector<std::pair<std::string, std::string>> GetInitVals() const{ return {}; }
+    virtual std::vector<std::pair<std::string, std::string>> GetVars() const{ return {}; }
 };
 
 //----------------------------------------------------------------------------
@@ -132,13 +132,13 @@ public:
     //----------------------------------------------------------------------------
     // ModelBase virtuals
     //----------------------------------------------------------------------------
-    std::vector<std::string>  GetParamNames() const
+    virtual std::vector<std::string>  GetParamNames() const
     {
         const auto &nm = ModelArray[m_LegacyTypeIndex];
         return nm.pNames;
     }
 
-    std::vector<std::pair<std::string, DerivedParamFunc>> GetDerivedParams() const
+    virtual std::vector<std::pair<std::string, DerivedParamFunc>> GetDerivedParams() const
     {
         const auto &m = ModelArray[m_LegacyTypeIndex];
 
@@ -162,7 +162,8 @@ public:
 
         return derivedParams;
     }
-    std::vector<std::pair<std::string, std::string>> GetInitVals() const
+
+    virtual std::vector<std::pair<std::string, std::string>> GetVars() const
     {
         const auto &nm = ModelArray[m_LegacyTypeIndex];
         return ZipStringVectors(nm.varNames, nm.varTypes);

--- a/lib/include/newNeuronModels.h
+++ b/lib/include/newNeuronModels.h
@@ -88,7 +88,7 @@ public:
     SET_THRESHOLD_CONDITION_CODE("$(V) >= 29.99");
 
     SET_PARAM_NAMES({"a", "b", "c", "d"});
-    SET_INIT_VALS({{"V","scalar"}, {"U", "scalar"}});
+    SET_VARS({{"V","scalar"}, {"U", "scalar"}});
 };
 
 //----------------------------------------------------------------------------
@@ -126,7 +126,7 @@ public:
     SET_THRESHOLD_CONDITION_CODE("$(V) >= $(Vspike)");
 
     SET_PARAM_NAMES({"therate", "trefract", "Vspike", "Vrest"});
-    SET_INIT_VALS({{"V", "scalar"}, {"seed", "uint64_t"}, {"spikeTime", "scalar"}});
+    SET_VARS({{"V", "scalar"}, {"seed", "uint64_t"}, {"spikeTime", "scalar"}});
     SET_EXTRA_GLOBAL_PARAMS({{"rates", "uint64_t *"}, {"offset", "unsigned int"}});
 
     virtual bool IsPoisson() const{ return true; }

--- a/lib/include/newWeightUpdateModels.h
+++ b/lib/include/newWeightUpdateModels.h
@@ -86,7 +86,7 @@ class StaticPulse : public Base
 public:
     DECLARE_MODEL(StaticPulse, 0, 1);
 
-    SET_INIT_VALS({{"g","scalar"}});
+    SET_VARS({{"g","scalar"}});
 
     SET_SIM_CODE(
         "$(addtoinSyn) = $(g);\n"
@@ -102,7 +102,7 @@ public:
     DECLARE_MODEL(StaticGraded, 2, 1);
 
     SET_PARAM_NAMES({"Epre", "Vslope"});
-    SET_INIT_VALS({{"g","scalar"}});
+    SET_VARS({{"g","scalar"}});
 
     SET_SIM_CODE(
         "$(addtoinSyn) = $(g) * tanh(($(V_pre) - $(Epre)) / $(Vslope))* DT;\n"
@@ -123,7 +123,7 @@ public:
 
     SET_PARAM_NAMES({"tLrn", "tChng", "tDecay", "tPunish10", "tPunish01",
         "gMax", "gMid", "gSlope", "tauShift", "gSyn0"});
-    SET_INIT_VALS({{"g", "scalar"}, {"gRaw", "scalar"}});
+    SET_VARS({{"g", "scalar"}, {"gRaw", "scalar"}});
 
     SET_SIM_CODE(
         "$(addtoinSyn) = $(g);"

--- a/lib/include/utils.h
+++ b/lib/include/utils.h
@@ -82,6 +82,12 @@ using namespace std;
 
 #define delB(x,i) x= ((x) & (~(0x80000000 >> (i)))) //!< Set the bit at the specified position i in x to 0
 
+//--------------------------------------------------------------------------
+/*! \brief Miscellaneous macros
+ */
+//--------------------------------------------------------------------------
+
+#define USE(expr) do { (void)(expr); } while (0) //!< Silence 'unused parameter' warnings
 
 #ifndef CPU_ONLY
 //--------------------------------------------------------------------------

--- a/lib/include/utils.h
+++ b/lib/include/utils.h
@@ -98,14 +98,14 @@ CUresult cudaFuncGetAttributesDriver(cudaFuncAttributes *attr, CUfunction kern);
  */
 //--------------------------------------------------------------------------
 
-void gennError(string error);
+void gennError(const string &error);
 
 
 //--------------------------------------------------------------------------
 //! \brief Tool for determining the size of variable types on the current architecture
 //--------------------------------------------------------------------------
 
-unsigned int theSize(string type);
+unsigned int theSize(const string &type);
 
 
 //--------------------------------------------------------------------------

--- a/lib/src/codeGenUtils.cc
+++ b/lib/src/codeGenUtils.cc
@@ -348,15 +348,15 @@ void neuron_substitutions_in_synaptic_code(
         substitute(wCode, "$(V_pre)", to_string(model.neuronPara[src][2]));
     }
     substitute(wCode, "$(sT_pre)", devPrefix+ "sT" + model.neuronName[src] + "[" + offsetPre + preIdx + "]");
-    auto preInitVals = model.neuronModel[src]->GetInitVals();
-    for (size_t j = 0; j < preInitVals.size(); j++) {
+    auto preVars = model.neuronModel[src]->GetVars();
+    for (size_t j = 0; j < preVars.size(); j++) {
         if (model.neuronVarNeedQueue[src][j]) {
-            substitute(wCode, "$(" + preInitVals[j].first + "_pre)",
-                       devPrefix + preInitVals[j].first + model.neuronName[src] + "[" + offsetPre + preIdx + "]");
+            substitute(wCode, "$(" + preVars[j].first + "_pre)",
+                       devPrefix + preVars[j].first + model.neuronName[src] + "[" + offsetPre + preIdx + "]");
         }
         else {
-            substitute(wCode, "$(" + preInitVals[j].first + "_pre)",
-                       devPrefix + preInitVals[j].first + model.neuronName[src] + "[" + preIdx + "]");
+            substitute(wCode, "$(" + preVars[j].first + "_pre)",
+                       devPrefix + preVars[j].first + model.neuronName[src] + "[" + preIdx + "]");
         }
     }
     extended_value_substitutions(wCode, model.neuronModel[src]->GetParamNames(), "_pre", model.neuronPara[src]);
@@ -373,15 +373,15 @@ void neuron_substitutions_in_synaptic_code(
     
     // postsynaptic neuron variables, parameters, and global parameters
     substitute(wCode, "$(sT_post)", devPrefix + "sT" + model.neuronName[trg] + "[" + offsetPost + postIdx + "]");
-    auto postInitVals = model.neuronModel[trg]->GetInitVals();
-    for (size_t j = 0; j < postInitVals.size(); j++) {
+    auto postVars = model.neuronModel[trg]->GetVars();
+    for (size_t j = 0; j < postVars.size(); j++) {
         if (model.neuronVarNeedQueue[trg][j]) {
-            substitute(wCode, "$(" + postInitVals[j].first + "_post)",
-                       devPrefix + postInitVals[j].first + model.neuronName[trg] + "[" + offsetPost + postIdx + "]");
+            substitute(wCode, "$(" + postVars[j].first + "_post)",
+                       devPrefix + postVars[j].first + model.neuronName[trg] + "[" + offsetPost + postIdx + "]");
         }
         else {
-            substitute(wCode, "$(" + postInitVals[j].first + "_post)",
-                       devPrefix + postInitVals[j].first + model.neuronName[trg] + "[" + postIdx + "]");
+            substitute(wCode, "$(" + postVars[j].first + "_post)",
+                       devPrefix + postVars[j].first + model.neuronName[trg] + "[" + postIdx + "]");
         }
     }
     extended_value_substitutions(wCode, model.neuronModel[trg]->GetParamNames(), "_post", model.neuronPara[trg]);

--- a/lib/src/generateCPU.cc
+++ b/lib/src/generateCPU.cc
@@ -109,9 +109,9 @@ void genNeuronFunction(const NNmodel &model, //!< Model description
         auto neuronModel = model.neuronModel[i];
 
         // Create iterators to iterate over the names of the neuron model's initial values
-        auto neuronModelInitVars = neuronModel->GetInitVals();
-        auto neuronModelInitVarNameBegin = GetPairKeyConstIter(neuronModelInitVars.cbegin());
-        auto neuronModelInitVarNameEnd = GetPairKeyConstIter(neuronModelInitVars.cend());
+        auto neuronModelVars = neuronModel->GetVars();
+        auto neuronModelVarNameBegin = GetPairKeyConstIter(neuronModelVars.cbegin());
+        auto neuronModelVarNameEnd = GetPairKeyConstIter(neuronModelVars.cend());
 
         // Create iterators to iterate over the names of the neuron model's derived parameters
         auto neuronModelDerivedParams = neuronModel->GetDerivedParams();
@@ -122,10 +122,10 @@ void genNeuronFunction(const NNmodel &model, //!< Model description
         auto neuronModelExtraGlobalParams = neuronModel->GetExtraGlobalParams();
         auto neuronModelExtraGlobalParamsNameBegin = GetPairKeyConstIter(neuronModelExtraGlobalParams.cbegin());
         auto neuronModelExtraGlobalParamsNameEnd = GetPairKeyConstIter(neuronModelExtraGlobalParams.cend());
-        for (size_t k = 0; k < neuronModelInitVars.size(); k++) {
+        for (size_t k = 0; k < neuronModelVars.size(); k++) {
 
-            os << neuronModelInitVars[k].second << " l" << neuronModelInitVars[k].first << " = ";
-            os << neuronModelInitVars[k].first << model.neuronName[i] << "[";
+            os << neuronModelVars[k].second << " l" << neuronModelVars[k].first << " = ";
+            os << neuronModelVars[k].first << model.neuronName[i] << "[";
             if ((model.neuronVarNeedQueue[i][k]) && (model.neuronDelaySlots[i] > 1)) {
                 os << "(delaySlot * " << model.neuronN[i] << ") + ";
             }
@@ -152,7 +152,7 @@ void genNeuronFunction(const NNmodel &model, //!< Model description
 
 
             if (model.synapseGType[synPopID] == INDIVIDUALG) {
-                for(const auto &v : psm->GetInitVals()) {
+                for(const auto &v : psm->GetVars()) {
                     os << v.second << " lps" << v.first << sName;
                     os << " = " <<  v.first << sName << "[n];" << ENDL;
                 }
@@ -163,20 +163,20 @@ void genNeuronFunction(const NNmodel &model, //!< Model description
             substitute(psCode, "$(t)", "t");
             substitute(psCode, "$(inSyn)", "inSyn" + sName + "[n]");
 
-            name_substitutions(psCode, "l", neuronModelInitVarNameBegin, neuronModelInitVarNameEnd, "");
+            name_substitutions(psCode, "l", neuronModelVarNameBegin, neuronModelVarNameEnd, "");
             value_substitutions(psCode, neuronModel->GetParamNames(), model.neuronPara[i]);
             value_substitutions(psCode, neuronModelDerivedParamNameBegin, neuronModelDerivedParamNameEnd, model.dnp[i]);
 
             // Create iterators to iterate over the names of the postsynaptic model's initial values
-            auto psmInitVars = psm->GetInitVals();
-            auto psmInitVarNameBegin = GetPairKeyConstIter(psmInitVars.cbegin());
-            auto psmInitVarNameEnd = GetPairKeyConstIter(psmInitVars.cend());
+            auto psmVars = psm->GetVars();
+            auto psmVarNameBegin = GetPairKeyConstIter(psmVars.cbegin());
+            auto psmVarNameEnd = GetPairKeyConstIter(psmVars.cend());
 
             if (model.synapseGType[synPopID] == INDIVIDUALG) {
-                name_substitutions(psCode, "lps", psmInitVarNameBegin, psmInitVarNameEnd, sName);
+                name_substitutions(psCode, "lps", psmVarNameBegin, psmVarNameEnd, sName);
             }
             else {
-                value_substitutions(psCode, psmInitVarNameBegin, psmInitVarNameEnd, model.postSynIni[synPopID]);
+                value_substitutions(psCode, psmVarNameBegin, psmVarNameEnd, model.postSynIni[synPopID]);
             }
             value_substitutions(psCode, psm->GetParamNames(), model.postSynapsePara[synPopID]);
 
@@ -209,7 +209,7 @@ void genNeuronFunction(const NNmodel &model, //!< Model description
             os << "// test whether spike condition was fulfilled previously" << ENDL;
             substitute(thCode, "$(id)", "n");
             substitute(thCode, "$(t)", "t");
-            name_substitutions(thCode, "l", neuronModelInitVarNameBegin, neuronModelInitVarNameEnd, "");
+            name_substitutions(thCode, "l", neuronModelVarNameBegin, neuronModelVarNameEnd, "");
             substitute(thCode, "$(sT)", "lsT");
             value_substitutions(thCode, neuronModel->GetParamNames(), model.neuronPara[i]);
             value_substitutions(thCode, neuronModelDerivedParamNameBegin, neuronModelDerivedParamNameEnd, model.dnp[i]);
@@ -225,7 +225,7 @@ void genNeuronFunction(const NNmodel &model, //!< Model description
         string sCode = neuronModel->GetSimCode();
         substitute(sCode, "$(id)", "n");
         substitute(sCode, "$(t)", "t");
-        name_substitutions(sCode, "l", neuronModelInitVarNameBegin, neuronModelInitVarNameEnd, "");
+        name_substitutions(sCode, "l", neuronModelVarNameBegin, neuronModelVarNameEnd, "");
         value_substitutions(sCode, neuronModel->GetParamNames(), model.neuronPara[i]);
         value_substitutions(sCode, neuronModelDerivedParamNameBegin, neuronModelDerivedParamNameEnd, model.dnp[i]);
         name_substitutions(sCode, "", neuronModelExtraGlobalParamsNameBegin, neuronModelExtraGlobalParamsNameEnd, model.neuronName[i]);
@@ -251,7 +251,7 @@ void genNeuronFunction(const NNmodel &model, //!< Model description
                 // code substitutions ----
                 substitute(eCode, "$(id)", "n");
                 substitute(eCode, "$(t)", "t");
-                extended_name_substitutions(eCode, "l", neuronModelInitVarNameBegin, neuronModelInitVarNameEnd, "_pre", "");
+                extended_name_substitutions(eCode, "l", neuronModelVarNameBegin, neuronModelVarNameEnd, "_pre", "");
                 name_substitutions(eCode, "", neuronModelExtraGlobalParamsNameBegin, neuronModelExtraGlobalParamsNameEnd, model.neuronName[i]);
                 eCode = ensureFtype(eCode, model.ftype);
                 checkUnreplacedVariables(eCode, "neuronSpkEvntCondition");
@@ -308,7 +308,7 @@ void genNeuronFunction(const NNmodel &model, //!< Model description
                 string rCode = neuronModel->GetResetCode();
                 substitute(rCode, "$(id)", "n");
                 substitute(rCode, "$(t)", "t");
-                name_substitutions(rCode, "l", neuronModelInitVarNameBegin, neuronModelInitVarNameEnd, "");
+                name_substitutions(rCode, "l", neuronModelVarNameBegin, neuronModelVarNameEnd, "");
                 value_substitutions(rCode, neuronModel->GetParamNames(), model.neuronPara[i]);
                 value_substitutions(rCode, neuronModelDerivedParamNameBegin, neuronModelDerivedParamNameEnd, model.dnp[i]);
                 substitute(rCode, "$(Isyn)", "Isyn");
@@ -323,12 +323,12 @@ void genNeuronFunction(const NNmodel &model, //!< Model description
         }
 
         // store the defined parts of the neuron state into the global state variables V etc
-        for (size_t k = 0; k < neuronModelInitVars.size(); k++) {
+        for (size_t k = 0; k < neuronModelVars.size(); k++) {
             if (model.neuronVarNeedQueue[i][k]) {
-                os << neuronModelInitVars[k].first << model.neuronName[i] << "[" << queueOffset << "n] = l" << neuronModelInitVars[k].first << ";" << ENDL;
+                os << neuronModelVars[k].first << model.neuronName[i] << "[" << queueOffset << "n] = l" << neuronModelVars[k].first << ";" << ENDL;
             }
             else {
-                os << neuronModelInitVars[k].first << model.neuronName[i] << "[n] = l" << neuronModelInitVars[k].first << ";" << ENDL;
+                os << neuronModelVars[k].first << model.neuronName[i] << "[n] = l" << neuronModelVars[k].first << ";" << ENDL;
             }
         }
 
@@ -340,15 +340,15 @@ void genNeuronFunction(const NNmodel &model, //!< Model description
             substitute(pdCode, "$(t)", "t");
             substitute(pdCode, "$(inSyn)", "inSyn" + sName + "[n]");
 
-            auto psmInitVars = psm->GetInitVals();
-            name_substitutions(pdCode, "lps", GetPairKeyConstIter(psmInitVars.cbegin()),
-                               GetPairKeyConstIter(psmInitVars.cend()), sName);
+            auto psmVars = psm->GetVars();
+            name_substitutions(pdCode, "lps", GetPairKeyConstIter(psmVars.cbegin()),
+                               GetPairKeyConstIter(psmVars.cend()), sName);
             value_substitutions(pdCode, psm->GetParamNames(), model.postSynapsePara[model.inSyn[i][j]]);
 
             auto psmDerivedParams = psm->GetDerivedParams();
             value_substitutions(pdCode, GetPairKeyConstIter(psmDerivedParams.cbegin()),
                                 GetPairKeyConstIter(psmDerivedParams.cend()), model.dpsp[model.inSyn[i][j]]);
-            name_substitutions(pdCode, "l", neuronModelInitVarNameBegin, neuronModelInitVarNameEnd, "");
+            name_substitutions(pdCode, "l", neuronModelVarNameBegin, neuronModelVarNameEnd, "");
             value_substitutions(pdCode, neuronModel->GetParamNames(), model.neuronPara[i]);
             value_substitutions(pdCode, neuronModelDerivedParamNameBegin, neuronModelDerivedParamNameEnd, model.dnp[i]);
             os << "// the post-synaptic dynamics" << ENDL;
@@ -361,7 +361,7 @@ void genNeuronFunction(const NNmodel &model, //!< Model description
             if (!psm->GetSupportCode().empty()) {
                 os << CB(29) << " // namespace bracket closed" << endl;
             }
-            for (const auto &v : psmInitVars) {
+            for (const auto &v : psmVars) {
                 os << v.first << sName << "[n]" << " = lps" << v.first << sName << ";" << ENDL;
             }
         }
@@ -444,9 +444,9 @@ void generate_process_presynaptic_events_code_CPU(
         auto wuExtraGlobalParamsNameEnd = GetPairKeyConstIter(wuExtraGlobalParams.cend());
 
         // Create iterators to iterate over the names of the weight update model's initial values
-        auto wuInitVars = wu->GetInitVals();
-        auto wuInitVarNameBegin = GetPairKeyConstIter(wuInitVars.cbegin());
-        auto wuInitVarNameEnd = GetPairKeyConstIter(wuInitVars.cend());
+        auto wuVars = wu->GetVars();
+        auto wuVarNameBegin = GetPairKeyConstIter(wuVars.cbegin());
+        auto wuVarNameEnd = GetPairKeyConstIter(wuVars.cend());
 
         if (evnt) {
             // code substitutions ----
@@ -479,18 +479,18 @@ void generate_process_presynaptic_events_code_CPU(
         substitute(wCode, "$(t)", "t");
         if (sparse) { // SPARSE
             if (model.synapseGType[i] == INDIVIDUALG) {
-                name_substitutions(wCode, "", wuInitVarNameBegin, wuInitVarNameEnd, model.synapseName[i] + "[C" + model.synapseName[i] + ".indInG[ipre] + j]");
+                name_substitutions(wCode, "", wuVarNameBegin, wuVarNameEnd, model.synapseName[i] + "[C" + model.synapseName[i] + ".indInG[ipre] + j]");
             }
             else {
-                value_substitutions(wCode, wuInitVarNameBegin, wuInitVarNameEnd, model.synapseIni[i]);
+                value_substitutions(wCode, wuVarNameBegin, wuVarNameEnd, model.synapseIni[i]);
             }
         }
         else { // DENSE
             if (model.synapseGType[i] == INDIVIDUALG) {
-                name_substitutions(wCode, "", wuInitVarNameBegin, wuInitVarNameEnd, model.synapseName[i] + "[ipre * " + to_string(model.neuronN[trg]) + " + ipost]");
+                name_substitutions(wCode, "", wuVarNameBegin, wuVarNameEnd, model.synapseName[i] + "[ipre * " + to_string(model.neuronN[trg]) + " + ipost]");
             }
             else {
-                value_substitutions(wCode, wuInitVarNameBegin, wuInitVarNameEnd, model.synapseIni[i]);
+                value_substitutions(wCode, wuVarNameBegin, wuVarNameEnd, model.synapseIni[i]);
             }
         }
         substitute(wCode, "$(inSyn)", "inSyn" + model.synapseName[i] + "[ipost]");
@@ -588,9 +588,9 @@ void genSynapseFunction(const NNmodel &model, //!< Model description
             auto wuDerivedParamNameEnd = GetPairKeyConstIter(wuDerivedParams.cend());
 
             // Create iterators to iterate over the names of the weight update model's initial values
-            auto wuInitVars = wu->GetInitVals();
-            auto wuInitVarNameBegin = GetPairKeyConstIter(wuInitVars.cbegin());
-            auto wuInitVarNameEnd = GetPairKeyConstIter(wuInitVars.cend());
+            auto wuVars = wu->GetVars();
+            auto wuVarNameBegin = GetPairKeyConstIter(wuVars.cbegin());
+            auto wuVarNameEnd = GetPairKeyConstIter(wuVars.cend());
 
             string SDcode= wu->GetSynapseDynamicsCode();
             substitute(SDcode, "$(t)", "t");
@@ -598,11 +598,11 @@ void genSynapseFunction(const NNmodel &model, //!< Model description
                 os << "for (int n= 0; n < C" << synapseName << ".connN; n++)" << OB(24) << ENDL;
                 if (model.synapseGType[k] == INDIVIDUALG) {
                     // name substitute synapse var names in synapseDynamics code
-                    name_substitutions(SDcode, "", wuInitVarNameBegin, wuInitVarNameEnd, synapseName + "[n]");
+                    name_substitutions(SDcode, "", wuVarNameBegin, wuVarNameEnd, synapseName + "[n]");
                 }
                 else {
                     // substitute initial values as constants for synapse var names in synapseDynamics code
-                    value_substitutions(SDcode, wuInitVarNameBegin, wuInitVarNameEnd, model.synapseIni[k]);
+                    value_substitutions(SDcode, wuVarNameBegin, wuVarNameEnd, model.synapseIni[k]);
                 }
                 // substitute parameter values for parameters in synapseDynamics code
                 value_substitutions(SDcode, wu->GetParamNames(), model.synapsePara[k]);
@@ -621,11 +621,11 @@ void genSynapseFunction(const NNmodel &model, //!< Model description
                 os << "// loop through all synapses" << endl;
                 // substitute initial values as constants for synapse var names in synapseDynamics code
                 if (model.synapseGType[k] == INDIVIDUALG) {
-                    name_substitutions(SDcode, "", wuInitVarNameBegin, wuInitVarNameEnd, synapseName + "[i*" + to_string(trgno) + "+j]");
+                    name_substitutions(SDcode, "", wuVarNameBegin, wuVarNameEnd, synapseName + "[i*" + to_string(trgno) + "+j]");
                 }
                 else {
                     // substitute initial values as constants for synapse var names in synapseDynamics code
-                    value_substitutions(SDcode, wuInitVarNameBegin, wuInitVarNameEnd, model.synapseIni[k]);
+                    value_substitutions(SDcode, wuVarNameBegin, wuVarNameEnd, model.synapseIni[k]);
                 }
                 // substitute parameter values for parameters in synapseDynamics code
                 value_substitutions(SDcode, wu->GetParamNames(), model.synapsePara[k]);
@@ -735,9 +735,9 @@ void genSynapseFunction(const NNmodel &model, //!< Model description
             auto wuExtraGlobalParamsNameEnd = GetPairKeyConstIter(wuExtraGlobalParams.cend());
 
             // Create iterators to iterate over the names of the weight update model's initial values
-            auto wuInitVars = wu->GetInitVals();
-            auto wuInitVarNameBegin = GetPairKeyConstIter(wuInitVars.cbegin());
-            auto wuInitVarNameEnd = GetPairKeyConstIter(wuInitVars.cend());
+            auto wuVars = wu->GetVars();
+            auto wuVarNameBegin = GetPairKeyConstIter(wuVars.cbegin());
+            auto wuVarNameEnd = GetPairKeyConstIter(wuVars.cend());
 
 // NOTE: WE DO NOT USE THE AXONAL DELAY FOR BACKWARDS PROPAGATION - WE CAN TALK ABOUT BACKWARDS DELAYS IF WE WANT THEM
 
@@ -777,10 +777,10 @@ void genSynapseFunction(const NNmodel &model, //!< Model description
             substitute(code, "$(t)", "t");
             // Code substitutions ----------------------------------------------------------------------------------
             if (sparse) { // SPARSE
-                name_substitutions(code, "", wuInitVarNameBegin, wuInitVarNameEnd, model.synapseName[k] + "[C" + model.synapseName[k] + ".remap[ipre]]");
+                name_substitutions(code, "", wuVarNameBegin, wuVarNameEnd, model.synapseName[k] + "[C" + model.synapseName[k] + ".remap[ipre]]");
             }
             else { // DENSE
-                name_substitutions(code, "", wuInitVarNameBegin, wuInitVarNameEnd, model.synapseName[k] + "[lSpk + " + to_string(model.neuronN[trg]) + " * ipre]");
+                name_substitutions(code, "", wuVarNameBegin, wuVarNameEnd, model.synapseName[k] + "[lSpk + " + to_string(model.neuronN[trg]) + " * ipre]");
             }
             value_substitutions(code, wu->GetParamNames(), model.synapsePara[k]);
             value_substitutions(code, wuDerivedParamNameBegin, wuDerivedParamNameEnd, model.dsp_w[k]);

--- a/lib/src/generateRunner.cc
+++ b/lib/src/generateRunner.cc
@@ -934,9 +934,15 @@ void genRunner(const NNmodel &model, //!< Model description
 #ifndef CPU_ONLY
     os << "    CHECK_CUDA_ERRORS(cudaSetDevice(" << theDevice << "));" << ENDL;
 
-    // If the model requires zero-copy set appropriate device flags
+    // If the model requires zero-copy
     if(model.zeroCopyInUse())
     {
+        // If device doesn't support mapping host memory error
+        if(!deviceProp[theDevice].canMapHostMemory) {
+            gennError("Device does not support mapping CPU host memory!");
+        }
+
+        // set appropriate device flags
         os << "    CHECK_CUDA_ERRORS(cudaSetDeviceFlags(cudaDeviceMapHost));" << ENDL;
     }
 #endif

--- a/lib/src/generateRunner.cc
+++ b/lib/src/generateRunner.cc
@@ -2180,6 +2180,13 @@ void genRunnerGPU(const NNmodel &model, //!< Model description
         os << "cudaEventElapsedTime(&tmp, neuronStart, neuronStop);" << ENDL;
         os << "neuron_tme+= tmp/1000.0;" << ENDL;
     }
+
+    // Synchronise if zero-copy is in use
+    if(model.zeroCopyInUse())
+    {
+        os << "cudaDeviceSynchronize();" << ENDL;
+    }
+
     os << "iT++;" << ENDL;
     os << "t= iT*DT;" << ENDL;
     os << CB(1130) << ENDL;

--- a/lib/src/modelSpec.cc
+++ b/lib/src/modelSpec.cc
@@ -103,6 +103,20 @@ bool NNmodel::zeroCopyInUse() const
         return true;
     }
 
+    // If any synapse groups have any weight update model state variables with zero-copy enabled return true
+    if(any_of(begin(synapseInitValZeroCopy), end(synapseInitValZeroCopy),
+        [](const set<string> &s){ return !s.empty(); }))
+    {
+        return true;
+    }
+
+    // If any synapse groups have any weight update model state variables with zero-copy enabled return true
+    if(any_of(begin(postSynapseInitValZeroCopy), end(postSynapseInitValZeroCopy),
+        [](const set<string> &s){ return !s.empty(); }))
+    {
+        return true;
+    }
+
     return false;
 }
 

--- a/lib/src/utils.cc
+++ b/lib/src/utils.cc
@@ -80,7 +80,7 @@ CUresult cudaFuncGetAttributesDriver(cudaFuncAttributes *attr, CUfunction kern) 
  */
 //--------------------------------------------------------------------------
 
-void gennError(string error)
+void gennError(const string &error)
 {
     cerr << "GeNN error: " << error << endl;
     exit(EXIT_FAILURE);
@@ -109,7 +109,7 @@ void writeHeader(ostream &os)
 //! \brief Tool for determining the size of variable types on the current architecture
 //--------------------------------------------------------------------------
 
-unsigned int theSize(string type) 
+unsigned int theSize(const string &type)
 {
   unsigned int size = 0;
   if (type.find("*") != string::npos) size= sizeof(char *); // it's a pointer ... any pointer should have the same size

--- a/tests/features/extra_global_params_in_sim_code/model_new.cc
+++ b/tests/features/extra_global_params_in_sim_code/model_new.cc
@@ -12,7 +12,7 @@ public:
 
     SET_EXTRA_GLOBAL_PARAMS({{"input", "scalar"}});
 
-    SET_INIT_VALS({{"x", "scalar"}, {"shift", "scalar"}});
+    SET_VARS({{"x", "scalar"}, {"shift", "scalar"}});
 };
 
 IMPLEMENT_MODEL(Neuron);
@@ -23,7 +23,7 @@ void modelDefinition(NNmodel &model)
   model.setDT(0.1);
   model.setName("extra_global_params_in_sim_code");
 
-  model.addNeuronPopulation<Neuron>("pre", 10, {}, Neuron::InitValues(0.0, 0.0));
+  model.addNeuronPopulation<Neuron>("pre", 10, {}, Neuron::VarValues(0.0, 0.0));
   model.setPrecision(GENN_FLOAT);
   model.finalize();
 }

--- a/tests/features/extra_global_params_in_sim_code_event_spare_inv/model_new.cc
+++ b/tests/features/extra_global_params_in_sim_code_event_spare_inv/model_new.cc
@@ -10,7 +10,7 @@ public:
 
     SET_SIM_CODE("$(x)= $(t)+$(shift);\n");
 
-    SET_INIT_VALS({{"x", "scalar"}, {"shift", "scalar"}});
+    SET_VARS({{"x", "scalar"}, {"shift", "scalar"}});
 };
 
 IMPLEMENT_MODEL(Neuron);
@@ -23,7 +23,7 @@ class WeightUpdateModel : public WeightUpdateModels::Base
 public:
     DECLARE_MODEL(WeightUpdateModel, 0, 1);
 
-    SET_INIT_VALS({{"w", "scalar"}});
+    SET_VARS({{"w", "scalar"}});
     SET_EXTRA_GLOBAL_PARAMS({{"thresh", "scalar"}});
 
     SET_EVENT_THRESHOLD_CONDITION_CODE("(fmod($(x_pre),$(thresh)) < 1e-4)");
@@ -38,8 +38,8 @@ void modelDefinition(NNmodel &model)
     model.setDT(0.1);
     model.setName("extra_global_params_in_sim_code_event_sparse_inv");
 
-    model.addNeuronPopulation<Neuron>("pre", 10, {}, Neuron::InitValues(0.0, 0.0));
-    model.addNeuronPopulation<Neuron>("post", 10, {}, Neuron::InitValues(0.0, 0.0));
+    model.addNeuronPopulation<Neuron>("pre", 10, {}, Neuron::VarValues(0.0, 0.0));
+    model.addNeuronPopulation<Neuron>("post", 10, {}, Neuron::VarValues(0.0, 0.0));
 
     string synName= "syn";
     for (int i= 0; i < 10; i++)
@@ -47,7 +47,7 @@ void modelDefinition(NNmodel &model)
         string theName= synName + std::to_string(i);
         model.addSynapsePopulation<WeightUpdateModel, PostsynapticModels::Izhikevich>(
             theName, SPARSE, INDIVIDUALG, i, "pre", "post",
-            {}, WeightUpdateModel::InitValues(0.0),
+            {}, WeightUpdateModel::VarValues(0.0),
             {}, {});
         model.setSpanTypeToPre(theName);
     }

--- a/tests/features/neuron_support_code_sim/model_new.cc
+++ b/tests/features/neuron_support_code_sim/model_new.cc
@@ -14,7 +14,7 @@ public:
 
     SET_THRESHOLD_CONDITION_CODE("(fmod($(x), 1.0) < 1e-4)");
 
-    SET_INIT_VALS({{"x", "scalar"}, {"shift", "scalar"}});
+    SET_VARS({{"x", "scalar"}, {"shift", "scalar"}});
 };
 
 IMPLEMENT_MODEL(Neuron);
@@ -27,7 +27,7 @@ class WeightUpdateModel : public WeightUpdateModels::Base
 public:
     DECLARE_MODEL(WeightUpdateModel, 0, 1);
 
-    SET_INIT_VALS({{"w", "scalar"}});
+    SET_VARS({{"w", "scalar"}});
 
     SET_SIM_CODE("$(w)= $(x_pre);");
 };
@@ -41,8 +41,8 @@ void modelDefinition(NNmodel &model)
     model.setDT(0.1);
     model.setName("neuron_support_code_sim");
 
-    model.addNeuronPopulation<Neuron>("pre", 10, {}, Neuron::InitValues(0.0, 0.0));
-    model.addNeuronPopulation<Neuron>("post", 10, {}, Neuron::InitValues(0.0, 0.0));
+    model.addNeuronPopulation<Neuron>("pre", 10, {}, Neuron::VarValues(0.0, 0.0));
+    model.addNeuronPopulation<Neuron>("post", 10, {}, Neuron::VarValues(0.0, 0.0));
 
     string synName= "syn";
     for (int i= 0; i < 10; i++)
@@ -50,7 +50,7 @@ void modelDefinition(NNmodel &model)
         string theName= synName + std::to_string(i);
         model.addSynapsePopulation<WeightUpdateModel, PostsynapticModels::Izhikevich>(
             theName, DENSE, INDIVIDUALG, i,"pre", "post",
-            {}, WeightUpdateModel::InitValues(0.0),
+            {}, WeightUpdateModel::VarValues(0.0),
             {}, {});
     }
     model.setPrecision(GENN_FLOAT);

--- a/tests/features/neuron_support_code_sim/model_new.cc
+++ b/tests/features/neuron_support_code_sim/model_new.cc
@@ -39,6 +39,7 @@ void modelDefinition(NNmodel &model)
     initGeNN();
 
     model.setDT(0.1);
+    model.setName("neuron_support_code_sim");
 
     model.addNeuronPopulation<Neuron>("pre", 10, {}, Neuron::InitValues(0.0, 0.0));
     model.addNeuronPopulation<Neuron>("post", 10, {}, Neuron::InitValues(0.0, 0.0));

--- a/tests/features/neuron_support_code_threshold/model_new.cc
+++ b/tests/features/neuron_support_code_threshold/model_new.cc
@@ -14,7 +14,7 @@ public:
 
     SET_THRESHOLD_CONDITION_CODE("checkThreshold($(x))");
 
-    SET_INIT_VALS({{"x", "scalar"}, {"shift", "scalar"}});
+    SET_VARS({{"x", "scalar"}, {"shift", "scalar"}});
 };
 
 IMPLEMENT_MODEL(Neuron);
@@ -27,7 +27,7 @@ class WeightUpdateModel : public WeightUpdateModels::Base
 public:
     DECLARE_MODEL(WeightUpdateModel, 0, 1);
 
-    SET_INIT_VALS({{"w", "scalar"}});
+    SET_VARS({{"w", "scalar"}});
 
     SET_SIM_CODE("$(w)= $(x_pre);");
 };
@@ -41,8 +41,8 @@ void modelDefinition(NNmodel &model)
     model.setDT(0.1);
     model.setName("neuron_support_code_threshold");
 
-    model.addNeuronPopulation<Neuron>("pre", 10, {}, Neuron::InitValues(0.0, 0.0));
-    model.addNeuronPopulation<Neuron>("post", 10, {}, Neuron::InitValues(0.0, 0.0));
+    model.addNeuronPopulation<Neuron>("pre", 10, {}, Neuron::VarValues(0.0, 0.0));
+    model.addNeuronPopulation<Neuron>("post", 10, {}, Neuron::VarValues(0.0, 0.0));
 
     string synName= "syn";
     for (int i= 0; i < 10; i++)
@@ -50,7 +50,7 @@ void modelDefinition(NNmodel &model)
         string theName= synName + std::to_string(i);
         model.addSynapsePopulation<WeightUpdateModel, PostsynapticModels::Izhikevich>(
             theName, DENSE, INDIVIDUALG, i,"pre", "post",
-            {}, WeightUpdateModel::InitValues(0.0),
+            {}, WeightUpdateModel::VarValues(0.0),
             {}, {});
     }
     model.setPrecision(GENN_FLOAT);

--- a/tests/features/post_vars_in_post_learn/model_new.cc
+++ b/tests/features/post_vars_in_post_learn/model_new.cc
@@ -13,7 +13,7 @@ public:
     SET_THRESHOLD_CONDITION_CODE("(fmod($(x),$(ISI)) < 1e-4)");
 
     SET_PARAM_NAMES({"ISI"});
-    SET_INIT_VALS({{"x", "scalar"}, {"shift", "scalar"}});
+    SET_VARS({{"x", "scalar"}, {"shift", "scalar"}});
 };
 
 IMPLEMENT_MODEL(Neuron);
@@ -26,7 +26,7 @@ class WeightUpdateModel : public WeightUpdateModels::Base
 public:
     DECLARE_MODEL(WeightUpdateModel, 0, 1);
 
-    SET_INIT_VALS({{"w", "scalar"}});
+    SET_VARS({{"w", "scalar"}});
 
     SET_LEARN_POST_CODE("$(w)= $(x_post);");
 };
@@ -40,8 +40,8 @@ void modelDefinition(NNmodel &model)
     model.setName("post_vars_in_post_learn");
 
 
-    model.addNeuronPopulation<Neuron>("pre", 10, Neuron::ParamValues(1.0), Neuron::InitValues(0.0, 0.0));
-    model.addNeuronPopulation<Neuron>("post", 10, Neuron::ParamValues(2.0), Neuron::InitValues(0.0, 0.0));
+    model.addNeuronPopulation<Neuron>("pre", 10, Neuron::ParamValues(1.0), Neuron::VarValues(0.0, 0.0));
+    model.addNeuronPopulation<Neuron>("post", 10, Neuron::ParamValues(2.0), Neuron::VarValues(0.0, 0.0));
 
     string synName= "syn";
     for (int i= 0; i < 10; i++)
@@ -49,7 +49,7 @@ void modelDefinition(NNmodel &model)
         string theName= synName + std::to_string(i);
         model.addSynapsePopulation<WeightUpdateModel, PostsynapticModels::Izhikevich>(
             theName, DENSE, INDIVIDUALG, i, "pre", "post",
-            {}, WeightUpdateModel::InitValues(0.0),
+            {}, WeightUpdateModel::VarValues(0.0),
             {}, {});
     }
     model.setPrecision(GENN_FLOAT);

--- a/tests/features/post_vars_in_post_learn_sparse/model_new.cc
+++ b/tests/features/post_vars_in_post_learn_sparse/model_new.cc
@@ -13,7 +13,7 @@ public:
     SET_THRESHOLD_CONDITION_CODE("(fmod($(x),$(ISI)) < 1e-4)");
 
     SET_PARAM_NAMES({"ISI"});
-    SET_INIT_VALS({{"x", "scalar"}, {"shift", "scalar"}});
+    SET_VARS({{"x", "scalar"}, {"shift", "scalar"}});
 };
 
 IMPLEMENT_MODEL(Neuron);
@@ -26,7 +26,7 @@ class WeightUpdateModel : public WeightUpdateModels::Base
 public:
     DECLARE_MODEL(WeightUpdateModel, 0, 1);
 
-    SET_INIT_VALS({{"w", "scalar"}});
+    SET_VARS({{"w", "scalar"}});
 
     SET_LEARN_POST_CODE("$(w)= $(x_post);");
 };
@@ -40,8 +40,8 @@ void modelDefinition(NNmodel &model)
     model.setName("post_vars_in_post_learn_sparse");
 
 
-    model.addNeuronPopulation<Neuron>("pre", 10, Neuron::ParamValues(1.0), Neuron::InitValues(0.0, 0.0));
-    model.addNeuronPopulation<Neuron>("post", 10, Neuron::ParamValues(2.0), Neuron::InitValues(0.0, 0.0));
+    model.addNeuronPopulation<Neuron>("pre", 10, Neuron::ParamValues(1.0), Neuron::VarValues(0.0, 0.0));
+    model.addNeuronPopulation<Neuron>("post", 10, Neuron::ParamValues(2.0), Neuron::VarValues(0.0, 0.0));
 
     string synName= "syn";
     for (int i= 0; i < 10; i++)
@@ -49,7 +49,7 @@ void modelDefinition(NNmodel &model)
         string theName= synName + std::to_string(i);
         model.addSynapsePopulation<WeightUpdateModel, PostsynapticModels::Izhikevich>(
             theName, SPARSE, INDIVIDUALG, i, "pre", "post",
-            {}, WeightUpdateModel::InitValues(0.0),
+            {}, WeightUpdateModel::VarValues(0.0),
             {}, {});
     }
     model.setPrecision(GENN_FLOAT);

--- a/tests/features/post_vars_in_sim_code/model_new.cc
+++ b/tests/features/post_vars_in_sim_code/model_new.cc
@@ -11,7 +11,7 @@ public:
     SET_SIM_CODE("$(x)= $(t)+$(shift);\n");
     SET_THRESHOLD_CONDITION_CODE("(fmod($(x),1.0) < 1e-4)");
 
-    SET_INIT_VALS({{"x", "scalar"}, {"shift", "scalar"}});
+    SET_VARS({{"x", "scalar"}, {"shift", "scalar"}});
 };
 
 IMPLEMENT_MODEL(Neuron);
@@ -24,7 +24,7 @@ class WeightUpdateModel : public WeightUpdateModels::Base
 public:
     DECLARE_MODEL(WeightUpdateModel, 0, 1);
 
-    SET_INIT_VALS({{"w", "scalar"}});
+    SET_VARS({{"w", "scalar"}});
 
     SET_SIM_CODE("$(w)= $(x_post);");
 };
@@ -37,8 +37,8 @@ void modelDefinition(NNmodel &model)
     model.setDT(0.1);
     model.setName("post_vars_in_sim_code");
 
-    model.addNeuronPopulation<Neuron>("pre", 10, {}, Neuron::InitValues(0.0, 0.0));
-    model.addNeuronPopulation<Neuron>("post", 10, {}, Neuron::InitValues(0.0, 0.0));
+    model.addNeuronPopulation<Neuron>("pre", 10, {}, Neuron::VarValues(0.0, 0.0));
+    model.addNeuronPopulation<Neuron>("post", 10, {}, Neuron::VarValues(0.0, 0.0));
 
     string synName= "syn";
     for (int i= 0; i < 10; i++)
@@ -46,7 +46,7 @@ void modelDefinition(NNmodel &model)
         string theName= synName + std::to_string(i);
         model.addSynapsePopulation<WeightUpdateModel, PostsynapticModels::Izhikevich>(
             theName, DENSE, INDIVIDUALG, i, "pre", "post",
-            {}, WeightUpdateModel::InitValues(0.0),
+            {}, WeightUpdateModel::VarValues(0.0),
             {}, {});
     }
     model.setPrecision(GENN_FLOAT);

--- a/tests/features/post_vars_in_sim_code_sparse/model_new.cc
+++ b/tests/features/post_vars_in_sim_code_sparse/model_new.cc
@@ -35,7 +35,7 @@ void modelDefinition(NNmodel &model)
 {
     initGeNN();
     model.setDT(0.1);
-    model.setName("post_vars_in_sim_code");
+    model.setName("post_vars_in_sim_code_sparse");
 
     model.addNeuronPopulation<Neuron>("pre", 10, {}, Neuron::InitValues(0.0, 0.0));
     model.addNeuronPopulation<Neuron>("post", 10, {}, Neuron::InitValues(0.0, 0.0));
@@ -45,7 +45,7 @@ void modelDefinition(NNmodel &model)
     {
         string theName= synName + std::to_string(i);
         model.addSynapsePopulation<WeightUpdateModel, PostsynapticModels::Izhikevich>(
-            theName, DENSE, INDIVIDUALG, i, "pre", "post",
+            theName, SPARSE, INDIVIDUALG, i, "pre", "post",
             {}, WeightUpdateModel::InitValues(0.0),
             {}, {});
     }

--- a/tests/features/post_vars_in_sim_code_sparse/model_new.cc
+++ b/tests/features/post_vars_in_sim_code_sparse/model_new.cc
@@ -11,7 +11,7 @@ public:
     SET_SIM_CODE("$(x)= $(t)+$(shift);\n");
     SET_THRESHOLD_CONDITION_CODE("(fmod($(x),1.0) < 1e-4)");
 
-    SET_INIT_VALS({{"x", "scalar"}, {"shift", "scalar"}});
+    SET_VARS({{"x", "scalar"}, {"shift", "scalar"}});
 };
 
 IMPLEMENT_MODEL(Neuron);
@@ -24,7 +24,7 @@ class WeightUpdateModel : public WeightUpdateModels::Base
 public:
     DECLARE_MODEL(WeightUpdateModel, 0, 1);
 
-    SET_INIT_VALS({{"w", "scalar"}});
+    SET_VARS({{"w", "scalar"}});
 
     SET_SIM_CODE("$(w)= $(x_post);");
 };
@@ -37,8 +37,8 @@ void modelDefinition(NNmodel &model)
     model.setDT(0.1);
     model.setName("post_vars_in_sim_code_sparse");
 
-    model.addNeuronPopulation<Neuron>("pre", 10, {}, Neuron::InitValues(0.0, 0.0));
-    model.addNeuronPopulation<Neuron>("post", 10, {}, Neuron::InitValues(0.0, 0.0));
+    model.addNeuronPopulation<Neuron>("pre", 10, {}, Neuron::VarValues(0.0, 0.0));
+    model.addNeuronPopulation<Neuron>("post", 10, {}, Neuron::VarValues(0.0, 0.0));
 
     string synName= "syn";
     for (int i= 0; i < 10; i++)
@@ -46,7 +46,7 @@ void modelDefinition(NNmodel &model)
         string theName= synName + std::to_string(i);
         model.addSynapsePopulation<WeightUpdateModel, PostsynapticModels::Izhikevich>(
             theName, SPARSE, INDIVIDUALG, i, "pre", "post",
-            {}, WeightUpdateModel::InitValues(0.0),
+            {}, WeightUpdateModel::VarValues(0.0),
             {}, {});
     }
     model.setPrecision(GENN_FLOAT);

--- a/tests/features/post_vars_in_synapse_dynamics/model_new.cc
+++ b/tests/features/post_vars_in_synapse_dynamics/model_new.cc
@@ -10,7 +10,7 @@ public:
 
     SET_SIM_CODE("$(x)= $(t)+$(shift);\n");
 
-    SET_INIT_VALS({{"x", "scalar"}, {"shift", "scalar"}});
+    SET_VARS({{"x", "scalar"}, {"shift", "scalar"}});
 };
 
 IMPLEMENT_MODEL(Neuron);
@@ -23,7 +23,7 @@ class WeightUpdateModel : public WeightUpdateModels::Base
 public:
     DECLARE_MODEL(WeightUpdateModel, 0, 1);
 
-    SET_INIT_VALS({{"w", "scalar"}});
+    SET_VARS({{"w", "scalar"}});
 
     SET_SYNAPSE_DYNAMICS_CODE("$(w)= $(x_post);");
 };
@@ -36,8 +36,8 @@ void modelDefinition(NNmodel &model)
     model.setDT(0.1);
     model.setName("post_vars_in_synapse_dynamics");
 
-    model.addNeuronPopulation<Neuron>("pre", 10, {}, Neuron::InitValues(0.0, 0.0));
-    model.addNeuronPopulation<Neuron>("post", 10, {}, Neuron::InitValues(0.0, 0.0));
+    model.addNeuronPopulation<Neuron>("pre", 10, {}, Neuron::VarValues(0.0, 0.0));
+    model.addNeuronPopulation<Neuron>("post", 10, {}, Neuron::VarValues(0.0, 0.0));
 
     string synName= "syn";
     for (int i= 0; i < 10; i++)
@@ -45,7 +45,7 @@ void modelDefinition(NNmodel &model)
         string theName= synName + std::to_string(i);
         model.addSynapsePopulation<WeightUpdateModel, PostsynapticModels::Izhikevich>(
             theName, DENSE, INDIVIDUALG, i, "pre", "post",
-            {}, WeightUpdateModel::InitValues(0.0),
+            {}, WeightUpdateModel::VarValues(0.0),
             {}, {});
     }
     model.setPrecision(GENN_FLOAT);

--- a/tests/features/post_vars_in_synapse_dynamics_sparse/model_new.cc
+++ b/tests/features/post_vars_in_synapse_dynamics_sparse/model_new.cc
@@ -10,7 +10,7 @@ public:
 
     SET_SIM_CODE("$(x)= $(t)+$(shift);\n");
 
-    SET_INIT_VALS({{"x", "scalar"}, {"shift", "scalar"}});
+    SET_VARS({{"x", "scalar"}, {"shift", "scalar"}});
 };
 
 IMPLEMENT_MODEL(Neuron);
@@ -23,7 +23,7 @@ class WeightUpdateModel : public WeightUpdateModels::Base
 public:
     DECLARE_MODEL(WeightUpdateModel, 0, 1);
 
-    SET_INIT_VALS({{"w", "scalar"}});
+    SET_VARS({{"w", "scalar"}});
 
     SET_SYNAPSE_DYNAMICS_CODE("$(w)= $(x_post);");
 };
@@ -36,8 +36,8 @@ void modelDefinition(NNmodel &model)
     model.setDT(0.1);
     model.setName("post_vars_in_synapse_dynamics_sparse");
 
-    model.addNeuronPopulation<Neuron>("pre", 10, {}, Neuron::InitValues(0.0, 0.0));
-    model.addNeuronPopulation<Neuron>("post", 10, {}, Neuron::InitValues(0.0, 0.0));
+    model.addNeuronPopulation<Neuron>("pre", 10, {}, Neuron::VarValues(0.0, 0.0));
+    model.addNeuronPopulation<Neuron>("post", 10, {}, Neuron::VarValues(0.0, 0.0));
 
     string synName= "syn";
     for (int i= 0; i < 10; i++)
@@ -45,7 +45,7 @@ void modelDefinition(NNmodel &model)
         string theName= synName + std::to_string(i);
         model.addSynapsePopulation<WeightUpdateModel, PostsynapticModels::Izhikevich>(
             theName, SPARSE, INDIVIDUALG, i, "pre", "post",
-            {}, WeightUpdateModel::InitValues(0.0),
+            {}, WeightUpdateModel::VarValues(0.0),
             {}, {});
     }
     model.setPrecision(GENN_FLOAT);

--- a/tests/features/pre_vars_in_post_learn/model_new.cc
+++ b/tests/features/pre_vars_in_post_learn/model_new.cc
@@ -13,7 +13,7 @@ public:
     SET_THRESHOLD_CONDITION_CODE("(fmod($(x),$(ISI)) < 1e-4)");
 
     SET_PARAM_NAMES({"ISI"});
-    SET_INIT_VALS({{"x", "scalar"}, {"shift", "scalar"}});
+    SET_VARS({{"x", "scalar"}, {"shift", "scalar"}});
 };
 
 IMPLEMENT_MODEL(Neuron);
@@ -26,7 +26,7 @@ class WeightUpdateModel : public WeightUpdateModels::Base
 public:
     DECLARE_MODEL(WeightUpdateModel, 0, 1);
 
-    SET_INIT_VALS({{"w", "scalar"}});
+    SET_VARS({{"w", "scalar"}});
 
     SET_LEARN_POST_CODE("$(w)= $(x_pre);");
 };
@@ -40,15 +40,15 @@ void modelDefinition(NNmodel &model)
     model.setName("pre_vars_in_post_learn");
 
 
-    model.addNeuronPopulation<Neuron>("pre", 10, Neuron::ParamValues(1.0), Neuron::InitValues(0.0, 0.0));
-    model.addNeuronPopulation<Neuron>("post", 10, Neuron::ParamValues(2.0), Neuron::InitValues(0.0, 0.0));
+    model.addNeuronPopulation<Neuron>("pre", 10, Neuron::ParamValues(1.0), Neuron::VarValues(0.0, 0.0));
+    model.addNeuronPopulation<Neuron>("post", 10, Neuron::ParamValues(2.0), Neuron::VarValues(0.0, 0.0));
     string synName= "syn";
     for (int i= 0; i < 10; i++)
     {
         string theName= synName + std::to_string(i);
         model.addSynapsePopulation<WeightUpdateModel, PostsynapticModels::Izhikevich>(
             theName, DENSE, INDIVIDUALG, i, "pre", "post",
-            {}, WeightUpdateModel::InitValues(0.0),
+            {}, WeightUpdateModel::VarValues(0.0),
             {}, {});
     }
     model.setPrecision(GENN_FLOAT);

--- a/tests/features/pre_vars_in_post_learn_sparse/model_new.cc
+++ b/tests/features/pre_vars_in_post_learn_sparse/model_new.cc
@@ -13,7 +13,7 @@ public:
     SET_THRESHOLD_CONDITION_CODE("(fmod($(x),$(ISI)) < 1e-4)");
 
     SET_PARAM_NAMES({"ISI"});
-    SET_INIT_VALS({{"x", "scalar"}, {"shift", "scalar"}});
+    SET_VARS({{"x", "scalar"}, {"shift", "scalar"}});
 };
 
 IMPLEMENT_MODEL(Neuron);
@@ -26,7 +26,7 @@ class WeightUpdateModel : public WeightUpdateModels::Base
 public:
     DECLARE_MODEL(WeightUpdateModel, 0, 1);
 
-    SET_INIT_VALS({{"w", "scalar"}});
+    SET_VARS({{"w", "scalar"}});
 
     SET_LEARN_POST_CODE("$(w)= $(x_pre);");
 };
@@ -40,15 +40,15 @@ void modelDefinition(NNmodel &model)
     model.setName("pre_vars_in_post_learn_sparse");
 
 
-    model.addNeuronPopulation<Neuron>("pre", 10, Neuron::ParamValues(1.0), Neuron::InitValues(0.0, 0.0));
-    model.addNeuronPopulation<Neuron>("post", 10, Neuron::ParamValues(2.0), Neuron::InitValues(0.0, 0.0));
+    model.addNeuronPopulation<Neuron>("pre", 10, Neuron::ParamValues(1.0), Neuron::VarValues(0.0, 0.0));
+    model.addNeuronPopulation<Neuron>("post", 10, Neuron::ParamValues(2.0), Neuron::VarValues(0.0, 0.0));
     string synName= "syn";
     for (int i= 0; i < 10; i++)
     {
         string theName= synName + std::to_string(i);
         model.addSynapsePopulation<WeightUpdateModel, PostsynapticModels::Izhikevich>(
             theName, SPARSE, INDIVIDUALG, i, "pre", "post",
-            {}, WeightUpdateModel::InitValues(0.0),
+            {}, WeightUpdateModel::VarValues(0.0),
             {}, {});
     }
     model.setPrecision(GENN_FLOAT);

--- a/tests/features/pre_vars_in_sim_code/model_new.cc
+++ b/tests/features/pre_vars_in_sim_code/model_new.cc
@@ -12,7 +12,7 @@ public:
 
     SET_THRESHOLD_CONDITION_CODE("(fmod($(x),1.0) < 1e-4)");
 
-    SET_INIT_VALS({{"x", "scalar"}, {"shift", "scalar"}});
+    SET_VARS({{"x", "scalar"}, {"shift", "scalar"}});
 };
 
 IMPLEMENT_MODEL(Neuron);
@@ -25,7 +25,7 @@ class WeightUpdateModel : public WeightUpdateModels::Base
 public:
     DECLARE_MODEL(WeightUpdateModel, 0, 1);
 
-    SET_INIT_VALS({{"w", "scalar"}});
+    SET_VARS({{"w", "scalar"}});
 
     SET_SIM_CODE("$(w)= $(x_pre);");
 };
@@ -38,8 +38,8 @@ void modelDefinition(NNmodel &model)
     model.setDT(0.1);
     model.setName("pre_vars_in_sim_code");
 
-    model.addNeuronPopulation<Neuron>("pre", 10, {}, Neuron::InitValues(0.0, 0.0));
-    model.addNeuronPopulation<Neuron>("post", 10, {}, Neuron::InitValues(0.0, 0.0));
+    model.addNeuronPopulation<Neuron>("pre", 10, {}, Neuron::VarValues(0.0, 0.0));
+    model.addNeuronPopulation<Neuron>("post", 10, {}, Neuron::VarValues(0.0, 0.0));
 
     string synName= "syn";
     for (int i= 0; i < 10; i++)
@@ -47,7 +47,7 @@ void modelDefinition(NNmodel &model)
         string theName= synName + std::to_string(i);
         model.addSynapsePopulation<WeightUpdateModel, PostsynapticModels::Izhikevich>(
             theName, DENSE, INDIVIDUALG, i, "pre", "post",
-            {}, WeightUpdateModel::InitValues(0.0),
+            {}, WeightUpdateModel::VarValues(0.0),
             {}, {});
     }
     model.setPrecision(GENN_FLOAT);

--- a/tests/features/pre_vars_in_sim_code_event/model_new.cc
+++ b/tests/features/pre_vars_in_sim_code_event/model_new.cc
@@ -12,7 +12,7 @@ public:
 
     SET_THRESHOLD_CONDITION_CODE("(fmod($(x),1.0) < 1e-4)");
 
-    SET_INIT_VALS({{"x", "scalar"}, {"shift", "scalar"}});
+    SET_VARS({{"x", "scalar"}, {"shift", "scalar"}});
 };
 
 IMPLEMENT_MODEL(Neuron);
@@ -25,7 +25,7 @@ class WeightUpdateModel : public WeightUpdateModels::Base
 public:
     DECLARE_MODEL(WeightUpdateModel, 1, 1);
 
-    SET_INIT_VALS({{"w", "scalar"}});
+    SET_VARS({{"w", "scalar"}});
     SET_PARAM_NAMES({"myTrigger"});
 
     SET_EVENT_THRESHOLD_CONDITION_CODE("(fmod($(x_pre),$(myTrigger)) < 1e-4)");
@@ -41,8 +41,8 @@ void modelDefinition(NNmodel &model)
     model.setDT(0.1);
     model.setName("pre_vars_in_sim_code_event");
 
-    model.addNeuronPopulation<Neuron>("pre", 10, {}, Neuron::InitValues(0.0, 0.0));
-    model.addNeuronPopulation<Neuron>("post", 10, {}, Neuron::InitValues(0.0, 0.0));
+    model.addNeuronPopulation<Neuron>("pre", 10, {}, Neuron::VarValues(0.0, 0.0));
+    model.addNeuronPopulation<Neuron>("post", 10, {}, Neuron::VarValues(0.0, 0.0));
 
     string synName= "syn";
     for (int i= 0; i < 10; i++)
@@ -50,7 +50,7 @@ void modelDefinition(NNmodel &model)
         string theName= synName + std::to_string(i);
         model.addSynapsePopulation<WeightUpdateModel, PostsynapticModels::Izhikevich>(
             theName, DENSE, INDIVIDUALG, i, "pre", "post",
-            WeightUpdateModel::ParamValues((double)(2*(i+1))), WeightUpdateModel::InitValues(0.0),
+            WeightUpdateModel::ParamValues((double)(2*(i+1))), WeightUpdateModel::VarValues(0.0),
             {}, {});
     }
     model.setPrecision(GENN_FLOAT);

--- a/tests/features/pre_vars_in_sim_code_event_sparse/model_new.cc
+++ b/tests/features/pre_vars_in_sim_code_event_sparse/model_new.cc
@@ -12,7 +12,7 @@ public:
 
     SET_THRESHOLD_CONDITION_CODE("(fmod($(x),1.0) < 1e-4)");
 
-    SET_INIT_VALS({{"x", "scalar"}, {"shift", "scalar"}});
+    SET_VARS({{"x", "scalar"}, {"shift", "scalar"}});
 };
 
 IMPLEMENT_MODEL(Neuron);
@@ -25,7 +25,7 @@ class WeightUpdateModel : public WeightUpdateModels::Base
 public:
     DECLARE_MODEL(WeightUpdateModel, 1, 1);
 
-    SET_INIT_VALS({{"w", "scalar"}});
+    SET_VARS({{"w", "scalar"}});
     SET_PARAM_NAMES({"myTrigger"});
 
     SET_EVENT_THRESHOLD_CONDITION_CODE("(fmod($(x_pre),$(myTrigger)) < 1e-4)");
@@ -40,8 +40,8 @@ void modelDefinition(NNmodel &model)
     model.setDT(0.1);
     model.setName("pre_vars_in_sim_code_event_sparse");
 
-    model.addNeuronPopulation<Neuron>("pre", 10, {}, Neuron::InitValues(0.0, 0.0));
-    model.addNeuronPopulation<Neuron>("post", 10, {}, Neuron::InitValues(0.0, 0.0));
+    model.addNeuronPopulation<Neuron>("pre", 10, {}, Neuron::VarValues(0.0, 0.0));
+    model.addNeuronPopulation<Neuron>("post", 10, {}, Neuron::VarValues(0.0, 0.0));
 
     string synName= "syn";
     for (int i= 0; i < 10; i++)
@@ -49,7 +49,7 @@ void modelDefinition(NNmodel &model)
         string theName= synName + std::to_string(i);
         model.addSynapsePopulation<WeightUpdateModel, PostsynapticModels::Izhikevich>(
             theName, SPARSE, INDIVIDUALG, i, "pre", "post",
-            WeightUpdateModel::ParamValues((double)(2*(i+1))), WeightUpdateModel::InitValues(0.0),
+            WeightUpdateModel::ParamValues((double)(2*(i+1))), WeightUpdateModel::VarValues(0.0),
             {}, {});
     }
     model.setPrecision(GENN_FLOAT);

--- a/tests/features/pre_vars_in_sim_code_event_sparse_inv/model_new.cc
+++ b/tests/features/pre_vars_in_sim_code_event_sparse_inv/model_new.cc
@@ -12,7 +12,7 @@ public:
 
     SET_THRESHOLD_CONDITION_CODE("(fmod($(x),1.0) < 1e-4)");
 
-    SET_INIT_VALS({{"x", "scalar"}, {"shift", "scalar"}});
+    SET_VARS({{"x", "scalar"}, {"shift", "scalar"}});
 };
 
 IMPLEMENT_MODEL(Neuron);
@@ -25,7 +25,7 @@ class WeightUpdateModel : public WeightUpdateModels::Base
 public:
     DECLARE_MODEL(WeightUpdateModel, 1, 1);
 
-    SET_INIT_VALS({{"w", "scalar"}});
+    SET_VARS({{"w", "scalar"}});
     SET_PARAM_NAMES({"myTrigger"});
 
     SET_EVENT_THRESHOLD_CONDITION_CODE("(fmod($(x_pre),$(myTrigger)) < 1e-4)");
@@ -40,8 +40,8 @@ void modelDefinition(NNmodel &model)
     model.setDT(0.1);
     model.setName("pre_vars_in_sim_code_event_sparse_inv");
 
-    model.addNeuronPopulation<Neuron>("pre", 10, {}, Neuron::InitValues(0.0, 0.0));
-    model.addNeuronPopulation<Neuron>("post", 10, {}, Neuron::InitValues(0.0, 0.0));
+    model.addNeuronPopulation<Neuron>("pre", 10, {}, Neuron::VarValues(0.0, 0.0));
+    model.addNeuronPopulation<Neuron>("post", 10, {}, Neuron::VarValues(0.0, 0.0));
 
     string synName= "syn";
     for (int i= 0; i < 10; i++)
@@ -49,7 +49,7 @@ void modelDefinition(NNmodel &model)
         string theName= synName + std::to_string(i);
         model.addSynapsePopulation<WeightUpdateModel, PostsynapticModels::Izhikevich>(
             theName, SPARSE, INDIVIDUALG, i, "pre", "post",
-            WeightUpdateModel::ParamValues((double)(2*(i+1))), WeightUpdateModel::InitValues(0.0),
+            WeightUpdateModel::ParamValues((double)(2*(i+1))), WeightUpdateModel::VarValues(0.0),
             {}, {});
         model.setSpanTypeToPre(theName);
     }

--- a/tests/features/pre_vars_in_sim_code_sparse/model_new.cc
+++ b/tests/features/pre_vars_in_sim_code_sparse/model_new.cc
@@ -12,7 +12,7 @@ public:
 
     SET_THRESHOLD_CONDITION_CODE("(fmod($(x),1.0) < 1e-4)");
 
-    SET_INIT_VALS({{"x", "scalar"}, {"shift", "scalar"}});
+    SET_VARS({{"x", "scalar"}, {"shift", "scalar"}});
 };
 
 IMPLEMENT_MODEL(Neuron);
@@ -25,7 +25,7 @@ class WeightUpdateModel : public WeightUpdateModels::Base
 public:
     DECLARE_MODEL(WeightUpdateModel, 0, 1);
 
-    SET_INIT_VALS({{"w", "scalar"}});
+    SET_VARS({{"w", "scalar"}});
 
     SET_SIM_CODE("$(w)= $(x_pre);");
 };
@@ -38,8 +38,8 @@ void modelDefinition(NNmodel &model)
     model.setDT(0.1);
     model.setName("pre_vars_in_sim_code_sparse");
 
-    model.addNeuronPopulation<Neuron>("pre", 10, {}, Neuron::InitValues(0.0, 0.0));
-    model.addNeuronPopulation<Neuron>("post", 10, {}, Neuron::InitValues(0.0, 0.0));
+    model.addNeuronPopulation<Neuron>("pre", 10, {}, Neuron::VarValues(0.0, 0.0));
+    model.addNeuronPopulation<Neuron>("post", 10, {}, Neuron::VarValues(0.0, 0.0));
 
     string synName= "syn";
     for (int i= 0; i < 10; i++)
@@ -47,7 +47,7 @@ void modelDefinition(NNmodel &model)
         string theName= synName + std::to_string(i);
         model.addSynapsePopulation<WeightUpdateModel, PostsynapticModels::Izhikevich>(
             theName, SPARSE, INDIVIDUALG, i, "pre", "post",
-            {}, WeightUpdateModel::InitValues(0.0),
+            {}, WeightUpdateModel::VarValues(0.0),
             {}, {});
     }
     model.setPrecision(GENN_FLOAT);

--- a/tests/features/pre_vars_in_synapse_dynamics/model_new.cc
+++ b/tests/features/pre_vars_in_synapse_dynamics/model_new.cc
@@ -10,7 +10,7 @@ public:
 
     SET_SIM_CODE("$(x)= $(t)+$(shift);\n");
 
-    SET_INIT_VALS({{"x", "scalar"}, {"shift", "scalar"}});
+    SET_VARS({{"x", "scalar"}, {"shift", "scalar"}});
 };
 
 IMPLEMENT_MODEL(Neuron);
@@ -23,7 +23,7 @@ class WeightUpdateModel : public WeightUpdateModels::Base
 public:
     DECLARE_MODEL(WeightUpdateModel, 0, 1);
 
-    SET_INIT_VALS({{"w", "scalar"}});
+    SET_VARS({{"w", "scalar"}});
 
     SET_SYNAPSE_DYNAMICS_CODE("$(w)= $(x_pre);");
 };
@@ -36,8 +36,8 @@ void modelDefinition(NNmodel &model)
     model.setDT(0.1);
     model.setName("pre_vars_in_synapse_dynamics");
 
-    model.addNeuronPopulation<Neuron>("pre", 10, {}, Neuron::InitValues(0.0, 0.0));
-    model.addNeuronPopulation<Neuron>("post", 10, {}, Neuron::InitValues(0.0, 0.0));
+    model.addNeuronPopulation<Neuron>("pre", 10, {}, Neuron::VarValues(0.0, 0.0));
+    model.addNeuronPopulation<Neuron>("post", 10, {}, Neuron::VarValues(0.0, 0.0));
 
     string synName= "syn";
     for (int i= 0; i < 10; i++)
@@ -45,7 +45,7 @@ void modelDefinition(NNmodel &model)
         string theName= synName + std::to_string(i);
         model.addSynapsePopulation<WeightUpdateModel, PostsynapticModels::Izhikevich>(
             theName, DENSE, INDIVIDUALG, i, "pre", "post",
-            {}, WeightUpdateModel::InitValues(0.0),
+            {}, WeightUpdateModel::VarValues(0.0),
             {}, {});
     }
     model.setPrecision(GENN_FLOAT);

--- a/tests/features/pre_vars_in_synapse_dynamics_sparse/model_new.cc
+++ b/tests/features/pre_vars_in_synapse_dynamics_sparse/model_new.cc
@@ -10,7 +10,7 @@ public:
 
     SET_SIM_CODE("$(x)= $(t)+$(shift);\n");
 
-    SET_INIT_VALS({{"x", "scalar"}, {"shift", "scalar"}});
+    SET_VARS({{"x", "scalar"}, {"shift", "scalar"}});
 };
 
 IMPLEMENT_MODEL(Neuron);
@@ -23,7 +23,7 @@ class WeightUpdateModel : public WeightUpdateModels::Base
 public:
     DECLARE_MODEL(WeightUpdateModel, 0, 1);
 
-    SET_INIT_VALS({{"w", "scalar"}});
+    SET_VARS({{"w", "scalar"}});
 
     SET_SYNAPSE_DYNAMICS_CODE("$(w)= $(x_pre);");
 };
@@ -36,8 +36,8 @@ void modelDefinition(NNmodel &model)
     model.setDT(0.1);
     model.setName("pre_vars_in_synapse_dynamics_sparse");
 
-    model.addNeuronPopulation<Neuron>("pre", 10, {}, Neuron::InitValues(0.0, 0.0));
-    model.addNeuronPopulation<Neuron>("post", 10, {}, Neuron::InitValues(0.0, 0.0));
+    model.addNeuronPopulation<Neuron>("pre", 10, {}, Neuron::VarValues(0.0, 0.0));
+    model.addNeuronPopulation<Neuron>("post", 10, {}, Neuron::VarValues(0.0, 0.0));
 
     string synName= "syn";
     for (int i= 0; i < 10; i++)
@@ -45,7 +45,7 @@ void modelDefinition(NNmodel &model)
         string theName= synName + std::to_string(i);
         model.addSynapsePopulation<WeightUpdateModel, PostsynapticModels::Izhikevich>(
             theName, SPARSE, INDIVIDUALG, i, "pre", "post",
-            {}, WeightUpdateModel::InitValues(0.0),
+            {}, WeightUpdateModel::VarValues(0.0),
             {}, {});
     }
     model.setPrecision(GENN_FLOAT);

--- a/tests/features/synapse_support_code_event_sim_code/model_new.cc
+++ b/tests/features/synapse_support_code_event_sim_code/model_new.cc
@@ -12,7 +12,7 @@ public:
 
     SET_THRESHOLD_CONDITION_CODE("(fmod($(x),1.0) < 1e-4)");
 
-    SET_INIT_VALS({{"x", "scalar"}, {"shift", "scalar"}});
+    SET_VARS({{"x", "scalar"}, {"shift", "scalar"}});
 };
 
 IMPLEMENT_MODEL(Neuron);
@@ -25,7 +25,7 @@ class WeightUpdateModel : public WeightUpdateModels::Base
 public:
     DECLARE_MODEL(WeightUpdateModel, 1, 1);
 
-    SET_INIT_VALS({{"w", "scalar"}});
+    SET_VARS({{"w", "scalar"}});
     SET_PARAM_NAMES({"myTrigger"});
 
     SET_SIM_SUPPORT_CODE("__device__ __host__ scalar getWeight(scalar x){ return x; }");
@@ -42,8 +42,8 @@ void modelDefinition(NNmodel &model)
     model.setDT(0.1);
     model.setName("synapse_support_code_event_sim_code");
 
-    model.addNeuronPopulation<Neuron>("pre", 10, {}, Neuron::InitValues(0.0, 0.0));
-    model.addNeuronPopulation<Neuron>("post", 10, {}, Neuron::InitValues(0.0, 0.0));
+    model.addNeuronPopulation<Neuron>("pre", 10, {}, Neuron::VarValues(0.0, 0.0));
+    model.addNeuronPopulation<Neuron>("post", 10, {}, Neuron::VarValues(0.0, 0.0));
 
     string synName= "syn";
     for (int i= 0; i < 10; i++)
@@ -51,7 +51,7 @@ void modelDefinition(NNmodel &model)
         string theName= synName + std::to_string(i);
         model.addSynapsePopulation<WeightUpdateModel, PostsynapticModels::Izhikevich>(
             theName, DENSE, INDIVIDUALG, i, "pre", "post",
-            WeightUpdateModel::ParamValues((double)2*(i+1)), WeightUpdateModel::InitValues(0.0),
+            WeightUpdateModel::ParamValues((double)2*(i+1)), WeightUpdateModel::VarValues(0.0),
             {}, {});
     }
     model.setPrecision(GENN_FLOAT);

--- a/tests/features/synapse_support_code_event_threshold/model_new.cc
+++ b/tests/features/synapse_support_code_event_threshold/model_new.cc
@@ -12,7 +12,7 @@ public:
 
     SET_THRESHOLD_CONDITION_CODE("(fmod($(x),1.0) < 1e-4)");
 
-    SET_INIT_VALS({{"x", "scalar"}, {"shift", "scalar"}});
+    SET_VARS({{"x", "scalar"}, {"shift", "scalar"}});
 };
 
 IMPLEMENT_MODEL(Neuron);
@@ -25,7 +25,7 @@ class WeightUpdateModel : public WeightUpdateModels::Base
 public:
     DECLARE_MODEL(WeightUpdateModel, 1, 1);
 
-    SET_INIT_VALS({{"w", "scalar"}});
+    SET_VARS({{"w", "scalar"}});
     SET_PARAM_NAMES({"myTrigger"});
 
     SET_SIM_SUPPORT_CODE("__device__ __host__ bool checkThreshold(scalar x, scalar trigger){ return (fmod(x, trigger) < 1e-4); }");
@@ -42,8 +42,8 @@ void modelDefinition(NNmodel &model)
     model.setDT(0.1);
     model.setName("synapse_support_code_event_threshold");
 
-    model.addNeuronPopulation<Neuron>("pre", 10, {}, Neuron::InitValues(0.0, 0.0));
-    model.addNeuronPopulation<Neuron>("post", 10, {}, Neuron::InitValues(0.0, 0.0));
+    model.addNeuronPopulation<Neuron>("pre", 10, {}, Neuron::VarValues(0.0, 0.0));
+    model.addNeuronPopulation<Neuron>("post", 10, {}, Neuron::VarValues(0.0, 0.0));
 
     string synName= "syn";
     for (int i= 0; i < 10; i++)
@@ -51,7 +51,7 @@ void modelDefinition(NNmodel &model)
         string theName= synName + std::to_string(i);
         model.addSynapsePopulation<WeightUpdateModel, PostsynapticModels::Izhikevich>(
             theName, DENSE, INDIVIDUALG, i, "pre", "post",
-            WeightUpdateModel::ParamValues((double)2*(i+1)), WeightUpdateModel::InitValues(0.0),
+            WeightUpdateModel::ParamValues((double)2*(i+1)), WeightUpdateModel::VarValues(0.0),
             {}, {});
     }
     model.setPrecision(GENN_FLOAT);

--- a/tests/features/synapse_support_code_post_learn/model_new.cc
+++ b/tests/features/synapse_support_code_post_learn/model_new.cc
@@ -13,7 +13,7 @@ public:
     SET_THRESHOLD_CONDITION_CODE("(fmod($(x),$(ISI)) < 1e-4)");
 
     SET_PARAM_NAMES({"ISI"});
-    SET_INIT_VALS({{"x", "scalar"}, {"shift", "scalar"}});
+    SET_VARS({{"x", "scalar"}, {"shift", "scalar"}});
 };
 
 IMPLEMENT_MODEL(Neuron);
@@ -26,7 +26,7 @@ class WeightUpdateModel : public WeightUpdateModels::Base
 public:
     DECLARE_MODEL(WeightUpdateModel, 0, 1);
 
-    SET_INIT_VALS({{"w", "scalar"}});
+    SET_VARS({{"w", "scalar"}});
 
     SET_LEARN_POST_SUPPORT_CODE("__device__ __host__ scalar getWeight(scalar x){ return x; }");
     SET_LEARN_POST_CODE("$(w)= getWeight($(x_pre));");
@@ -40,8 +40,8 @@ void modelDefinition(NNmodel &model)
     model.setDT(0.1);
     model.setName("synapse_support_code_post_learn");
 
-    model.addNeuronPopulation<Neuron>("pre", 10, Neuron::ParamValues(1.0), Neuron::InitValues(0.0, 0.0));
-    model.addNeuronPopulation<Neuron>("post", 10, Neuron::ParamValues(2.0), Neuron::InitValues(0.0, 0.0));
+    model.addNeuronPopulation<Neuron>("pre", 10, Neuron::ParamValues(1.0), Neuron::VarValues(0.0, 0.0));
+    model.addNeuronPopulation<Neuron>("post", 10, Neuron::ParamValues(2.0), Neuron::VarValues(0.0, 0.0));
 
     string synName= "syn";
     for (int i= 0; i < 10; i++)
@@ -49,7 +49,7 @@ void modelDefinition(NNmodel &model)
         string theName= synName + std::to_string(i);
         model.addSynapsePopulation<WeightUpdateModel, PostsynapticModels::Izhikevich>(
             theName, DENSE, INDIVIDUALG, i, "pre", "post",
-            {}, WeightUpdateModel::InitValues(0.0),
+            {}, WeightUpdateModel::VarValues(0.0),
             {}, {});
     }
     model.setPrecision(GENN_FLOAT);

--- a/tests/features/synapse_support_code_sim_code/model_new.cc
+++ b/tests/features/synapse_support_code_sim_code/model_new.cc
@@ -12,7 +12,7 @@ public:
 
     SET_THRESHOLD_CONDITION_CODE("(fmod($(x),1.0) < 1e-4)");
 
-    SET_INIT_VALS({{"x", "scalar"}, {"shift", "scalar"}});
+    SET_VARS({{"x", "scalar"}, {"shift", "scalar"}});
 };
 
 IMPLEMENT_MODEL(Neuron);
@@ -25,7 +25,7 @@ class WeightUpdateModel : public WeightUpdateModels::Base
 public:
     DECLARE_MODEL(WeightUpdateModel, 0, 1);
 
-    SET_INIT_VALS({{"w", "scalar"}});
+    SET_VARS({{"w", "scalar"}});
 
     SET_SIM_SUPPORT_CODE("__device__ __host__ scalar getWeight(scalar x){ return x; }");
     SET_SIM_CODE("$(w)= getWeight($(x_pre));");
@@ -39,8 +39,8 @@ void modelDefinition(NNmodel &model)
     model.setDT(0.1);
     model.setName("synapse_support_code_sim_code");
 
-    model.addNeuronPopulation<Neuron>("pre", 10, {}, Neuron::InitValues(0.0, 0.0));
-    model.addNeuronPopulation<Neuron>("post", 10, {}, Neuron::InitValues(0.0, 0.0));
+    model.addNeuronPopulation<Neuron>("pre", 10, {}, Neuron::VarValues(0.0, 0.0));
+    model.addNeuronPopulation<Neuron>("post", 10, {}, Neuron::VarValues(0.0, 0.0));
 
     string synName= "syn";
     for (int i= 0; i < 10; i++)
@@ -48,7 +48,7 @@ void modelDefinition(NNmodel &model)
         string theName= synName + std::to_string(i);
         model.addSynapsePopulation<WeightUpdateModel, PostsynapticModels::Izhikevich>(
             theName, DENSE, INDIVIDUALG, i, "pre", "post",
-            {}, WeightUpdateModel::InitValues(0.0),
+            {}, WeightUpdateModel::VarValues(0.0),
             {}, {});
     }
     model.setPrecision(GENN_FLOAT);

--- a/tests/features/synapse_support_code_synapse_dynamics/model_new.cc
+++ b/tests/features/synapse_support_code_synapse_dynamics/model_new.cc
@@ -10,7 +10,7 @@ public:
 
     SET_SIM_CODE("$(x)= $(t)+$(shift);\n");
 
-    SET_INIT_VALS({{"x", "scalar"}, {"shift", "scalar"}});
+    SET_VARS({{"x", "scalar"}, {"shift", "scalar"}});
 };
 
 IMPLEMENT_MODEL(Neuron);
@@ -23,7 +23,7 @@ class WeightUpdateModel : public WeightUpdateModels::Base
 public:
     DECLARE_MODEL(WeightUpdateModel, 0, 1);
 
-    SET_INIT_VALS({{"w", "scalar"}});
+    SET_VARS({{"w", "scalar"}});
 
     SET_SYNAPSE_DYNAMICS_SUPPORT_CODE("__device__ __host__ scalar getWeight(scalar x){ return x; }");
     SET_SYNAPSE_DYNAMICS_CODE("$(w)= getWeight($(x_post));");
@@ -37,8 +37,8 @@ void modelDefinition(NNmodel &model)
     model.setDT(0.1);
     model.setName("synapse_support_code_synapse_dynamics");
 
-    model.addNeuronPopulation<Neuron>("pre", 10, {}, Neuron::InitValues(0.0, 0.0));
-    model.addNeuronPopulation<Neuron>("post", 10, {}, Neuron::InitValues(0.0, 0.0));
+    model.addNeuronPopulation<Neuron>("pre", 10, {}, Neuron::VarValues(0.0, 0.0));
+    model.addNeuronPopulation<Neuron>("post", 10, {}, Neuron::VarValues(0.0, 0.0));
 
     string synName= "syn";
     for (int i= 0; i < 10; i++)
@@ -46,7 +46,7 @@ void modelDefinition(NNmodel &model)
         string theName= synName + std::to_string(i);
         model.addSynapsePopulation<WeightUpdateModel, PostsynapticModels::Izhikevich>(
             theName, DENSE, INDIVIDUALG, i, "pre", "post",
-            {}, WeightUpdateModel::InitValues(0.0),
+            {}, WeightUpdateModel::VarValues(0.0),
             {}, {});
     }
     model.setPrecision(GENN_FLOAT);


### PR DESCRIPTION
Providing your GPU supports the extension, this change allows you to flag state variables to be implemented as a single zero-copy array rather than separate host and device arrays:

```c++
// Store spikes from neuron population 'E' in zero-copied memory
model.setNeuronSpikeZeroCopy("E");

// Store membrane voltage of neurons in population 'E' in zero-copied memory
model.setNeuronVarZeroCopy("E", "V");

// Store synaptic weights for synapse population 'IE' in zero-copied memory
model.setSynapseWeightUpdateVarZeroCopy("IE", "g");
```

Under the hood this changes the way the state variables are allocated and freed and removes the calls to ``cudaMemcpy`` from the ``pullXXXXFromDevice`` and ``pushXXXToDevice`` helpers. Any thoughts on the API/implementation would be much appreciated.

Specifically I am still a little unsure about exactly how the ``__device__`` symbols (the ones with the dd_ prefix) work so I'm a little unsure about how sane the implementation of ``deviceZeroCopy`` here https://github.com/genn-team/genn/blob/zero_copy/lib/src/generateRunner.cc#L450-L461 is.