### PR TITLE
Multiple postsynaptic input

### DIFF
--- a/lib/include/newModels.h
+++ b/lib/include/newModels.h
@@ -122,6 +122,7 @@ public:
     typedef std::function<double(const std::vector<double> &, double)> DerivedParamFunc;
     typedef std::vector<std::string> StringVec;
     typedef std::vector<std::pair<std::string, std::string>> StringPairVec;
+    typedef std::vector<std::pair<std::string, std::pair<std::string, double>>> NameTypeValVec;
     typedef std::vector<std::pair<std::string, DerivedParamFunc>> DerivedParamVec;
 
     //----------------------------------------------------------------------------

--- a/lib/include/newNeuronModels.h
+++ b/lib/include/newNeuronModels.h
@@ -20,6 +20,7 @@
 #define SET_RESET_CODE(RESET_CODE) virtual std::string getResetCode() const{ return RESET_CODE; }
 #define SET_SUPPORT_CODE(SUPPORT_CODE) virtual std::string getSupportCode() const{ return SUPPORT_CODE; }
 #define SET_EXTRA_GLOBAL_PARAMS(...) virtual StringPairVec getExtraGlobalParams() const{ return __VA_ARGS__; }
+#define SET_ADDITIONAL_INPUT_VARS(...) virtual NameTypeValVec getAdditionalInputVars() const{ return __VA_ARGS__; }
 
 //----------------------------------------------------------------------------
 // NeuronModels::Base
@@ -54,6 +55,10 @@ public:
     //! Gets names and types (as strings) of additional
     //! per-population parameters for the weight update model.
     virtual NewModels::Base::StringPairVec getExtraGlobalParams() const{ return {}; }
+
+    //! Gets names, types (as strings) and initial values of local variables into which
+    //! the 'apply input code' of (potentially) multiple postsynaptic input models can apply input
+    virtual NewModels::Base::NameTypeValVec getAdditionalInputVars() const{ return {}; }
 
     //! Is this neuron model the internal Poisson model (which requires a number of special cases)
     //! \private

--- a/lib/include/newNeuronModels.h
+++ b/lib/include/newNeuronModels.h
@@ -53,7 +53,7 @@ public:
 
     //! Gets names and types (as strings) of additional
     //! per-population parameters for the weight update model.
-    virtual std::vector<std::pair<std::string, std::string>> getExtraGlobalParams() const{ return {}; }
+    virtual NewModels::Base::StringPairVec getExtraGlobalParams() const{ return {}; }
 
     //! Is this neuron model the internal Poisson model (which requires a number of special cases)
     //! \private

--- a/lib/include/newPostsynapticModels.h
+++ b/lib/include/newPostsynapticModels.h
@@ -8,7 +8,8 @@
 // Macros
 //----------------------------------------------------------------------------
 #define SET_DECAY_CODE(DECAY_CODE) virtual std::string getDecayCode() const{ return DECAY_CODE; }
-#define SET_CURRENT_CONVERTER_CODE(CURRENT_CONVERTER_CODE) virtual std::string getCurrentConverterCode() const{ return CURRENT_CONVERTER_CODE; }
+#define SET_CURRENT_CONVERTER_CODE(CURRENT_CONVERTER_CODE) virtual std::string getApplyInputCode() const{ return "$(Isyn) += " CURRENT_CONVERTER_CODE ";"; }
+#define SET_APPLY_INPUT_CODE(APPLY_INPUT_CODE) virtual std::string getApplyInputCode() const{ return APPLY_INPUT_CODE; }
 #define SET_SUPPORT_CODE(SUPPORT_CODE) virtual std::string getSupportCode() const{ return SUPPORT_CODE; }
 
 //----------------------------------------------------------------------------
@@ -24,7 +25,7 @@ public:
     // Declared virtuals
     //----------------------------------------------------------------------------
     virtual std::string getDecayCode() const{ return ""; }
-    virtual std::string getCurrentConverterCode() const{ return ""; }
+    virtual std::string getApplyInputCode() const{ return ""; }
     virtual std::string getSupportCode() const{ return ""; }
 };
 
