### PR TITLE
Small optimisation for postsynaptic parallelism of sparse matrices

### DIFF
--- a/lib/include/synapseGroup.h
+++ b/lib/include/synapseGroup.h
@@ -102,6 +102,11 @@ public:
     bool isWUVarZeroCopyEnabled(const std::string &var) const;
     bool isPSVarZeroCopyEnabled(const std::string &var) const;
 
+    //!< Do true spikes or spike event handlers require access to presynaptic variables?
+    //!< If they do not, additional optimisations can be made
+    bool arePreVarsRequiredForTrueSpike() const{ return arePreVarsRequiredForSynapse(getWUModel()->getSimCode()); }
+    bool arePreVarsRequiredForSpikeLikeEvent() const{ return arePreVarsRequiredForSynapse(getWUModel()->getEventCode()); }
+
     void addExtraGlobalNeuronParams(std::map<string, string> &kernelParameters) const;
     void addExtraGlobalSynapseParams(std::map<string, string> &kernelParameters) const;
     void addExtraGlobalPostLearnParams(std::map<string, string> &kernelParameters) const;
@@ -115,6 +120,8 @@ private:
     //------------------------------------------------------------------------
     // Private methods
     //------------------------------------------------------------------------
+    bool arePreVarsRequiredForSynapse(const std::string &code) const;
+
     void addExtraGlobalSimParams(const std::string &prefix, const std::string &suffix, const NewModels::Base::StringPairVec &extraGlobalParameters,
                                  std::map<std::string, std::string> &kernelParameters) const;
     void addExtraGlobalPostLearnParams(const std::string &prefix, const std::string &suffix, const NewModels::Base::StringPairVec &extraGlobalParameters,

--- a/lib/include/synapseGroup.h
+++ b/lib/include/synapseGroup.h
@@ -59,7 +59,7 @@ public:
     void setClusterIndex(int hostID, int deviceID){ m_HostID = hostID; m_DeviceID = deviceID; }
 
     void setMaxConnections(unsigned int maxConnections);
-    void setSpanType(SpanType spanType);
+    void setSpanType(SpanType spanType){ m_SpanType = spanType; }
 
     void initDerivedParams(double dt);
     void calcKernelSizes(unsigned int blockSize, unsigned int &paddedKernelIDStart);
@@ -101,10 +101,6 @@ public:
     bool isZeroCopyEnabled() const;
     bool isWUVarZeroCopyEnabled(const std::string &var) const;
     bool isPSVarZeroCopyEnabled(const std::string &var) const;
-
-    //!< Is this synapse group too large to use shared memory for combining postsynaptic output
-    // **THINK** this is very cuda-specific
-    bool isPSAtomicAddRequired(unsigned int blockSize) const;
 
     void addExtraGlobalNeuronParams(std::map<string, string> &kernelParameters) const;
     void addExtraGlobalSynapseParams(std::map<string, string> &kernelParameters) const;

--- a/lib/src/synapseGroup.cc
+++ b/lib/src/synapseGroup.cc
@@ -143,6 +143,37 @@ bool SynapseGroup::isPSVarZeroCopyEnabled(const std::string &var) const
     return (m_PSVarZeroCopyEnabled.find(var) != std::end(m_PSVarZeroCopyEnabled));
 }
 
+bool SynapseGroup::arePreVarsRequiredForSynapse(const std::string &code) const
+{
+    // Get presynaptic neuron model
+    const auto *preNeuronModel = getSrcNeuronGroup()->getNeuronModel();
+
+    // If presynaptic neuron is poisson and code references it's voltage - return true
+    if (preNeuronModel->isPoisson() && code.find("$(V_pre)") != std::string::npos) {
+        return true;
+    }
+
+    // If code references presynaptic spike time - return true
+    if(code.find("$(sT_pre)") != std::string::npos)
+    {
+        return true;
+    }
+
+    // Loop through presynaptic neuron model variables
+    for(const auto &v : preNeuronModel->getVars()) {
+        // Get name this variable would be referred to in synapse code
+        const std::string preVarName = "$(" + v.first + "_pre)";
+
+        // If code references variable - return true
+        if(code.find(preVarName) != std::string::npos)
+        {
+            return true;
+        }
+    }
+
+    return false;
+}
+
 void SynapseGroup::addExtraGlobalNeuronParams(std::map<std::string, std::string> &kernelParameters) const
 {
     // Loop through list of extra global weight update parameters

--- a/tests/run_tests.sh
+++ b/tests/run_tests.sh
@@ -34,13 +34,15 @@ for f in features/*;
         # Loop through model suffixes
         for s in "" _new;
             do
+                # Determine where the sim code is located for this test
+                c=$(basename $f)$s"_CODE"
+
                 # Clean
-                make clean 1>> ../../msg 2>> ../../msg
+                make $MAKE_FLAGS SIM_CODE=$c clean 1>> ../../msg 2>> ../../msg
 
                 # Build and generate model
                 if genn-buildmodel.sh $BUILD_FLAGS model$s.cc 1>>../../msg 2>> ../../msg ; then
-                    # Determine where the sim code is located for this test and build
-                    c=$(basename $f)$s"_CODE"
+                    # Make
                     if make $MAKE_FLAGS SIM_CODE=$c 1>>../../msg 2>>../../msg ; then
                         # Run tests
                         ./test --gtest_output="xml:test_results$s.xml"


### PR DESCRIPTION
I spotted the opportunity for this small optimisation to the way the ``SparseProjection'' structure is read in. Potentially a large number of non-coalesced global memory accesses can be alleviated (in exchange for a small shared memory overhead) by copying the offset of each matrix row into shared memory rather than(/as well as) the presynaptic spike ids. This results in static weight update code like this:
```c++
if (threadIdx.x < lmax) {
    j = dd_glbSpkPN[(r * BLOCKSZ_SYN) + threadIdx.x];
    prePos = dd_indInGpnToKC[j];
    shSpkPrePos[threadIdx.x] = prePos;
    shSpkNPost[threadIdx.x] = dd_indInGpnToKC[j + 1] - prePos;
}
__syncthreads();
// loop through all incoming spikes
for (j = 0; j < lmax; j++) {
    // only work on existing neurons
    if (lid < 676) {
        prePos = shSpkPrePos[j];
        npost = shSpkNPost[j];
        if (lid < npost) {
            prePos += lid;
            ipost = dd_indpnToKC[prePos];    // Coalesced because adjacent threads have adjacent prePos
            addtoinSyn = (5.24999999999999981e-02f);
            atomicAdd(&dd_inSynpnToKC[ipost], addtoinSyn);
        }
    }
    
}
```
In the process I attempted to tidy up and comment the synaptic code generator and, while doing so, spotted the following:

- Presynaptic parallelism theoretically supported using shared memory but this code was broken so I have removed it
- There might be cases where presynaptic parallelism of dense matrices is useful - For completeness I have added a very basic placeholder implementation using global memory atomics.

Even so this code remains extremely complex so I am considering refactoring it in such a way that it makes adding e.g. 16-bit floating point support somewhat less of a terrifying prospect!
