### PR TITLE
CodeGenUtil unit tests

### DIFF
--- a/lib/include/codeGenUtils.h
+++ b/lib/include/codeGenUtils.h
@@ -64,16 +64,18 @@ void substitute(string &s, const string &trg, const string &rep);
 //! \brief This function performs a list of name substitutions for variables in code snippets.
 //--------------------------------------------------------------------------
 template<typename NameIter>
-inline void name_substitutions(string &code, const string &prefix, NameIter namesBegin, NameIter namesEnd, const string &postfix= "")
+inline void name_substitutions(string &code, const string &prefix, NameIter namesBegin, NameIter namesEnd, const string &postfix= "", const string &ext = "")
 {
     for (NameIter n = namesBegin; n != namesEnd; n++) {
-        substitute(code, "$(" + *n + ")", prefix + *n + postfix);
+        substitute(code,
+                   "$(" + *n + ext + ")",
+                   prefix + *n + postfix);
     }
 }
 
-inline void name_substitutions(string &code, const string &prefix, const vector<string> &names, const string &postfix= "")
+inline void name_substitutions(string &code, const string &prefix, const vector<string> &names, const string &postfix= "", const string &ext = "")
 {
-    name_substitutions(code, prefix, names.cbegin(), names.cend(), postfix);
+    name_substitutions(code, prefix, names.cbegin(), names.cend(), postfix, ext);
 }
 
 
@@ -81,7 +83,7 @@ inline void name_substitutions(string &code, const string &prefix, const vector<
 //! \brief This function performs a list of value substitutions for parameters in code snippets.
 //--------------------------------------------------------------------------
 template<typename NameIter>
-inline void value_substitutions(string &code, NameIter namesBegin, NameIter namesEnd, const vector<double> &values)
+inline void value_substitutions(string &code, NameIter namesBegin, NameIter namesEnd, const vector<double> &values, const string &ext = "")
 {
     NameIter n = namesBegin;
     auto v = values.cbegin();
@@ -89,52 +91,15 @@ inline void value_substitutions(string &code, NameIter namesBegin, NameIter name
         stringstream stream;
         stream.precision(std::numeric_limits<double>::max_digits10);
         stream << std::scientific << *v;
-        substitute(code, "$(" + *n + ")", "(" + stream.str() + ")");
+        substitute(code,
+                   "$(" + *n + ext + ")",
+                   "(" + stream.str() + ")");
     }
 }
 
-inline void value_substitutions(string &code, const vector<string> &names, const vector<double> &values)
+inline void value_substitutions(string &code, const vector<string> &names, const vector<double> &values, const string &ext = "")
 {
-    value_substitutions(code, names.cbegin(), names.cend(), values);
-}
-
-
-//--------------------------------------------------------------------------
-//! \brief This function performs a list of name substitutions for variables in code snippets where the variables have an extension in their names (e.g. "_pre").
-//--------------------------------------------------------------------------
-template<typename NameIter>
-inline void extended_name_substitutions(string &code, const string &prefix, NameIter namesBegin, NameIter namesEnd, const string &ext, const string &postfix= "")
-{
-    for (NameIter n = namesBegin; n != namesEnd; n++) {
-        substitute(code, "$(" + *n + ext + ")", prefix + *n + postfix);
-    }
-}
-
-inline void extended_name_substitutions(string &code, const string &prefix, const vector<string> &names, const string &ext, const string &postfix= "")
-{
-    extended_name_substitutions(code, prefix, names.cbegin(), names.cend(), ext, postfix);
-}
-
-//--------------------------------------------------------------------------
-//! \brief This function performs a list of value substitutions for parameters in code snippets where the parameters have an extension in their names (e.g. "_pre").
-//--------------------------------------------------------------------------
-template<typename NameIter>
-inline void extended_value_substitutions(string &code, NameIter namesBegin, NameIter namesEnd,
-                                         const string &ext, const vector<double> &values)
-{
-    NameIter n = namesBegin;
-    auto v = values.cbegin();
-    for (;n != namesEnd && v != values.cend(); n++, v++) {
-        stringstream stream;
-        stream.precision(std::numeric_limits<double>::max_digits10);
-        stream << std::scientific << *v;
-        substitute(code, "$(" + *n + ext + ")", "(" + stream.str() + ")");
-    }
-}
-
-inline void extended_value_substitutions(string &code, const vector<string> &names, const string &ext, const vector<double> &values)
-{
-    extended_value_substitutions(code, names.cbegin(), names.cend(), ext, values);
+    value_substitutions(code, names.cbegin(), names.cend(), values, ext);
 }
 
 //--------------------------------------------------------------------------

--- a/lib/src/codeGenUtils.cc
+++ b/lib/src/codeGenUtils.cc
@@ -359,17 +359,17 @@ void neuron_substitutions_in_synaptic_code(
                        devPrefix + preVars[j].first + model.neuronName[src] + "[" + preIdx + "]");
         }
     }
