### PR TITLE
Fix for bug in generation of CPU only individual id synaptic matrices

### DIFF
--- a/lib/src/generateCPU.cc
+++ b/lib/src/generateCPU.cc
@@ -395,7 +395,7 @@ void generate_process_presynaptic_events_code_CPU(
         }
 
         if (model.synapseGType[i] == INDIVIDUALID) {
-            os << "unsigned int gid = (ipre * " << model.neuronN[i] << " + ipost);" << ENDL;
+            os << "unsigned int gid = (ipre * " << model.neuronN[trg] << " + ipost);" << ENDL;
         }
 
         if (!weightUpdateModels[synt].simCode_supportCode.empty()) {


### PR DESCRIPTION
Before I start on rationalising the various types of synaptic matrix I have been testing the existing code and cherry picked out this small fix