### PR TITLE
Synapse dynamics code which provides input

### DIFF
--- a/lib/include/standardSubstitutions.h
+++ b/lib/include/standardSubstitutions.h
@@ -91,9 +91,9 @@ void neuronReset(
 void weightUpdateThresholdCondition(
     std::string &eCode,
     const SynapseGroup &sg,
-    const DerivedParamNameIterCtx &nmDerivedParams,
-    const ExtraGlobalParamNameIterCtx &nmExtraGlobalParams,
-   const string &preIdx, //!< index of the pre-synaptic neuron to be accessed for _pre variables; differs for different Span)
+    const DerivedParamNameIterCtx &wuDerivedParams,
+    const ExtraGlobalParamNameIterCtx &wuExtraGlobalParams,
+    const string &preIdx, //!< index of the pre-synaptic neuron to be accessed for _pre variables; differs for different Span)
     const string &postIdx, //!< index of the post-synaptic neuron to be accessed for _post variables; differs for different Span)
     const string &devPrefix,
     const std::string &ftype);

--- a/lib/include/standardSubstitutions.h
+++ b/lib/include/standardSubstitutions.h
@@ -114,6 +114,7 @@ void weightUpdateDynamics(
     const SynapseGroup *sg,
     const VarNameIterCtx &wuVars,
     const DerivedParamNameIterCtx &wuDerivedParams,
+    const ExtraGlobalParamNameIterCtx &wuExtraGlobalParams,
     const string &preIdx, //!< index of the pre-synaptic neuron to be accessed for _pre variables; differs for different Span)
     const string &postIdx, //!< index of the post-synaptic neuron to be accessed for _post variables; differs for different Span)
     const string &devPrefix,

--- a/lib/src/generateCPU.cc
+++ b/lib/src/generateCPU.cc
@@ -417,79 +417,85 @@ void genSynapseFunction(const NNmodel &model, //!< Model description
     os << "*/" << std::endl;
     os << "//-------------------------------------------------------------------------" << std::endl << std::endl;
 
-    // synapse dynamics function
-    os << "void calcSynapseDynamicsCPU(" << model.getPrecision() << " t)" << std::endl;
-    os << CodeStream::OB(1000);
-    os << "// execute internal synapse dynamics if any" << std::endl;
+    if (!model.getSynapseDynamicsGroups().empty()) {
+        // synapse dynamics function
+        os << "void calcSynapseDynamicsCPU(" << model.getPrecision() << " t)" << std::endl;
+        os << CodeStream::OB(1000);
 
-    for(const auto &s : model.getSynapseDynamicsGroups())
-    {
-        const SynapseGroup *sg = model.findSynapseGroup(s.first);
-        const auto *wu = sg->getWUModel();
+        os << model.getPrecision() << " addtoinSyn;" << std::endl;
+        os << std::endl;
 
-        // there is some internal synapse dynamics
-        if (!wu->getSynapseDynamicsCode().empty()) {
+        os << "// execute internal synapse dynamics if any" << std::endl;
 
-            os << "// synapse group " << s.first << std::endl;
-            os << CodeStream::OB(1005);
+        for(const auto &s : model.getSynapseDynamicsGroups())
+        {
+            const SynapseGroup *sg = model.findSynapseGroup(s.first);
+            const auto *wu = sg->getWUModel();
 
-            if (sg->getSrcNeuronGroup()->isDelayRequired()) {
-                os << "unsigned int delaySlot = (spkQuePtr" << sg->getSrcNeuronGroup()->getName();
-                os << " + " << (sg->getSrcNeuronGroup()->getNumDelaySlots() - sg->getDelaySteps());
-                os << ") % " << sg->getSrcNeuronGroup()->getNumDelaySlots() << ";" << std::endl;
-            }
+            // there is some internal synapse dynamics
+            if (!wu->getSynapseDynamicsCode().empty()) {
 
-            if (!wu->getSynapseDynamicsSuppportCode().empty()) {
-                os << "using namespace " << s.first << "_weightupdate_synapseDynamics;" << std::endl;
-            }
+                os << "// synapse group " << s.first << std::endl;
+                os << CodeStream::OB(1005);
 
-            // Create iteration context to iterate over the variables and derived parameters
-            DerivedParamNameIterCtx wuDerivedParams(wu->getDerivedParams());
-            ExtraGlobalParamNameIterCtx wuExtraGlobalParams(wu->getExtraGlobalParams());
-            VarNameIterCtx wuVars(wu->getVars());
-
-            string SDcode= wu->getSynapseDynamicsCode();
-            substitute(SDcode, "$(t)", "t");
-            substitute(SDcode, "$(updatelinsyn)", "$(inSyn) += $(addtoinSyn)");
-
-            if (sg->getMatrixType() & SynapseMatrixConnectivity::SPARSE) { // SPARSE
-                os << "for (int n= 0; n < C" << s.first << ".connN; n++)" << CodeStream::OB(24) << std::endl;
-                if (sg->getMatrixType() & SynapseMatrixWeight::INDIVIDUAL) {
-                    // name substitute synapse var names in synapseDynamics code
-                    name_substitutions(SDcode, "", wuVars.nameBegin, wuVars.nameEnd, s.first + "[n]");
+                if (sg->getSrcNeuronGroup()->isDelayRequired()) {
+                    os << "unsigned int delaySlot = (spkQuePtr" << sg->getSrcNeuronGroup()->getName();
+                    os << " + " << (sg->getSrcNeuronGroup()->getNumDelaySlots() - sg->getDelaySteps());
+                    os << ") % " << sg->getSrcNeuronGroup()->getNumDelaySlots() << ";" << std::endl;
                 }
 
-                const std::string postIdx = "C" + s.first + ".ind[n]";
-                substitute(SDcode, "$(inSyn)", "inSyn" + s.first + "[" + postIdx + "]");
-
-                StandardSubstitutions::weightUpdateDynamics(SDcode, sg, wuVars, wuDerivedParams, wuExtraGlobalParams,
-                                                            "C" + s.first + ".preInd[n]",
-                                                            postIdx, "", model.getPrecision());
-                os << SDcode << std::endl;
-                os << CodeStream::CB(24);
-            }
-            else { // DENSE
-                os << "for (int i = 0; i < " <<  sg->getSrcNeuronGroup()->getNumNeurons() << "; i++)" << CodeStream::OB(25);
-                os << "for (int j = 0; j < " <<  sg->getTrgNeuronGroup()->getNumNeurons() << "; j++)" << CodeStream::OB(26);
-                os << "// loop through all synapses" << endl;
-                // substitute initial values as constants for synapse var names in synapseDynamics code
-                if (sg->getMatrixType() & SynapseMatrixWeight::INDIVIDUAL) {
-                    name_substitutions(SDcode, "", wuVars.nameBegin, wuVars.nameEnd,
-                                       s.first + "[i*" + to_string(sg->getTrgNeuronGroup()->getNumNeurons()) + "+j]");
+                if (!wu->getSynapseDynamicsSuppportCode().empty()) {
+                    os << "using namespace " << s.first << "_weightupdate_synapseDynamics;" << std::endl;
                 }
 
-                substitute(SDcode, "$(inSyn)", "inSyn" + s.first + "[j]");
+                // Create iteration context to iterate over the variables and derived parameters
+                DerivedParamNameIterCtx wuDerivedParams(wu->getDerivedParams());
+                ExtraGlobalParamNameIterCtx wuExtraGlobalParams(wu->getExtraGlobalParams());
+                VarNameIterCtx wuVars(wu->getVars());
 
-                StandardSubstitutions::weightUpdateDynamics(SDcode, sg, wuVars, wuDerivedParams, wuExtraGlobalParams,
-                                                            "i","j", "", model.getPrecision());
-                os << SDcode << std::endl;
-                os << CodeStream::CB(26);
-                os << CodeStream::CB(25);
+                string SDcode= wu->getSynapseDynamicsCode();
+                substitute(SDcode, "$(t)", "t");
+                substitute(SDcode, "$(updatelinsyn)", "$(inSyn) += $(addtoinSyn)");
+
+                if (sg->getMatrixType() & SynapseMatrixConnectivity::SPARSE) { // SPARSE
+                    os << "for (int n= 0; n < C" << s.first << ".connN; n++)" << CodeStream::OB(24) << std::endl;
+                    if (sg->getMatrixType() & SynapseMatrixWeight::INDIVIDUAL) {
+                        // name substitute synapse var names in synapseDynamics code
+                        name_substitutions(SDcode, "", wuVars.nameBegin, wuVars.nameEnd, s.first + "[n]");
+                    }
+
+                    const std::string postIdx = "C" + s.first + ".ind[n]";
+                    substitute(SDcode, "$(inSyn)", "inSyn" + s.first + "[" + postIdx + "]");
+
+                    StandardSubstitutions::weightUpdateDynamics(SDcode, sg, wuVars, wuDerivedParams, wuExtraGlobalParams,
+                                                                "C" + s.first + ".preInd[n]",
+                                                                postIdx, "", model.getPrecision());
+                    os << SDcode << std::endl;
+                    os << CodeStream::CB(24);
+                }
+                else { // DENSE
+                    os << "for (int i = 0; i < " <<  sg->getSrcNeuronGroup()->getNumNeurons() << "; i++)" << CodeStream::OB(25);
+                    os << "for (int j = 0; j < " <<  sg->getTrgNeuronGroup()->getNumNeurons() << "; j++)" << CodeStream::OB(26);
+                    os << "// loop through all synapses" << endl;
+                    // substitute initial values as constants for synapse var names in synapseDynamics code
+                    if (sg->getMatrixType() & SynapseMatrixWeight::INDIVIDUAL) {
+                        name_substitutions(SDcode, "", wuVars.nameBegin, wuVars.nameEnd,
+                                        s.first + "[i*" + to_string(sg->getTrgNeuronGroup()->getNumNeurons()) + "+j]");
+                    }
+
+                    substitute(SDcode, "$(inSyn)", "inSyn" + s.first + "[j]");
+
+                    StandardSubstitutions::weightUpdateDynamics(SDcode, sg, wuVars, wuDerivedParams, wuExtraGlobalParams,
+                                                                "i","j", "", model.getPrecision());
+                    os << SDcode << std::endl;
+                    os << CodeStream::CB(26);
+                    os << CodeStream::CB(25);
+                }
+                os << CodeStream::CB(1005);
             }
-            os << CodeStream::CB(1005);
         }
+        os << CodeStream::CB(1000);
     }
-    os << CodeStream::CB(1000);
 
     // synapse function header
     os << "void calcSynapsesCPU(" << model.getPrecision() << " t)" << std::endl;
@@ -508,7 +514,7 @@ void genSynapseFunction(const NNmodel &model, //!< Model description
     os << model.getPrecision() << " addtoinSyn;" << std::endl;
     os << std::endl;
 
-   for(const auto &s : model.getSynapseGroups()) {
+    for(const auto &s : model.getSynapseGroups()) {
         os << "// synapse group " << s.first << std::endl;
         os << CodeStream::OB(1006);
 

--- a/lib/src/generateKernels.cc
+++ b/lib/src/generateKernels.cc
@@ -723,7 +723,7 @@ void genSynapseKernel(const NNmodel &model, //!< Model description
 
     if (!model.getSynapseDynamicsGroups().empty()) {
         os << "#define BLOCKSZ_SYNDYN " << synDynBlkSz << endl;
-	
+
         // SynapseDynamics kernel header
         os << "extern \"C\" __global__ void calcSynapseDynamics(";
         for(const auto &p : model.getSynapseDynamicsKernelParameters()) {
@@ -736,9 +736,10 @@ void genSynapseKernel(const NNmodel &model, //!< Model description
 
         // common variables for all cases
         os << "unsigned int id = BLOCKSZ_SYNDYN * blockIdx.x + threadIdx.x;" << std::endl;
+        os << model.getPrecision() << " addtoinSyn;" << std::endl;
+        os << std::endl;
 
         os << "// execute internal synapse dynamics if any" << std::endl;
-        os << std::endl;
 
         bool firstSynapseDynamicsGroup = true;
         for(const auto &s : model.getSynapseDynamicsGroups())

--- a/lib/src/standardSubstitutions.cc
+++ b/lib/src/standardSubstitutions.cc
@@ -188,6 +188,7 @@ void StandardSubstitutions::weightUpdateDynamics(
     const SynapseGroup *sg,
     const VarNameIterCtx &wuVars,
     const DerivedParamNameIterCtx &wuDerivedParams,
+    const ExtraGlobalParamNameIterCtx &wuExtraGlobalParams,
     const string &preIdx, //!< index of the pre-synaptic neuron to be accessed for _pre variables; differs for different Span)
     const string &postIdx, //!< index of the post-synaptic neuron to be accessed for _post variables; differs for different Span)
     const string &devPrefix,
@@ -197,11 +198,13 @@ void StandardSubstitutions::weightUpdateDynamics(
          value_substitutions(SDcode, wuVars.nameBegin, wuVars.nameEnd, sg->getWUInitVals());
      }
 
-     // substitute parameter values for parameters in synapseDynamics code
+    // substitute parameter values for parameters in synapseDynamics code
     value_substitutions(SDcode, sg->getWUModel()->getParamNames(), sg->getWUParams());
 
     // substitute values for derived parameters in synapseDynamics code
     value_substitutions(SDcode, wuDerivedParams.nameBegin, wuDerivedParams.nameEnd, sg->getWUDerivedParams());
+    name_substitutions(SDcode, "", wuExtraGlobalParams.nameBegin, wuExtraGlobalParams.nameEnd, sg->getName());
+    substitute(SDcode, "$(addtoinSyn)", "addtoinSyn");
     neuron_substitutions_in_synaptic_code(SDcode, sg, preIdx, postIdx, devPrefix);
     SDcode= ensureFtype(SDcode, ftype);
     checkUnreplacedVariables(SDcode, "synapseDynamics");


### PR DESCRIPTION
Currently synapse dynamics code could only update state variables in the neuron or weight update rule. It couldn't provide synaptic input through the postsynaptic update. 

This prevents it being used for updating continuous synapses (which I think is a nicer way to implement these than sending a spike-like-event every time step). This change should let ``$(updatelinsyn)``, ``$(inSyn)`` and ``$(addtoinSyn)`` be used within the synapse dynamics in the same way they are within true-spike handling code. 

I'm really not that familiar with the synapse dynamics code though so a review would be much appreciated!