-    extended_value_substitutions(wCode, model.neuronModel[src]->GetParamNames(), "_pre", model.neuronPara[src]);
+    value_substitutions(wCode, model.neuronModel[src]->GetParamNames(), model.neuronPara[src], "_pre");
 
     auto preDerivedParams = model.neuronModel[src]->GetDerivedParams();
     auto preDerivedParamNameBegin = GetPairKeyConstIter(preDerivedParams.cbegin());
     auto preDerivedParamNameEnd = GetPairKeyConstIter(preDerivedParams.cend());
-    extended_value_substitutions(wCode, preDerivedParamNameBegin, preDerivedParamNameEnd, "_pre", model.dnp[src]);
+    value_substitutions(wCode, preDerivedParamNameBegin, preDerivedParamNameEnd, model.dnp[src], "_pre");
 
     auto preExtraGlobalParams = model.neuronModel[src]->GetExtraGlobalParams();
     auto preExtraGlobalParamsNameBegin = GetPairKeyConstIter(preExtraGlobalParams.cbegin());
     auto preExtraGlobalParamsNameEnd = GetPairKeyConstIter(preExtraGlobalParams.cend());
-    extended_name_substitutions(wCode, devPrefix, preExtraGlobalParamsNameBegin, preExtraGlobalParamsNameEnd, "_pre", model.neuronName[src]);
+    name_substitutions(wCode, devPrefix, preExtraGlobalParamsNameBegin, preExtraGlobalParamsNameEnd, model.neuronName[src], "_pre");
     
     // postsynaptic neuron variables, parameters, and global parameters
     substitute(wCode, "$(sT_post)", devPrefix + "sT" + model.neuronName[trg] + "[" + offsetPost + postIdx + "]");
@@ -384,15 +384,15 @@ void neuron_substitutions_in_synaptic_code(
                        devPrefix + postVars[j].first + model.neuronName[trg] + "[" + postIdx + "]");
         }
     }
-    extended_value_substitutions(wCode, model.neuronModel[trg]->GetParamNames(), "_post", model.neuronPara[trg]);
+    value_substitutions(wCode, model.neuronModel[trg]->GetParamNames(), model.neuronPara[trg], "_post");
 
     auto postDerivedParams = model.neuronModel[trg]->GetDerivedParams();
     auto postDerivedParamNameBegin= GetPairKeyConstIter(postDerivedParams.cbegin());
     auto postDerivedParamNameEnd = GetPairKeyConstIter(postDerivedParams.cend());
-    extended_value_substitutions(wCode, postDerivedParamNameBegin, postDerivedParamNameEnd, "_post", model.dnp[trg]);
+    value_substitutions(wCode, postDerivedParamNameBegin, postDerivedParamNameEnd, model.dnp[trg], "_post");
 
     auto postExtraGlobalParams = model.neuronModel[trg]->GetExtraGlobalParams();
     auto postExtraGlobalParamsNameBegin = GetPairKeyConstIter(postExtraGlobalParams.cbegin());
     auto postExtraGlobalParamsNameEnd = GetPairKeyConstIter(postExtraGlobalParams.cend());
-    extended_name_substitutions(wCode, devPrefix, postExtraGlobalParamsNameBegin, postExtraGlobalParamsNameEnd, "_post", model.neuronName[trg]);
+    name_substitutions(wCode, devPrefix, postExtraGlobalParamsNameBegin, postExtraGlobalParamsNameEnd, model.neuronName[trg], "_post");
 }

