### PR TITLE
Backport of fixes for serious parts of #147

### DIFF
--- a/lib/src/modelSpec.cc
+++ b/lib/src/modelSpec.cc
@@ -281,18 +281,19 @@ void NNmodel::initLearnGrps()
     // for synapse kernel
     for (int i = 0; i < synapseGrpN; i++) {
         const auto &wu = weightUpdateModels[synapseType[i]];
-        unsigned int src = synapseSource[i];
-        unsigned int trg = synapseTarget[i];
+        unsigned int ni[2];
+        ni[0] = synapseSource[i];
+        ni[1] = synapseTarget[i];
         unsigned int nt[2];
-        nt[0]= neuronType[src]; // pre
-        nt[1]= neuronType[trg]; // post
+        nt[0]= neuronType[ni[0]]; // pre
+        nt[1]= neuronType[ni[1]]; // post
         string suffix[2];
         suffix[0]= "_pre";
         suffix[1]= "_post";
         for (int k= 0; k < 2; k++) {
             for (int j= 0, l= nModels[nt[k]].extraGlobalNeuronKernelParameters.size(); j < l; j++) {
                 string pname= nModels[nt[k]].extraGlobalNeuronKernelParameters[j];
-                string pnamefull= pname + neuronName[src];
+                string pnamefull= pname + neuronName[ni[k]];
                 string ptype= nModels[nt[k]].extraGlobalNeuronKernelParameterTypes[j];
                 if (find(synapseKernelParameters.begin(), synapseKernelParameters.end(), pnamefull) == synapseKernelParameters.end()) {
                     // parameter wasn't registered yet - is it used?
@@ -328,18 +329,19 @@ void NNmodel::initLearnGrps()
     // for simLearnPost
     for (int i = 0; i < synapseGrpN; i++) {
         const auto &wu = weightUpdateModels[synapseType[i]];
-        unsigned int src = synapseSource[i];
-        unsigned int trg = synapseTarget[i];
+        unsigned int ni[2];
+        ni[0] = synapseSource[i];
+        ni[1] = synapseTarget[i];
         unsigned int nt[2];
-        nt[0]= neuronType[src]; // pre
-        nt[1]= neuronType[trg]; // post
+        nt[0]= neuronType[ni[0]]; // pre
+        nt[1]= neuronType[ni[1]]; // post
         string suffix[2];
         suffix[0]= "_pre";
         suffix[1]= "_post";
         for (int k= 0; k < 2; k++) {
             for (int j= 0, l= nModels[nt[k]].extraGlobalNeuronKernelParameters.size(); j < l; j++) {
                 string pname= nModels[nt[k]].extraGlobalNeuronKernelParameters[j];
-                string pnamefull= pname + neuronName[src];
+                string pnamefull= pname + neuronName[ni[k]];
                 string ptype= nModels[nt[k]].extraGlobalNeuronKernelParameterTypes[j];
                 if (find(simLearnPostKernelParameters.begin(), simLearnPostKernelParameters.end(), pnamefull) == simLearnPostKernelParameters.end()) {
                     // parameter wasn't registered yet - is it used?
@@ -371,18 +373,19 @@ void NNmodel::initLearnGrps()
     // for synapse Dynamics
     for (int i = 0; i < synapseGrpN; i++) {
         const auto &wu = weightUpdateModels[synapseType[i]];
-        unsigned int src = synapseSource[i];
-        unsigned int trg = synapseTarget[i];
+        unsigned int ni[2];
+        ni[0] = synapseSource[i];
+        ni[1] = synapseTarget[i];
         unsigned int nt[2];
-        nt[0]= neuronType[src]; // pre
-        nt[1]= neuronType[trg]; // post
+        nt[0]= neuronType[ni[0]]; // pre
+        nt[1]= neuronType[ni[1]]; // post
         string suffix[2];
         suffix[0]= "_pre";
         suffix[1]= "_post";
         for (int k= 0; k < 2; k++) {
             for (int j= 0, l= nModels[nt[k]].extraGlobalNeuronKernelParameters.size(); j < l; j++) {
                 string pname= nModels[nt[k]].extraGlobalNeuronKernelParameters[j];
-                string pnamefull= pname + neuronName[src];
+                string pnamefull= pname + neuronName[ni[k]];
                 string ptype= nModels[nt[k]].extraGlobalNeuronKernelParameterTypes[j];
                 if (find(synapseDynamicsKernelParameters.begin(), synapseDynamicsKernelParameters.end(), pnamefull) == synapseDynamicsKernelParameters.end()) {
                     // parameter wasn't registered yet - is it used?

--- a/lib/src/stringUtils.cc
+++ b/lib/src/stringUtils.cc
@@ -425,7 +425,7 @@ void neuron_substitutions_in_synaptic_code(
     }
     extended_value_substitutions(wCode, nModels[nt_pre].pNames, "_pre", model.neuronPara[src]);
     extended_value_substitutions(wCode, nModels[nt_pre].dpNames, "_pre", model.dnp[src]);
-    extended_name_substitutions(wCode, devPrefix, nModels[nt_pre].extraGlobalNeuronKernelParameters, "_pre", model.neuronName[src]);
+    extended_name_substitutions(wCode, "", nModels[nt_pre].extraGlobalNeuronKernelParameters, "_pre", model.neuronName[src]);
     
     // postsynaptic neuron variables, parameters, and global parameters
     substitute(wCode, "$(sT_post)", devPrefix + "sT" + model.neuronName[trg] + "[" + offsetPost + postIdx + "]");
@@ -441,7 +441,7 @@ void neuron_substitutions_in_synaptic_code(
     }
     extended_value_substitutions(wCode, nModels[nt_post].pNames, "_post", model.neuronPara[trg]);
     extended_value_substitutions(wCode, nModels[nt_post].dpNames, "_post", model.dnp[trg]);
-    extended_name_substitutions(wCode, devPrefix, nModels[nt_post].extraGlobalNeuronKernelParameters, "_post", model.neuronName[trg]);
+    extended_name_substitutions(wCode, "", nModels[nt_post].extraGlobalNeuronKernelParameters, "_post", model.neuronName[trg]);
 }
 
 #endif // STRINGUTILS_CC

--- a/tests/features/extra_global_post_param_in_sim_code/Makefile
+++ b/tests/features/extra_global_post_param_in_sim_code/Makefile
@@ -1,0 +1,7 @@
+EXECUTABLE      := test
+SOURCES         := test.cu $(GTEST_DIR)/src/gtest-all.cc $(GTEST_DIR)/src/gtest_main.cc
+
+INCLUDE_FLAGS	:= -I $(GTEST_DIR) -isystem $(GTEST_DIR)/include
+LINK_FLAGS	:= -lpthread
+
+include $(GENN_PATH)/userproject/include/makefile_common_gnu.mk

--- a/tests/features/extra_global_post_param_in_sim_code/model.cc
+++ b/tests/features/extra_global_post_param_in_sim_code/model.cc
@@ -1,0 +1,54 @@
+#include "modelSpec.h"
+
+// NEURONS
+//==============
+double neuron_ini[2] = { // one neuron variable
+    0.0, // 0 - the time
+    0.0  // 1 - individual shift
+};
+
+// Synapses
+//==================================================
+
+double synapses_ini[1]= {
+    0.0 // the copied time value
+};
+
+void modelDefinition(NNmodel &model)
+{
+  initGeNN();
+  model.setDT(0.1);
+  model.setName("extra_global_post_param_in_sim_code");
+
+  neuronModel n;
+  n.varNames = {"x", "shift"};
+  n.varTypes = {"scalar", "scalar"};
+  n.extraGlobalNeuronKernelParameters = {"k"};
+  n.extraGlobalNeuronKernelParameterTypes = {"scalar"};
+
+  n.simCode= "$(x)= $(t)+$(shift);";
+  n.thresholdConditionCode= "(fmod($(x),1.0) < 1e-4)";
+
+  const int DUMMYNEURON= nModels.size();
+  nModels.push_back(n);
+
+  weightUpdateModel s;
+  s.varNames = {"w"};
+  s.varTypes = {"scalar"};
+  s.simCode= "$(w)= $(x_post) * $(k_post);";
+  const int DUMMYSYNAPSE= weightUpdateModels.size();
+  weightUpdateModels.push_back(s);
+
+  model.addNeuronPopulation("pre", 10, DUMMYNEURON, NULL, neuron_ini);
+  model.addNeuronPopulation("post", 10, DUMMYNEURON, NULL, neuron_ini);
+  string synName= "syn";
+  for (int i= 0; i < 10; i++)
+  {
+      string theName= synName + std::to_string(i);
+      model.addSynapsePopulation(theName, DUMMYSYNAPSE, DENSE, INDIVIDUALG, i,IZHIKEVICH_PS, "pre", "post",
+                                 synapses_ini, NULL,
+                                 NULL, NULL);
+  }
+  model.setPrecision(GENN_FLOAT);
+  model.finalize();
+}

--- a/tests/features/extra_global_post_param_in_sim_code/test.cc
+++ b/tests/features/extra_global_post_param_in_sim_code/test.cc
@@ -1,0 +1,46 @@
+// Google test includes
+#include "gtest/gtest.h"
+
+// Auto-generated simulation code includess
+#include "extra_global_post_param_in_sim_code_CODE/definitions.h"
+
+// **NOTE** base-class for simulation tests must be
+// included after auto-generated globals are includes
+#include "../../utils/simulation_test_vars.h"
+#include "../../utils/simulation_neuron_policy_pre_post_var.h"
+#include "../../utils/simulation_synapse_policy_dense.h"
+
+// Combine neuron and synapse policies together to build variable-testing fixture
+typedef SimulationTestVars<SimulationNeuronPolicyPrePostVar, SimulationSynapsePolicyDense> SimTest;
+
+TEST_P(SimTest, AcceptableError)
+{
+  kpost = 1.0f;
+
+  float err = Simulate(
+    [](unsigned int d, unsigned int j, unsigned int k, float t, float &newX)
+    {
+        if ((t > 1.1001) && (fmod(t-DT-(d+1)*DT+5e-5,1.0f) < 1e-4))
+        {
+            newX = t-2*DT+10*k;
+            return true;
+        }
+        else
+        {
+          return false;
+        }
+    });
+
+  // Check total error is less than some tolerance
+  EXPECT_LT(err, 3e-2);
+}
+
+#ifndef CPU_ONLY
+auto simulatorBackends = ::testing::Values(true, false);
+#else
+auto simulatorBackends = ::testing::Values(false);
+#endif
+
+INSTANTIATE_TEST_CASE_P(extra_global_post_param_in_sim_code,
+                        SimTest,
+                        simulatorBackends);

--- a/tests/features/extra_global_pre_param_in_sim_code/Makefile
+++ b/tests/features/extra_global_pre_param_in_sim_code/Makefile
@@ -1,0 +1,7 @@
+EXECUTABLE      := test
+SOURCES         := test.cu $(GTEST_DIR)/src/gtest-all.cc $(GTEST_DIR)/src/gtest_main.cc
+
+INCLUDE_FLAGS	:= -I $(GTEST_DIR) -isystem $(GTEST_DIR)/include
+LINK_FLAGS	:= -lpthread
+
+include $(GENN_PATH)/userproject/include/makefile_common_gnu.mk

--- a/tests/features/extra_global_pre_param_in_sim_code/model.cc
+++ b/tests/features/extra_global_pre_param_in_sim_code/model.cc
@@ -1,0 +1,54 @@
+#include "modelSpec.h"
+
+// NEURONS
+//==============
+double neuron_ini[2] = { // one neuron variable
+    0.0, // 0 - the time
+    0.0  // 1 - individual shift
+};
+
+// Synapses
+//==================================================
+
+double synapses_ini[1]= {
+    0.0 // the copied time value
+};
+
+void modelDefinition(NNmodel &model)
+{
+  initGeNN();
+  model.setDT(0.1);
+  model.setName("extra_global_pre_param_in_sim_code");
+
+  neuronModel n;
+  n.varNames = {"x", "shift"};
+  n.varTypes = {"scalar", "scalar"};
+  n.extraGlobalNeuronKernelParameters = {"k"};
+  n.extraGlobalNeuronKernelParameterTypes = {"scalar"};
+
+  n.simCode= "$(x)= $(t)+$(shift);";
+  n.thresholdConditionCode= "(fmod($(x),1.0) < 1e-4)";
+
+  const int DUMMYNEURON= nModels.size();
+  nModels.push_back(n);
+
+  weightUpdateModel s;
+  s.varNames = {"w"};
+  s.varTypes = {"scalar"};
+  s.simCode= "$(w)= $(x_post) * $(k_pre);";
+  const int DUMMYSYNAPSE= weightUpdateModels.size();
+  weightUpdateModels.push_back(s);
+
+  model.addNeuronPopulation("pre", 10, DUMMYNEURON, NULL, neuron_ini);
+  model.addNeuronPopulation("post", 10, DUMMYNEURON, NULL, neuron_ini);
+  string synName= "syn";
+  for (int i= 0; i < 10; i++)
+  {
+      string theName= synName + std::to_string(i);
+      model.addSynapsePopulation(theName, DUMMYSYNAPSE, DENSE, INDIVIDUALG, i,IZHIKEVICH_PS, "pre", "post",
+                                 synapses_ini, NULL,
+                                 NULL, NULL);
+  }
+  model.setPrecision(GENN_FLOAT);
+  model.finalize();
+}

--- a/tests/features/extra_global_pre_param_in_sim_code/test.cc
+++ b/tests/features/extra_global_pre_param_in_sim_code/test.cc
@@ -1,0 +1,46 @@
+// Google test includes
+#include "gtest/gtest.h"
+
+// Auto-generated simulation code includess
+#include "extra_global_pre_param_in_sim_code_CODE/definitions.h"
+
+// **NOTE** base-class for simulation tests must be
+// included after auto-generated globals are includes
+#include "../../utils/simulation_test_vars.h"
+#include "../../utils/simulation_neuron_policy_pre_post_var.h"
+#include "../../utils/simulation_synapse_policy_dense.h"
+
+// Combine neuron and synapse policies together to build variable-testing fixture
+typedef SimulationTestVars<SimulationNeuronPolicyPrePostVar, SimulationSynapsePolicyDense> SimTest;
+
+TEST_P(SimTest, AcceptableError)
+{
+  kpre = 1.0f;
+
+  float err = Simulate(
+    [](unsigned int d, unsigned int j, unsigned int k, float t, float &newX)
+    {
+        if ((t > 1.1001) && (fmod(t-DT-(d+1)*DT+5e-5,1.0f) < 1e-4))
+        {
+            newX = t-2*DT+10*k;
+            return true;
+        }
+        else
+        {
+          return false;
+        }
+    });
+
+  // Check total error is less than some tolerance
+  EXPECT_LT(err, 3e-2);
+}
+
+#ifndef CPU_ONLY
+auto simulatorBackends = ::testing::Values(true, false);
+#else
+auto simulatorBackends = ::testing::Values(false);
+#endif
+
+INSTANTIATE_TEST_CASE_P(extra_global_pre_param_in_sim_code,
+                        SimTest,
+                        simulatorBackends);


### PR DESCRIPTION
- device prefix shouldn't be used on extra global parameters as they're passed directly to kernel rather than accessed as device globals
- building of list of list of synapse kernel parameters was broken