### PR TITLE
GCC version test for regex insufficient

### DIFF
--- a/lib/src/stringUtils.cc
+++ b/lib/src/stringUtils.cc
@@ -14,7 +14,7 @@
 // 2) GCC 5.X.X and future
 // 3) Any future (4.10.X?) releases
 // 4) 4.9.1 and subsequent patch releases (GCC fully implemented regex in 4.9.0
-// BUT bug 61227 https://gcc.gnu.org/bugzilla/show_bug.cgi?id=61227 prevented \w from working.
+// BUT bug 61227 https://gcc.gnu.org/bugzilla/show_bug.cgi?id=61227 prevented \w from working)
 #if !defined(__GNUC__) || \
     __GNUC__ > 4 || \
     (__GNUC__ == 4 && (__GNUC_MINOR__ > 9 || \
@@ -386,7 +386,6 @@ void checkUnreplacedVariables(string code, string codeName)
 #else
 void checkUnreplacedVariables(string code, string codeName) 
 {
-#error "WHY NO REGEX"
 }
 #endif
 

--- a/lib/src/stringUtils.cc
+++ b/lib/src/stringUtils.cc
@@ -8,7 +8,21 @@
 
 #include <limits>
 
-#if !defined(__GNUC__) || (__GNUC__ >= 4 && __GNUC_MINOR__ >= 9)
+// Is C++ regex library operational?
+// We assume it is for:
+// 1) Non GCC compilers
+// 2) GCC 5.X.X and future
+// 3) Any future (4.10.X?) releases
+// 4) 4.9.1 and subsequent patch releases (GCC fully implemented regex in 4.9.0
+// BUT bug 61227 https://gcc.gnu.org/bugzilla/show_bug.cgi?id=61227 prevented \w from working.
+#if !defined(__GNUC__) || \
+    __GNUC__ > 4 || \
+    (__GNUC__ == 4 && (__GNUC_MINOR__ > 9 || \
+                      (__GNUC_MINOR__ == 9 && __GNUC_PATCHLEVEL__ >= 1)))
+    #define REGEX_OPERATIONAL
+#endif
+
+#ifdef REGEX_OPERATIONAL
 #include <regex>
 #endif
 
@@ -349,9 +363,7 @@ string ensureFtype(const string &oldcode, const string &type)
     return code;
 }
 
-
-#if !defined(__GNUC__) || (__GNUC__ >= 4 && __GNUC_MINOR__ >= 9)
-
+#ifdef REGEX_OPERATIONAL
 //--------------------------------------------------------------------------
 /*! \brief This function checks for unknown variable definitions and returns a gennError if any are found
  */
@@ -374,6 +386,7 @@ void checkUnreplacedVariables(string code, string codeName)
 #else
 void checkUnreplacedVariables(string code, string codeName) 
 {
+#error "WHY NO REGEX"
 }
 #endif
 


### PR DESCRIPTION
So this issue was two-fold

1. The test for GCC version was incorrect - you need to use horrible tests of this sort https://gcc.gnu.org/onlinedocs/cpp/Common-Predefined-Macros.html
2. We use \w in our regex and this bug https://gcc.gnu.org/bugzilla/show_bug.cgi?id=61227 was preventing that working in 4.9.0. 

I've made the test more robust and to test for 4.9.1.