### PR TITLE
Determining which weight update model extra global parameters to pass to kernels was totally broken

### DIFF
--- a/lib/include/modelSpec.h
+++ b/lib/include/modelSpec.h
@@ -217,7 +217,7 @@ public:
     const map<string, string> &getSynapseKernelParameters() const{ return synapseKernelParameters; }
 
     //! Gets std::map containing names and types of each parameter that should be passed through to the postsynaptic learning kernel
-    const map<string, string> &getSimLearnPostKernelParameters() const{ return synapseDynamicsKernelParameters; }
+    const map<string, string> &getSimLearnPostKernelParameters() const{ return simLearnPostKernelParameters; }
 
     //! Gets std::map containing names and types of each parameter that should be passed through to the synapse dynamics kernel
     const map<string, string> &getSynapseDynamicsKernelParameters() const{ return synapseDynamicsKernelParameters; }

--- a/lib/include/synapseGroup.h
+++ b/lib/include/synapseGroup.h
@@ -106,8 +106,10 @@ public:
     // **THINK** this is very cuda-specific
     bool isPSAtomicAddRequired(unsigned int blockSize) const;
 
-    void addExtraGlobalSynapseParams(std::map<string, string> &kernelParameters) const;
     void addExtraGlobalNeuronParams(std::map<string, string> &kernelParameters) const;
+    void addExtraGlobalSynapseParams(std::map<string, string> &kernelParameters) const;
+    void addExtraGlobalPostLearnParams(std::map<string, string> &kernelParameters) const;
+    void addExtraGlobalSynapseDynamicsParams(std::map<string, string> &kernelParameters) const;
 
     // **THINK** do these really belong here - they are very code-generation specific
     std::string getOffsetPre() const;

--- a/lib/src/modelSpec.cc
+++ b/lib/src/modelSpec.cc
@@ -814,9 +814,10 @@ void NNmodel::finalize()
         }
 
         // Make extra global parameter lists
-        s.second.addExtraGlobalSynapseParams(synapseKernelParameters);
         s.second.addExtraGlobalNeuronParams(neuronKernelParameters);
-
+        s.second.addExtraGlobalSynapseParams(synapseKernelParameters);
+        s.second.addExtraGlobalPostLearnParams(simLearnPostKernelParameters);
+        s.second.addExtraGlobalSynapseDynamicsParams(synapseDynamicsKernelParameters);
     }
 
     setPopulationSums();

--- a/lib/src/synapseGroup.cc
+++ b/lib/src/synapseGroup.cc
@@ -166,6 +166,21 @@ bool SynapseGroup::isPSAtomicAddRequired(unsigned int blockSize) const
     return false;
 }
 
+void SynapseGroup::addExtraGlobalNeuronParams(std::map<std::string, std::string> &kernelParameters) const
+{
+    // Loop through list of extra global weight update parameters
+    for(auto const &p : getWUModel()->getExtraGlobalParams()) {
+        // If it's not already in set
+        std::string pnamefull = p.first + getName();
+        if (kernelParameters.find(pnamefull) == kernelParameters.end()) {
+            // If the presynaptic neuron requires this parameter in it's spike event conditions, add it
+            if (getSrcNeuronGroup()->isParamRequiredBySpikeEventCondition(pnamefull)) {
+                kernelParameters.insert(pair<string, string>(pnamefull, p.second));
+            }
+        }
+    }
+}
+
 void SynapseGroup::addExtraGlobalSynapseParams(std::map<std::string, std::string> &kernelParameters) const
 {
     // Synapse kernel
@@ -180,9 +195,11 @@ void SynapseGroup::addExtraGlobalSynapseParams(std::map<std::string, std::string
     // Finally add any weight update model extra global
     // parameters referenced in the sim to the map of kernel paramters
     addExtraGlobalSimParams(getName(), "", getWUModel()->getExtraGlobalParams(), kernelParameters);
+}
 
-    // Learn post
-    // -----------
+
+void SynapseGroup::addExtraGlobalPostLearnParams(std::map<string, string> &kernelParameters) const
+{
     // Add any of the pre or postsynaptic neuron group's extra global
     // parameters referenced in the sim code to the map of kernel parameters
     addExtraGlobalPostLearnParams(getSrcNeuronGroup()->getName(), "_pre", getSrcNeuronGroup()->getNeuronModel()->getExtraGlobalParams(),
@@ -194,8 +211,10 @@ void SynapseGroup::addExtraGlobalSynapseParams(std::map<std::string, std::string
     // parameters referenced in the sim to the map of kernel paramters
     addExtraGlobalPostLearnParams(getName(), "", getWUModel()->getExtraGlobalParams(), kernelParameters);
 
-    // Synapse dynamics
-    // ----------------
+}
+
+void SynapseGroup::addExtraGlobalSynapseDynamicsParams(std::map<string, string> &kernelParameters) const
+{
     // Add any of the pre or postsynaptic neuron group's extra global
     // parameters referenced in the sim code to the map of kernel parameters
     addExtraGlobalSynapseDynamicsParams(getSrcNeuronGroup()->getName(), "_pre", getSrcNeuronGroup()->getNeuronModel()->getExtraGlobalParams(),
@@ -206,21 +225,6 @@ void SynapseGroup::addExtraGlobalSynapseParams(std::map<std::string, std::string
     // Finally add any weight update model extra global
     // parameters referenced in the sim to the map of kernel paramters
     addExtraGlobalSynapseDynamicsParams(getName(), "", getWUModel()->getExtraGlobalParams(), kernelParameters);
-}
-
-void SynapseGroup::addExtraGlobalNeuronParams(std::map<std::string, std::string> &kernelParameters) const
-{
-    // Loop through list of extra global weight update parameters
-    for(auto const &p : getWUModel()->getExtraGlobalParams()) {
-        // If it's not already in set
-        std::string pnamefull = p.first + getName();
-        if (kernelParameters.find(pnamefull) == kernelParameters.end()) {
-            // If the presynaptic neuron requires this parameter in it's spike event conditions, add it
-            if (getSrcNeuronGroup()->isParamRequiredBySpikeEventCondition(pnamefull)) {
-                kernelParameters.insert(pair<string, string>(pnamefull, p.second));
-            }
-        }
-    }
 }
 
 void SynapseGroup::addExtraGlobalSimParams(const std::string &prefix, const std::string &suffix, const NewModels::Base::StringPairVec &extraGlobalParameters,


### PR DESCRIPTION
1. For some reason I was merging all three types (synapse dynamics, synapse and post learning) of parameter together
2. Even if I had been building maps of post learning parameters correctly, NNmodel::getSimLearnPostKernelParameters() was returning the wrong variable