--- a/lib/src/generateCPU.cc
+++ b/lib/src/generateCPU.cc
@@ -251,7 +251,7 @@ void genNeuronFunction(const NNmodel &model, //!< Model description
                 // code substitutions ----
                 substitute(eCode, "$(id)", "n");
                 substitute(eCode, "$(t)", "t");
-                extended_name_substitutions(eCode, "l", neuronModelVarNameBegin, neuronModelVarNameEnd, "_pre", "");
+                name_substitutions(eCode, "l", neuronModelVarNameBegin, neuronModelVarNameEnd, "", "_pre");
                 name_substitutions(eCode, "", neuronModelExtraGlobalParamsNameBegin, neuronModelExtraGlobalParamsNameEnd, model.neuronName[i]);
                 eCode = ensureFtype(eCode, model.ftype);
                 checkUnreplacedVariables(eCode, "neuronSpkEvntCondition");

--- a/lib/src/generateKernels.cc
+++ b/lib/src/generateKernels.cc
@@ -343,7 +343,7 @@ void genNeuronKernel(const NNmodel &model, //!< Model description
                 // code substitutions ----
                 substitute(eCode, "$(id)", "n");
                 substitute(eCode, "$(t)", "t");
-                extended_name_substitutions(eCode, "l", neuronModelVarNameBegin, neuronModelVarNameEnd, "_pre", "");
+                name_substitutions(eCode, "l", neuronModelVarNameBegin, neuronModelVarNameEnd, "", "_pre");
                 name_substitutions(eCode, "", neuronModelExtraGlobalParamsNameBegin, neuronModelExtraGlobalParamsNameEnd, model.neuronName[i]);
                 eCode = ensureFtype(eCode, model.ftype);
                 checkUnreplacedVariables(eCode, "neuronSpkEvntCondition");

--- a/tests/run_tests.sh
+++ b/tests/run_tests.sh
@@ -22,9 +22,11 @@ popd
 # Delete existing output
 rm -f msg
 
-# Loop through feature tests
+# Zero counters of test passes and fails
 NUM_SUCCESSES=0
 NUM_FAILURES=0
+
+# Loop through feature tests
 for f in features/*;
     do
         echo "Running test $f..."
@@ -57,6 +59,26 @@ for f in features/*;
         popd
     done;
 
+# Enter unit tests directory
+pushd unit
+
+# Clean
+make clean 1>> ../../msg 2>> ../../msg
+
+# Build
+make $MAKE_FLAGS 1>>../../msg 2>>../../msg || exit $?
+
+# Run tests
+./test --gtest_output="xml:test_results$s.xml"
+if [ $? -eq 0 ]; then
+    NUM_SUCCESSES=$((NUM_SUCCESSES+1))
+else
+    NUM_FAILURES=$((NUM_FAILURES+1))
+fi
+
+# Pop unit tests directory
+popd
+
 # Print brief summary of output
-echo "$NUM_SUCCESSES feature tests succeeded"
-echo "$NUM_FAILURES feature tests failed"
+echo "$NUM_SUCCESSES tests succeeded"
+echo "$NUM_FAILURES tests failed"

--- a/tests/unit/Makefile
+++ b/tests/unit/Makefile
@@ -1,0 +1,17 @@
+
+
+CXX = g++
+CXXFLAGS = -std=c++11 -I "$(GTEST_DIR)" -isystem "$(GTEST_DIR)/include" -I "$(GENN_PATH)/lib/include" -I "$(GENN_PATH)/userproject/include" -DCPU_ONLY
+LINK_FLAGS = -lpthread
+
+SOURCES = codeGenUtils.cc $(GTEST_DIR)/src/gtest-all.cc $(GTEST_DIR)/src/gtest_main.cc $(GENN_PATH)/lib/src/codeGenUtils.cc
+OBJECTS =$(foreach obj,$(basename $(SOURCES)),$(obj).o)
+
+%.o: %.cc
+	$(CXX)  -c -o $@ $< $(CXXFLAGS)
+
+test: $(OBJECTS) 
+	$(CXX) -o $@ $^ $(CXXFLAGS) $(LINK_FLAGS)
+	
+clean:
+	rm -f *.o test

--- a/tests/unit/codeGenUtils.cc
+++ b/tests/unit/codeGenUtils.cc
@@ -1,0 +1,65 @@
+// C++ standard includes
+#include <limits>
+#include <tuple>
+
+// C standard includes
+#include <cstdlib>
+
+// Google test includes
+#include "gtest/gtest.h"
+
+// GeNN includes
+#include "codeGenUtils.h"
+
+//--------------------------------------------------------------------------
+// SingleValueSubstitutionTest
+//--------------------------------------------------------------------------
+class SingleValueSubstitutionTest : public ::testing::TestWithParam<double>
+{
+protected:
+    //--------------------------------------------------------------------------
+    // Test virtuals
+    //--------------------------------------------------------------------------
+    virtual void SetUp()
+    {
+        // Substitute variable for value
+        m_Code = "$(test)";
+        std::vector<std::string> names = {"test"};
+        std::vector<double> values = { GetParam() };
+        value_substitutions(m_Code, names, values);
+
+        // For safety, value_substitutions adds brackets around substituted values - trim these out
+        m_Code = m_Code.substr(1, m_Code.size() - 2);
+    }
+
+    //--------------------------------------------------------------------------
+    // Protected API
+    //--------------------------------------------------------------------------
+    const std::string &GetCode() const { return m_Code; }
+
+private:
+    //--------------------------------------------------------------------------
+    // Private API
+    //--------------------------------------------------------------------------
+    std::string m_Code;
+};
+
+//--------------------------------------------------------------------------
+// Tests
+//--------------------------------------------------------------------------
+TEST_P(SingleValueSubstitutionTest, CorrectGeneratedValue)
+{
+    // Convert results back to double and check they match
+    double result = std::atof(GetCode().c_str());
+    ASSERT_DOUBLE_EQ(result, GetParam());
+}
+
+//--------------------------------------------------------------------------
+// Instatiations
+//--------------------------------------------------------------------------
+INSTANTIATE_TEST_CASE_P(DoubleValues,
+                        SingleValueSubstitutionTest,
+                        ::testing::Values(std::numeric_limits<double>::min(),
+                                          std::numeric_limits<double>::max(),
+                                          1.0,
+                                          -1.0));


### PR DESCRIPTION
As much to get the finer-grained test creation ball rolling that anything I added some tests to cover the bug @mstimberg  found. In the process (and to save writing duplicate tests) I removed the ``extended_name_substitutions`` and ``extended_value_substitutions`` and added the extended options they provide as additional arguments (with defaults) to the standard versions. Once this is merged, I'll cherry pick along with #132 to master.

I'm pretty bad at writing Makefiles so the one that builds the unit tests could almost certainly do with some improvements!