@@ -42,7 +43,7 @@ public:
     // Base virtuals
     //----------------------------------------------------------------------------
     virtual std::string getDecayCode() const;
-    virtual std::string getCurrentConverterCode() const;
+    virtual std::string getApplyInputCode() const;
     virtual std::string getSupportCode() const;
 };
 

--- a/lib/include/newPostsynapticModels.h
+++ b/lib/include/newPostsynapticModels.h
@@ -11,7 +11,6 @@
 #define SET_CURRENT_CONVERTER_CODE(CURRENT_CONVERTER_CODE) virtual std::string getApplyInputCode() const{ return "$(Isyn) += " CURRENT_CONVERTER_CODE ";"; }
 #define SET_APPLY_INPUT_CODE(APPLY_INPUT_CODE) virtual std::string getApplyInputCode() const{ return APPLY_INPUT_CODE; }
 #define SET_SUPPORT_CODE(SUPPORT_CODE) virtual std::string getSupportCode() const{ return SUPPORT_CODE; }
-#define SET_ADDITIONAL_INPUT_VARS(...) virtual NameTypeValVec getAdditionalInputVars() const{ return __VA_ARGS__; }
 
 //----------------------------------------------------------------------------
 // PostsynapticModels::Base
@@ -28,7 +27,6 @@ public:
     virtual std::string getDecayCode() const{ return ""; }
     virtual std::string getApplyInputCode() const{ return ""; }
     virtual std::string getSupportCode() const{ return ""; }
-    virtual NewModels::Base::NameTypeValVec getAdditionalInputVars() const{ return {}; }
 };
 
 //----------------------------------------------------------------------------

--- a/lib/include/newPostsynapticModels.h
+++ b/lib/include/newPostsynapticModels.h
@@ -11,6 +11,7 @@
 #define SET_CURRENT_CONVERTER_CODE(CURRENT_CONVERTER_CODE) virtual std::string getApplyInputCode() const{ return "$(Isyn) += " CURRENT_CONVERTER_CODE ";"; }
 #define SET_APPLY_INPUT_CODE(APPLY_INPUT_CODE) virtual std::string getApplyInputCode() const{ return APPLY_INPUT_CODE; }
 #define SET_SUPPORT_CODE(SUPPORT_CODE) virtual std::string getSupportCode() const{ return SUPPORT_CODE; }
+#define SET_ADDITIONAL_INPUT_VARS(...) virtual NameTypeValVec getAdditionalInputVars() const{ return __VA_ARGS__; }
 
 //----------------------------------------------------------------------------
 // PostsynapticModels::Base
@@ -27,6 +28,7 @@ public:
     virtual std::string getDecayCode() const{ return ""; }
     virtual std::string getApplyInputCode() const{ return ""; }
     virtual std::string getSupportCode() const{ return ""; }
+    virtual NewModels::Base::NameTypeValVec getAdditionalInputVars() const{ return {}; }
 };
 
 //----------------------------------------------------------------------------

--- a/lib/include/standardGeneratedSections.h
+++ b/lib/include/standardGeneratedSections.h
@@ -43,8 +43,4 @@ void neuronSpikeEventTest(
     const ExtraGlobalParamNameIterCtx &nmExtraGlobalParams,
     const std::string &localID,
     const std::string &ftype);
-
-void neuronAdditionalPostsynapseInputVars(
-    CodeStream &ox,
-    const NeuronGroup &ng);
-}
+}   // namespace StandardGeneratedSections

--- a/lib/include/standardGeneratedSections.h
+++ b/lib/include/standardGeneratedSections.h
@@ -43,4 +43,8 @@ void neuronSpikeEventTest(
     const ExtraGlobalParamNameIterCtx &nmExtraGlobalParams,
     const std::string &localID,
     const std::string &ftype);
+
+void neuronAdditionalPostsynapseInputVars(
+    CodeStream &ox,
+    const NeuronGroup &ng);
 }

