### PR TITLE
Do not use `std::to_string` to convert double values to strings

### DIFF
--- a/lib/include/codeGenUtils.h
+++ b/lib/include/codeGenUtils.h
@@ -1,6 +1,7 @@
 #pragma once
 
 // Standard includes
+#include <limits>
 #include <string>
 #include <sstream>
 #include <vector>
@@ -85,7 +86,10 @@ inline void value_substitutions(string &code, NameIter namesBegin, NameIter name
     NameIter n = namesBegin;
     auto v = values.cbegin();
     for (;n != namesEnd && v != values.cend(); n++, v++) {
-        substitute(code, "$(" + *n + ")", "(" + to_string(*v) + ")");
+        stringstream stream;
+        stream.precision(std::numeric_limits<double>::max_digits10);
+        stream << std::scientific << *v;
+        substitute(code, "$(" + *n + ")", "(" + stream.str() + ")");
     }
 }
 
@@ -121,7 +125,10 @@ inline void extended_value_substitutions(string &code, NameIter namesBegin, Name
     NameIter n = namesBegin;
     auto v = values.cbegin();
     for (;n != namesEnd && v != values.cend(); n++, v++) {
-        substitute(code, "$(" + *n + ext + ")", "(" + to_string(*v) + ")");
+        stringstream stream;
+        stream.precision(std::numeric_limits<double>::max_digits10);
+        stream << std::scientific << *v;
+        substitute(code, "$(" + *n + ext + ")", "(" + stream.str() + ")");
     }
 }
 


### PR DESCRIPTION
Triggered by some "division by zero" warnings, I realized that GeNN's use of `std::to_string` to convert the parameter values into strings to directly insert them into the code is rather dangerous. This function uses the standard `%f` formatting, i.e. only 6 digits after the decimal point. I think in most GeNN models this is not a big problem, since parameters are defined in ms, mV, etc. However, in `brian2genn` we use Brian's unit system which internally represents all numbers in the base unit, e.g. `-70mV` is represented as `-0.070`. We therefore not only lose precision, but GeNN's string formatting will replace every value that is smaller than `1e-7` by `0`, so that means that all those conductances in `nS`, or capacitances in `pF` will completely disappear...

The change proposed with this PR takes a very conservative approach and uses a string representation that is [supposed to give the bit-by-bit equivalent](http://www.boost.org/doc/libs/1_47_0/libs/math/doc/sf_and_dist/html/math_toolkit/utils/fp_facets/examples.html#math_toolkit.utils.fp_facets.examples.simple_example_with_std__stringstreams)  -- my C++ string skills are very rudimentary, though, maybe there's a better solution. This is a bit ugly since the values in the generated code will be quite long (e.g. `-70` will be represented as `-7.00000000000000000e+0`...), but well. I'd be happy with anything that does not replace our constants by zero :wink: 