### PR TITLE
Use the correct synapse name for "using namespace" (synapse dynamics)

### DIFF
--- a/lib/src/generateKernels.cc
+++ b/lib/src/generateKernels.cc
@@ -930,7 +930,7 @@ void genSynapseKernel(const NNmodel &model, //!< Model description
                     os << "if (" << localID << " < dd_indInG" << synapseName << "[" << srcno << "])" << OB(25);
                     os << "// all threads participate that can work on an existing synapse" << ENDL;
                     if (!wu->GetSynapseDynamicsSuppportCode().empty()) {
-			            os << " using namespace " << model.synapseName[i] << "_weightupdate_synapseDynamics;" << ENDL;
+			            os << " using namespace " << synapseName << "_weightupdate_synapseDynamics;" << ENDL;
 		            }
                     if (model.synapseGType[k] == INDIVIDUALG) {
                         // name substitute synapse var names in synapseDynamics code


### PR DESCRIPTION
@moritzaugustin reported an error with brian2genn (brian-team/brian2genn#46) which I think is due to an incorrect use of `model.synapseName[i]`, which should be `model.synapseName[k]` instead, or equivalently `synapseName` (which has earlier been introduced already). I'm not 100% sure about this, but it fixes our issue :) I think this got not detected by the tests because it needs several synapse models to occur, but again, I don't claim to really understand this code ;)