### PR TITLE
Allowing custom logic within $(updatelinsyn)

### DIFF
--- a/lib/include/newPostsynapticModels.h
+++ b/lib/include/newPostsynapticModels.h
@@ -10,6 +10,7 @@
 #define SET_DECAY_CODE(DECAY_CODE) virtual std::string getDecayCode() const{ return DECAY_CODE; }
 #define SET_CURRENT_CONVERTER_CODE(CURRENT_CONVERTER_CODE) virtual std::string getCurrentConverterCode() const{ return CURRENT_CONVERTER_CODE; }
 #define SET_SUPPORT_CODE(SUPPORT_CODE) virtual std::string getSupportCode() const{ return SUPPORT_CODE; }
+#define SET_UPDATE_LIN_SYN_CODE(UPDATE_LIN_SYN_CODE) virtual std::string getUpdateLinSynCode() const{ return UPDATE_LIN_SYN_CODE; }
 
 //----------------------------------------------------------------------------
 // PostsynapticModels::Base
@@ -26,6 +27,7 @@ public:
     virtual std::string getDecayCode() const{ return ""; }
     virtual std::string getCurrentConverterCode() const{ return ""; }
     virtual std::string getSupportCode() const{ return ""; }
+    virtual std::string getUpdateLinSynCode() const{ return ""; }
 };
 
 //----------------------------------------------------------------------------