--- a/lib/include/standardSubstitutions.h
+++ b/lib/include/standardSubstitutions.h
@@ -39,7 +39,7 @@ typedef NameIterCtx<NewModels::Base::StringPairVec> ExtraGlobalParamNameIterCtx;
 //----------------------------------------------------------------------------
 namespace StandardSubstitutions
 {
-void postSynapseCurrentConverter(
+void postSynapseApplyInput(
     std::string &psCode,          //!< the code string to work on
     const SynapseGroup *sg,
     const NeuronGroup &ng,

--- a/lib/src/generateCPU.cc
+++ b/lib/src/generateCPU.cc
@@ -249,17 +249,16 @@ void genNeuronFunction(const NNmodel &model, //!< Model description
             }
 
             // Apply substitutions to current converter code
-            string psCode = psm->getCurrentConverterCode();
+            string psCode = psm->getApplyInputCode();
             substitute(psCode, "$(id)", "n");
             substitute(psCode, "$(inSyn)", "inSyn" + sg->getName() + "[n]");
-            StandardSubstitutions::postSynapseCurrentConverter(psCode, sg, n.second,
+            StandardSubstitutions::postSynapseApplyInput(psCode, sg, n.second,
                 nmVars, nmDerivedParams, nmExtraGlobalParams, model.getPrecision());
 
             if (!psm->getSupportCode().empty()) {
                 os << CodeStream::OB(29) << " using namespace " << sg->getName() << "_postsyn;" << std::endl;
             }
-            os << "Isyn += ";
-            os << psCode << ";" << std::endl;
+            os << psCode << std::endl;
             if (!psm->getSupportCode().empty()) {
                 os << CodeStream::CB(29) << " // namespace bracket closed" << std::endl;
             }

--- a/lib/src/generateCPU.cc
+++ b/lib/src/generateCPU.cc
@@ -237,8 +237,10 @@ void genNeuronFunction(const NNmodel &model, //!< Model description
             os << model.getPrecision() << " Isyn = 0;" << std::endl;
         }
 
-        // Generate code to intialize any additional postsynapse input vars
-        StandardGeneratedSections::neuronAdditionalPostsynapseInputVars(os, n.second);
+        // Initialise any additional input variables supported by neuron model
+        for(const auto &a : nm->getAdditionalInputVars()) {
+            os << a.second.first << " " << a.first << " = " << a.second.second << ";" << std::endl;
+        }
 
         for(const auto *sg : n.second.getInSyn()) {
             const auto *psm = sg->getPSModel();

--- a/lib/src/generateCPU.cc
+++ b/lib/src/generateCPU.cc
@@ -237,6 +237,8 @@ void genNeuronFunction(const NNmodel &model, //!< Model description
             os << model.getPrecision() << " Isyn = 0;" << std::endl;
         }
 
+        // Generate code to intialize any additional postsynapse input vars
+        StandardGeneratedSections::neuronAdditionalPostsynapseInputVars(os, n.second);
 
         for(const auto *sg : n.second.getInSyn()) {
             const auto *psm = sg->getPSModel();

--- a/lib/src/generateKernels.cc
+++ b/lib/src/generateKernels.cc
@@ -516,16 +516,16 @@ void genNeuronKernel(const NNmodel &model, //!< Model description
                     os << " = dd_" <<  v.first << sg->getName() << "[" << localID << "];" << std::endl;
                 }
             }
-            string psCode = psm->getCurrentConverterCode();
+            string psCode = psm->getApplyInputCode();
             substitute(psCode, "$(id)", localID);
             substitute(psCode, "$(inSyn)", "linSyn" + sg->getName());
-            StandardSubstitutions::postSynapseCurrentConverter(psCode, sg, n.second,
+            StandardSubstitutions::postSynapseApplyInput(psCode, sg, n.second,
                 nmVars, nmDerivedParams, nmExtraGlobalParams, model.getPrecision());
 
             if (!psm->getSupportCode().empty()) {
                 os << CodeStream::OB(29) << " using namespace " << sg->getName() << "_postsyn;" << std::endl;
             }
-            os << "Isyn += " << psCode << ";" << std::endl;
+            os << psCode << std::endl;
             if (!psm->getSupportCode().empty()) {
                 os << CodeStream::CB(29) << " // namespace bracket closed" << std::endl;
             }

--- a/lib/src/generateKernels.cc
+++ b/lib/src/generateKernels.cc
@@ -505,6 +505,10 @@ void genNeuronKernel(const NNmodel &model, //!< Model description
         if (n.second.getInSyn().size() > 0 || (nm->getSimCode().find("Isyn") != string::npos)) {
             os << model.getPrecision() << " Isyn = 0;" << std::endl;
         }
+
+        // Generate code to intialize any additional postsynapse input vars
+        StandardGeneratedSections::neuronAdditionalPostsynapseInputVars(os, n.second);
+
         for(const auto *sg : n.second.getInSyn()) {
             const auto *psm = sg->getPSModel();
 

--- a/lib/src/generateKernels.cc
+++ b/lib/src/generateKernels.cc
@@ -506,8 +506,10 @@ void genNeuronKernel(const NNmodel &model, //!< Model description
             os << model.getPrecision() << " Isyn = 0;" << std::endl;
         }
 
-        // Generate code to intialize any additional postsynapse input vars
-        StandardGeneratedSections::neuronAdditionalPostsynapseInputVars(os, n.second);
+        // Initialise any additional input variables supported by neuron model
+        for(const auto &a : nm->getAdditionalInputVars()) {
+            os << a.second.first << " " << a.first << " = " << a.second.second << ";" << std::endl;
+        }
 
         for(const auto *sg : n.second.getInSyn()) {
             const auto *psm = sg->getPSModel();

--- a/lib/src/newPostsynapticModels.cc
+++ b/lib/src/newPostsynapticModels.cc
@@ -13,10 +13,10 @@ std::string PostsynapticModels::LegacyWrapper::getDecayCode() const
     return ps.postSynDecay;
 }
 //----------------------------------------------------------------------------
-std::string PostsynapticModels::LegacyWrapper::getCurrentConverterCode() const
+std::string PostsynapticModels::LegacyWrapper::getApplyInputCode() const
 {
     const auto &ps = postSynModels[m_LegacyTypeIndex];
-    return ps.postSyntoCurrent;
+    return "$(Isyn) += " + ps.postSyntoCurrent + ";";
 }
 //----------------------------------------------------------------------------
 std::string PostsynapticModels::LegacyWrapper::getSupportCode() const

--- a/lib/src/standardGeneratedSections.cc
+++ b/lib/src/standardGeneratedSections.cc
@@ -31,7 +31,7 @@ void StandardGeneratedSections::neuronOutputInit(
         os << devPrefix << "glbSpkCnt" << ng.getName() << "[0] = 0;" << std::endl;
     }
 }
-
+//----------------------------------------------------------------------------
 void StandardGeneratedSections::neuronLocalVarInit(
     CodeStream &os,
     const NeuronGroup &ng,
@@ -48,7 +48,7 @@ void StandardGeneratedSections::neuronLocalVarInit(
         os << localID << "];" << std::endl;
     }
 }
-
+//----------------------------------------------------------------------------
 void StandardGeneratedSections::neuronLocalVarWrite(
     CodeStream &os,
     const NeuronGroup &ng,
@@ -66,7 +66,7 @@ void StandardGeneratedSections::neuronLocalVarWrite(
         }
     }
 }
-
+//----------------------------------------------------------------------------
 void StandardGeneratedSections::neuronSpikeEventTest(
     CodeStream &os,
     const NeuronGroup &ng,
@@ -100,5 +100,34 @@ void StandardGeneratedSections::neuronSpikeEventTest(
 
         // Close scope for spike-like event test
         os << CodeStream::CB(31);
+    }
+}
+//----------------------------------------------------------------------------
+void StandardGeneratedSections::neuronAdditionalPostsynapseInputVars(
+    CodeStream &os,
+    const NeuronGroup &ng)
+{
+    // Loop through all incoming synapses
+    std::map<std::string, std::pair<std::string, double>> extraVars;
+    for(const auto *sg : ng.getInSyn()) {
+        // Loop through additional input variables provided by post synaptic model
+        const auto *psm = sg->getPSModel();
+        for(const auto &a : psm->getAdditionalInputVars()) {
+            // If variable isn't already in map, insert it
+            auto existingVar = extraVars.find(a.first);
+            if(existingVar == extraVars.end()) {
+                extraVars.insert(a);
+            }
+            // Otherwise check that existing version has same type and value
+            else if(a.second != existingVar->second)
+            {
+                gennError("Incoming presynaptic models provide different definitions of additional input variable '" + a.first + "'");
+            }
+        }
+    }
+
+    // Add extra variables
+    for(const auto &v : extraVars) {
+        os << v.second.first << " " << v.first << " = " << v.second.second << ";" << std::endl;
     }
 }

--- a/lib/src/standardGeneratedSections.cc
+++ b/lib/src/standardGeneratedSections.cc
@@ -102,32 +102,3 @@ void StandardGeneratedSections::neuronSpikeEventTest(
         os << CodeStream::CB(31);
     }
 }
-//----------------------------------------------------------------------------
-void StandardGeneratedSections::neuronAdditionalPostsynapseInputVars(
-    CodeStream &os,
-    const NeuronGroup &ng)
-{
-    // Loop through all incoming synapses
-    std::map<std::string, std::pair<std::string, double>> extraVars;
-    for(const auto *sg : ng.getInSyn()) {
-        // Loop through additional input variables provided by post synaptic model
-        const auto *psm = sg->getPSModel();
-        for(const auto &a : psm->getAdditionalInputVars()) {
-            // If variable isn't already in map, insert it
-            auto existingVar = extraVars.find(a.first);
-            if(existingVar == extraVars.end()) {
-                extraVars.insert(a);
-            }
-            // Otherwise check that existing version has same type and value
-            else if(a.second != existingVar->second)
-            {
-                gennError("Incoming presynaptic models provide different definitions of additional input variable '" + a.first + "'");
-            }
-        }
-    }
-
-    // Add extra variables
-    for(const auto &v : extraVars) {
-        os << v.second.first << " " << v.first << " = " << v.second.second << ";" << std::endl;
-    }
-}

--- a/lib/src/standardSubstitutions.cc
+++ b/lib/src/standardSubstitutions.cc
@@ -7,7 +7,7 @@
 //----------------------------------------------------------------------------
 // StandardSubstitutions
 //----------------------------------------------------------------------------
-void StandardSubstitutions::postSynapseCurrentConverter(
+void StandardSubstitutions::postSynapseApplyInput(
     std::string &psCode,          //!< the code string to work on
     const SynapseGroup *sg,
     const NeuronGroup &ng,
@@ -20,8 +20,9 @@ void StandardSubstitutions::postSynapseCurrentConverter(
     auto psmVars = VarNameIterCtx(sg->getPSModel()->getVars());
     auto psmDerivedParams = DerivedParamNameIterCtx(sg->getPSModel()->getDerivedParams());
 
-    // Substitute in time parameter
+    // Substitute in time and standard Isyn parameters
     substitute(psCode, "$(t)", "t");
+    substitute(psCode, "$(Isyn)", "Isyn");
 
     name_substitutions(psCode, "l", nmVars.nameBegin, nmVars.nameEnd, "");
     value_substitutions(psCode, ng.getNeuronModel()->getParamNames(), ng.getParams());


### PR DESCRIPTION
As discussed post synaptic models can only currently update the ``Isyn`` local variable using this syntax:
```c++
SET_CURRENT_CONVERTER_CODE("$(inSyn) * ($(E) - $(V))");
```
This macro still exists but is now shorthand for:
```c++
SET_APPLY_INPUT_CODE("$(Isyn) += $(inSyn) * ($(E) - $(V));");
```
This new, more flexible code string can now be used to implement more complex code such as:
```c++
SET_APPLY_INPUT_CODE(
    "$(Isyn) += $(inSyn) * ($(E) - $(V));\n"
    "Isyn2 *= $(inSyn);\n");
```
This means that different postsynaptic update rules can inject input in different ways. 
So neuron kernel can correctly initialise these 'additional input variables' neuron models can list additional input variable, their types and initial values e.g.
```c++
SET_ADDITIONAL_INPUT_VARS({{"Isyn2", {"scalar", 1.0}}});
```