--- a/lib/src/generateCPU.cc
+++ b/lib/src/generateCPU.cc
@@ -35,6 +35,18 @@
 //-------------------------------------------------------------------------
 namespace
 {
+std::string getUpdateLinSynCode(const PostsynapticModels::Base *psm)
+{
+    // If the post synaptic model has no custom code for updating
+    // linear synapses just return standard increment
+    if(psm->getUpdateLinSynCode().empty()) {
+        return "$(inSyn) += $(addtoinSyn)";
+    }
+    // Otherwise set $(inSyn) to the code string
+    else {
+        return "$(inSyn) = " + psm->getUpdateLinSynCode();
+    }
+}
 //-------------------------------------------------------------------------
 /*!
   \brief Function for generating the CUDA synapse kernel code that handles presynaptic
@@ -54,6 +66,7 @@ void generate_process_presynaptic_events_code_CPU(
 
     if ((evnt && sg.isSpikeEventRequired()) || (!evnt && sg.isTrueSpikeRequired())) {
         const auto *wu = sg.getWUModel();
+        const auto *psm = sg.getPSModel();
         const bool sparse = sg.getMatrixType() & SynapseMatrixConnectivity::SPARSE;
 
         // Detect spike events or spikes and do the update
@@ -117,7 +130,7 @@ void generate_process_presynaptic_events_code_CPU(
 
         // Code substitutions ----------------------------------------------------------------------------------
         string wCode = evnt ? wu->getEventCode() : wu->getSimCode();
-        substitute(wCode, "$(updatelinsyn)", "$(inSyn) += $(addtoinSyn)");
+        substitute(wCode, "$(updatelinsyn)", getUpdateLinSynCode(psm));
         substitute(wCode, "$(t)", "t");
         if (sparse) { // SPARSE
             if (sg.getMatrixType() & SynapseMatrixWeight::INDIVIDUAL) {
@@ -431,6 +444,7 @@ void genSynapseFunction(const NNmodel &model, //!< Model description
         {
             const SynapseGroup *sg = model.findSynapseGroup(s.first);
             const auto *wu = sg->getWUModel();
+            const auto *psm = sg->getPSModel();
 
             // there is some internal synapse dynamics
             if (!wu->getSynapseDynamicsCode().empty()) {
@@ -455,7 +469,7 @@ void genSynapseFunction(const NNmodel &model, //!< Model description
 
                 string SDcode= wu->getSynapseDynamicsCode();
                 substitute(SDcode, "$(t)", "t");
-                substitute(SDcode, "$(updatelinsyn)", "$(inSyn) += $(addtoinSyn)");
+                substitute(SDcode, "$(updatelinsyn)", getUpdateLinSynCode(psm));
 
                 if (sg->getMatrixType() & SynapseMatrixConnectivity::SPARSE) { // SPARSE
                     os << "for (int n= 0; n < C" << s.first << ".connN; n++)" << CodeStream::OB(24) << std::endl;

--- a/lib/src/generateKernels.cc
+++ b/lib/src/generateKernels.cc
@@ -92,13 +92,13 @@ std::string getUpdateLinSynCode(const PostsynapticModels::Base *psm, bool atomic
 
             // Generate custom atomic operation based using atomicCAS
             std::ostringstream casStream;
-            casStream << casType << " addressOfInSyn = (" << casType << "*)&$(inSyn);" << std::endl;
+            casStream << casType << "* addressOfInSyn = (" << casType << "*)&$(inSyn);" << std::endl;
             casStream << casType << " old = *addressOfInSyn;" << std::endl;
             casStream << casType << " assumed;" << std::endl;
             casStream << "do" << "{" << std::endl;
             casStream << "    assumed = old;" << std::endl;
-            casStream << "    old = atomicCAS(addressOfInSyn, assumes, " << fromFloatIntrinsic << "(" << uCode << "));" << std::endl;
-            casStream << "}" << " while(assumed != old);";
+            casStream << "    old = atomicCAS(addressOfInSyn, assumed, " << fromFloatIntrinsic << "(" << uCode << "));" << std::endl;
+            casStream << "}" << " while(assumed != old)";
 
             // Return generated code
             return casStream.str();

--- a/lib/src/generateKernels.cc
+++ b/lib/src/generateKernels.cc
@@ -92,7 +92,7 @@ std::string getUpdateLinSynCode(const PostsynapticModels::Base *psm, bool atomic
 
             // Generate custom atomic operation based using atomicCAS
             std::ostringstream casStream;
-            casStream << casType << " addressOfInSyn = (" << casType << "*)&($inSyn);" << std::endl;
+            casStream << casType << " addressOfInSyn = (" << casType << "*)&$(inSyn);" << std::endl;
             casStream << casType << " old = *addressOfInSyn;" << std::endl;
             casStream << casType << " assumed;" << std::endl;
             casStream << "do" << "{" << std::endl;

--- a/lib/src/generateKernels.cc
+++ b/lib/src/generateKernels.cc
@@ -50,6 +50,66 @@ string getFloatAtomicAdd(const string &ftype)
         return "atomicAdd";
     }
 }
+//--------------------------------------------------------------------------
+std::tuple<std::string, std::string, std::string> getCASTypeAndIntrinsics(const std::string &ftype) {
+    if(ftype == "float") {
+        return std::make_tuple("unsigned int", "__uint_as_float", "__float_as_uint");
+    }
+    else if(ftype == "double") {
+        return std::make_tuple("unsigned long long int", "__longlong_as_double", "__double_as_longlong");
+    }
+    else {
+        gennError("CUDA doesn't support CAS instruction of suitable size for floating point type '" + ftype + "'");
+    }
+}
+//--------------------------------------------------------------------------
+std::string getUpdateLinSynCode(const PostsynapticModels::Base *psm, bool atomicRequired, const std::string &ftype)
+{
+    // If the post synaptic model has no custom code for updating linear synapses
+    if(psm->getUpdateLinSynCode().empty()) {
+        // If atomics are required, use cuda atomic add operation
+        if(atomicRequired) {
+            return getFloatAtomicAdd(ftype) + "(&$(inSyn), $(addtoinSyn))";
+        }
+        // Otherwise use standard increment
+        else {
+            return "$(inSyn) += $(addtoinSyn)";
+        }
+    }
+    // Otherwise
+    else {
+        // If atomic is required
+        if(atomicRequired) {
+            // Determine what sort of CAS type and intrinsic are required for this floating point type
+            std::string casType;
+            std::string toFloatIntrinsic;
+            std::string fromFloatIntrinsic;
+            std::tie(casType, toFloatIntrinsic, fromFloatIntrinsic) = getCASTypeAndIntrinsics(ftype);
+
+            // Substitute the current value of variable with 'assumed' (and correct intrinsic to convert)
+            std::string uCode = psm->getUpdateLinSynCode();
+            substitute(uCode, "$(inSyn)", toFloatIntrinsic + "(assumed)");
+
+            // Generate custom atomic operation based using atomicCAS
+            std::ostringstream casStream;
+            casStream << casType << " addressOfInSyn = (" << casType << "*)&($inSyn);" << std::endl;
+            casStream << casType << " old = *addressOfInSyn;" << std::endl;
+            casStream << casType << " assumed;" << std::endl;
+            casStream << "do" << "{" << std::endl;
+            casStream << "    assumed = old;" << std::endl;
+            casStream << "    old = atomicCAS(addressOfInSyn, assumes, " << fromFloatIntrinsic << "(" << uCode << "));" << std::endl;
+            casStream << "}" << " while(assumed != old);";
+
+            // Return generated code
+            return casStream.str();
+        }
+        // Otherwise set $(inSyn) to the code string
+        else {
+            return "$(inSyn) = " + psm->getUpdateLinSynCode();
+        }
+    }
+}
+//--------------------------------------------------------------------------
 // parallelisation along pre-synaptic spikes, looped over post-synaptic neurons
 void generatePreParallelisedSparseCode(
     CodeStream &os, //!< output stream for code
@@ -62,6 +122,7 @@ void generatePreParallelisedSparseCode(
     const int UIntSz = sizeof(unsigned int) * 8;
     const int logUIntSz = (int) (logf((float) UIntSz) / logf(2.0f) + 1e-5f);
     const auto *wu = sg.getWUModel();
+    const auto *psm = sg.getPSModel();
 
     // Create iteration context to iterate over the variables; derived and extra global parameters
     DerivedParamNameIterCtx wuDerivedParams(wu->getDerivedParams());
@@ -132,14 +193,15 @@ a max possible number of connections via the model.setMaxConn() function.\n");
 
 // Code substitutions ----------------------------------------------------------------------------------
     string wCode = evnt ? wu->getEventCode() : wu->getSimCode();
-    substitute(wCode, "$(t)", "t");
+    const bool atomicRequired = sg.isPSAtomicAddRequired(synapseBlkSz);
 
-    if (sg.isPSAtomicAddRequired(synapseBlkSz)) { // SPARSE using atomicAdd
-        substitute(wCode, "$(updatelinsyn)", getFloatAtomicAdd(ftype) + "(&$(inSyn), $(addtoinSyn))");
+    substitute(wCode, "$(t)", "t");
+    substitute(wCode, "$(updatelinsyn)", getUpdateLinSynCode(psm, atomicRequired, ftype));
+
+    if (atomicRequired) { // SPARSE using atomicAdd
         substitute(wCode, "$(inSyn)", "dd_inSyn" + sg.getName() + "[ipost]");
     }
     else { // using shared memory
-        substitute(wCode, "$(updatelinsyn)", "$(inSyn) += $(addtoinSyn)");
         substitute(wCode, "$(inSyn)", "shLg[ipost]");
     }
 
@@ -165,7 +227,7 @@ a max possible number of connections via the model.setMaxConn() function.\n");
     os << CodeStream::CB(102);
     //os << CodeStream::CB(101);
 }
-
+//--------------------------------------------------------------------------
 // classical parallelisation of post-synaptic neurons in parallel and spikes in a loop
 void generatePostParallelisedCode(
     CodeStream &os, //!< output stream for code
@@ -177,6 +239,7 @@ void generatePostParallelisedCode(
     const bool evnt = (postfix == "Evnt");
     const int UIntSz = sizeof(unsigned int) * 8;
     const int logUIntSz = (int) (logf((float) UIntSz) / logf(2.0f) + 1e-5f);
+    const auto *psm = sg.getPSModel();
     const auto *wu = sg.getWUModel();
 
     // Create iteration context to iterate over the variables; derived and extra global parameters
@@ -260,14 +323,17 @@ a max possible number of connections via the model.setMaxConn() function.\n");
 
     // Code substitutions ----------------------------------------------------------------------------------
     string wCode = (evnt ? wu->getEventCode() : wu->getSimCode());
+    const bool atomicRequired = sg.isPSAtomicAddRequired(synapseBlkSz);
+    const bool sparse = (sg.getMatrixType() & SynapseMatrixConnectivity::SPARSE);
+
     substitute(wCode, "$(t)", "t");
-    if (sg.getMatrixType() & SynapseMatrixConnectivity::SPARSE) { // SPARSE
-        if (sg.isPSAtomicAddRequired(synapseBlkSz)) { // SPARSE using atomicAdd
-            substitute(wCode, "$(updatelinsyn)", getFloatAtomicAdd(ftype) + "(&$(inSyn), $(addtoinSyn))");
+    substitute(wCode, "$(updatelinsyn)", getUpdateLinSynCode(psm, atomicRequired && sparse, ftype));
+
+    if (sparse) { // SPARSE
+        if (atomicRequired) { // SPARSE using atomicAdd
             substitute(wCode, "$(inSyn)", "dd_inSyn" + sg.getName() + "[ipost]");
         }
         else { // SPARSE using shared memory
-            substitute(wCode, "$(updatelinsyn)", "$(inSyn) += $(addtoinSyn)");
             substitute(wCode, "$(inSyn)", "shLg[ipost]");
         }
 
@@ -276,7 +342,6 @@ a max possible number of connections via the model.setMaxConn() function.\n");
         }
     }
     else { // DENSE
-        substitute(wCode, "$(updatelinsyn)", "$(inSyn) += $(addtoinSyn)");
         substitute(wCode, "$(inSyn)", "linSyn");
         if (sg.getMatrixType() & SynapseMatrixWeight::INDIVIDUAL) {
             name_substitutions(wCode, "dd_", wuVars.nameBegin, wuVars.nameEnd, sg.getName() + "[shSpk"

--- a/lib/src/generateKernels.cc
+++ b/lib/src/generateKernels.cc
@@ -60,6 +60,7 @@ std::tuple<std::string, std::string, std::string> getCASTypeAndIntrinsics(const 
     }
     else {
         gennError("CUDA doesn't support CAS instruction of suitable size for floating point type '" + ftype + "'");
+        return std::make_tuple("", "", "");
     }
 }
 //--------------------------------------------------------------------------

--- a/lib/src/standardSubstitutions.cc
+++ b/lib/src/standardSubstitutions.cc
@@ -182,8 +182,10 @@ void StandardSubstitutions::weightUpdateSim(
 
     // substitute post-synaptic model parameter values into weight update code
     DerivedParamNameIterCtx psmDerivedParams(sg.getPSModel()->getDerivedParams());
+    VarNameIterCtx psmVars(sg.getPSModel()->getVars());
     value_substitutions(wCode, sg.getPSModel()->getParamNames(), sg.getPSParams());
     value_substitutions(wCode, psmDerivedParams.nameBegin, psmDerivedParams.nameEnd, sg.getPSDerivedParams());
+    name_substitutions(wCode, devPrefix, psmVars.nameBegin, psmVars.nameEnd, sg.getName() + "[" + postIdx + "]");
 
     substitute(wCode, "$(addtoinSyn)", "addtoinSyn");
     neuron_substitutions_in_synaptic_code(wCode, &sg, preIdx, postIdx, devPrefix);
@@ -214,8 +216,10 @@ void StandardSubstitutions::weightUpdateDynamics(
 
     // substitute post-synaptic model parameter values into weight update code
     DerivedParamNameIterCtx psmDerivedParams(sg->getPSModel()->getDerivedParams());
+    VarNameIterCtx psmVars(sg->getPSModel()->getVars());
     value_substitutions(SDcode, sg->getPSModel()->getParamNames(), sg->getPSParams());
     value_substitutions(SDcode, psmDerivedParams.nameBegin, psmDerivedParams.nameEnd, sg->getPSDerivedParams());
+    name_substitutions(SDcode, devPrefix, psmVars.nameBegin, psmVars.nameEnd, sg->getName() + "[" + postIdx + "]");
 
     substitute(SDcode, "$(addtoinSyn)", "addtoinSyn");
     neuron_substitutions_in_synaptic_code(SDcode, sg, preIdx, postIdx, devPrefix);

--- a/lib/src/standardSubstitutions.cc
+++ b/lib/src/standardSubstitutions.cc
@@ -170,13 +170,21 @@ void StandardSubstitutions::weightUpdateSim(
     const string &devPrefix,
     const std::string &ftype)
 {
-     if (sg.getMatrixType() & SynapseMatrixWeight::GLOBAL) {
-         value_substitutions(wCode, wuVars.nameBegin, wuVars.nameEnd, sg.getWUInitVals());
-     }
+    // If the synapse group has global (immutable) state, substitute in the initial values
+    if (sg.getMatrixType() & SynapseMatrixWeight::GLOBAL) {
+        value_substitutions(wCode, wuVars.nameBegin, wuVars.nameEnd, sg.getWUInitVals());
+    }
 
+    // substitute weight update parameter values into weight update code
     value_substitutions(wCode, sg.getWUModel()->getParamNames(), sg.getWUParams());
     value_substitutions(wCode, wuDerivedParams.nameBegin, wuDerivedParams.nameEnd, sg.getWUDerivedParams());
     name_substitutions(wCode, "", wuExtraGlobalParams.nameBegin, wuExtraGlobalParams.nameEnd, sg.getName());
+
+    // substitute post-synaptic model parameter values into weight update code
+    DerivedParamNameIterCtx psmDerivedParams(sg.getPSModel()->getDerivedParams());
+    value_substitutions(wCode, sg.getPSModel()->getParamNames(), sg.getPSParams());
+    value_substitutions(wCode, psmDerivedParams.nameBegin, psmDerivedParams.nameEnd, sg.getPSDerivedParams());
+
     substitute(wCode, "$(addtoinSyn)", "addtoinSyn");
     neuron_substitutions_in_synaptic_code(wCode, &sg, preIdx, postIdx, devPrefix);
     wCode= ensureFtype(wCode, ftype);
@@ -194,16 +202,21 @@ void StandardSubstitutions::weightUpdateDynamics(
     const string &devPrefix,
     const std::string &ftype)
 {
-     if (sg->getMatrixType() & SynapseMatrixWeight::GLOBAL) {
-         value_substitutions(SDcode, wuVars.nameBegin, wuVars.nameEnd, sg->getWUInitVals());
-     }
+    // If the synapse group has global (immutable) state, substitute in the initial values
+    if (sg->getMatrixType() & SynapseMatrixWeight::GLOBAL) {
+        value_substitutions(SDcode, wuVars.nameBegin, wuVars.nameEnd, sg->getWUInitVals());
+    }
 
-    // substitute parameter values for parameters in synapseDynamics code
+    // substitute weight update parameter values into synapseDynamics code
     value_substitutions(SDcode, sg->getWUModel()->getParamNames(), sg->getWUParams());
-
-    // substitute values for derived parameters in synapseDynamics code
     value_substitutions(SDcode, wuDerivedParams.nameBegin, wuDerivedParams.nameEnd, sg->getWUDerivedParams());
     name_substitutions(SDcode, "", wuExtraGlobalParams.nameBegin, wuExtraGlobalParams.nameEnd, sg->getName());
+
+    // substitute post-synaptic model parameter values into weight update code
+    DerivedParamNameIterCtx psmDerivedParams(sg->getPSModel()->getDerivedParams());
+    value_substitutions(SDcode, sg->getPSModel()->getParamNames(), sg->getPSParams());
+    value_substitutions(SDcode, psmDerivedParams.nameBegin, psmDerivedParams.nameEnd, sg->getPSDerivedParams());
+
     substitute(SDcode, "$(addtoinSyn)", "addtoinSyn");
     neuron_substitutions_in_synaptic_code(SDcode, sg, preIdx, postIdx, devPrefix);
     SDcode= ensureFtype(SDcode, ftype);


### PR DESCRIPTION
Some synapse types aren't a simple linear summation e.g. this SpineML synapse model https://github.com/SpineML/spineml/blob/master/examples/Striatal%20Model/Conductance_exp_Mg_block_synapse_sat.xml results in a GeNNified update like this:

``$(inSyn) = $(inSyn)+(1-$(inSyn)/$(N))*($(addtoinSyn));``

In this P.R. I have implemented this by adding a new code string to the postsynaptic model that gets used within the magic ``$(updatelinesyn)`` call. When ``$(updatelinsyn)`` doesn't result in an atomic operation implementing this is trivial and by using ``atomicCAS`` as suggested in http://docs.nvidia.com/cuda/cuda-c-programming-guide/index.html#atomic-functions, atomic updates can be implemented like this:

```c++
unsigned int* addressOfInSyn = (unsigned int*)&dd_inSynCortex_input_to_D1_MSN_to_D1___MSN_Synapse_1_weight_update[ipost];
unsigned int old = *addressOfInSyn;
unsigned int assumed;
do {
    assumed = old;
     old = atomicCAS(addressOfInSyn, assumed, __float_as_uint(__uint_as_float(assumed)+(1-__uint_as_float(assumed)/(2.50000000000000000e+02f))*(addtoinSyn)));
} while(assumed != old);
```
@tnowotny, I would appreciate your thoughts on this, both on the GPU implications of using these atomicCAS constructs and on this being a correct interpretation of these synapse models.
