### PR TITLE
C++11 improvements

### DIFF
--- a/lib/include/modelSpec.h
+++ b/lib/include/modelSpec.h
@@ -87,6 +87,12 @@ enum FloatType
 class NNmodel
 {
 public:
+    // Typedefines
+    //=======================
+    typedef map<string, NeuronGroup>::value_type NeuronGroupValueType;
+    typedef map<string, SynapseGroup>::value_type SynapseGroupValueType;
+
+
     NNmodel();
     ~NNmodel();
 
@@ -283,23 +289,17 @@ public:
             gennError("Trying to add a synapse population to a finalized model.");
         }
 
-
         auto srcNeuronGrp = findNeuronGroup(src);
         auto trgNeuronGrp = findNeuronGroup(trg);
 
-        srcNeuronGrp->checkNumDelaySlots(delaySteps);
-        if (delaySteps != NO_DELAY)
-        {
-            needSynapseDelay = true;
-        }
-
         // Add synapse group
-        auto result = m_SynapseGroups.insert(
-            pair<string, SynapseGroup>(
-                name, SynapseGroup(name, mtype, delaySteps,
-                                   WeightUpdateModel::getInstance(), weightParamValues.getValues(), weightVarValues.getValues(),
-                                   PostsynapticModel::getInstance(), postsynapticParamValues.getValues(), postsynapticVarValues.getValues(),
-                                   srcNeuronGrp, trgNeuronGrp)));
+        auto result = m_SynapseGroups.emplace(
+            std::piecewise_construct,
+            std::forward_as_tuple(name),
+            std::forward_as_tuple(name, mtype, delaySteps,
+                                  WeightUpdateModel::getInstance(), weightParamValues.getValues(), weightVarValues.getValues(),
+                                  PostsynapticModel::getInstance(), postsynapticParamValues.getValues(), postsynapticVarValues.getValues(),
+                                  srcNeuronGrp, trgNeuronGrp));
 
         if(!result.second)
         {
@@ -308,29 +308,7 @@ public:
         }
         else
         {
-            // Get pointer to new synapse group
-            SynapseGroup *newSynapseGroup = &result.first->second;
-
-            // If the weight update model requires presynaptic
-            // spike times, set flag in source neuron group
-            if (newSynapseGroup->getWUModel()->isPreSpikeTimeRequired()) {
-                srcNeuronGrp->setSpikeTimeRequired(true);
-                needSt = true;
-            }
-
-            // If the weight update model requires postsynaptic
-            // spike times, set flag in target neuron group
-            if (newSynapseGroup->getWUModel()->isPostSpikeTimeRequired()) {
-                trgNeuronGrp->setSpikeTimeRequired(true);
-                needSt = true;
-            }
-
-            // Add references to target and source neuron groups
-            trgNeuronGrp->addInSyn(newSynapseGroup);
-            srcNeuronGrp->addOutSyn(newSynapseGroup);
-
-            // Return
-            return newSynapseGroup;
+            return &result.first->second;
         }
     }
 
@@ -369,8 +347,6 @@ private:
     string RNtype; //!< Underlying type for random number generation (default: uint64_t)
     double dt; //!< The integration time step of the model
     bool final; //!< Flag for whether the model has been finalized
-    bool needSt; //!< Whether last spike times are needed at all in this network model (related to STDP)
-    bool needSynapseDelay; //!< Whether delayed synapse conductance is required in the network
     bool timing;
     unsigned int seed;
     unsigned int resetKernel;  //!< The identity of the kernel in which the spike counters will be reset.

--- a/lib/include/modelSpec.h
+++ b/lib/include/modelSpec.h
@@ -188,10 +188,10 @@ public:
         }
 
         // Add neuron group
-        auto result = m_NeuronGroups.insert(
-            pair<string, NeuronGroup>(
-                name, NeuronGroup(name, size, NeuronModel::getInstance(),
-                                  paramValues.getValues(), varValues.getValues())));
+        auto result = m_NeuronGroups.emplace(std::piecewise_construct,
+            std::forward_as_tuple(name),
+            std::forward_as_tuple(name, size, NeuronModel::getInstance(),
+                                  paramValues.getValues(), varValues.getValues()));
 
         if(!result.second)
         {

--- a/lib/include/neuronGroup.h
+++ b/lib/include/neuronGroup.h
@@ -25,6 +25,8 @@ public:
         m_HostID(0), m_DeviceID(0)
     {
     }
+    NeuronGroup(const NeuronGroup&) = delete;
+    NeuronGroup() = delete;
 
     //------------------------------------------------------------------------
     // Public methods

--- a/lib/include/newModels.h
+++ b/lib/include/newModels.h
@@ -182,7 +182,7 @@ public:
         {
             // Add pair consisting of parameter name and lambda function which calls
             // through to the DPS object associated with the legacy model
-            derivedParams.push_back(std::pair<std::string, DerivedParamFunc>(
+            derivedParams.push_back(std::make_pair(
               m.dpNames[p],
               [this, p](const std::vector<double> &pars, double dt)
               {
@@ -216,7 +216,7 @@ protected:
         // Build vector from legacy neuron model
         for(size_t v = 0; v < a.size(); v++)
         {
-            zip.push_back(std::pair<std::string, std::string>(a[v], b[v]));
+            zip.push_back(std::make_pair(a[v], b[v]));
         }
 
         return zip;

--- a/lib/include/synapseGroup.h
+++ b/lib/include/synapseGroup.h
@@ -21,14 +21,9 @@ public:
     SynapseGroup(const std::string name, SynapseMatrixType matrixType, unsigned int delaySteps,
                  const WeightUpdateModels::Base *wu, const std::vector<double> &wuParams, const std::vector<double> &wuInitVals,
                  const PostsynapticModels::Base *ps, const std::vector<double> &psParams, const std::vector<double> &psInitVals,
-                 NeuronGroup *srcNeuronGroup, NeuronGroup *trgNeuronGroup) :
-        m_PaddedKernelIDRange(0, 0), m_Name(name), m_SpanType(SpanType::POSTSYNAPTIC), m_DelaySteps(delaySteps), m_MaxConnections(trgNeuronGroup->getNumNeurons()), m_MatrixType(matrixType),
-        m_SrcNeuronGroup(srcNeuronGroup), m_TrgNeuronGroup(trgNeuronGroup),
-        m_TrueSpikeRequired(false), m_SpikeEventRequired(false), m_EventThresholdReTestRequired(false),
-        m_WUModel(wu), m_WUParams(wuParams), m_WUInitVals(wuInitVals), m_PSModel(ps), m_PSParams(psParams), m_PSInitVals(psInitVals),
-        m_HostID(0), m_DeviceID(0)
-    {
-    }
+                 NeuronGroup *srcNeuronGroup, NeuronGroup *trgNeuronGroup);
+    SynapseGroup(const SynapseGroup&) = delete;
+    SynapseGroup() = delete;
 
     //------------------------------------------------------------------------
     // Enumerations

--- a/lib/src/generateALL.cc
+++ b/lib/src/generateALL.cc
@@ -158,14 +158,14 @@ void chooseDevice(NNmodel &model, //!< the nn model we are generating code for
         // Populate the neuron group size
         std::transform(model.getNeuronGroups().cbegin(), model.getNeuronGroups().cend(),
                        std::back_insert_iterator<vector<unsigned int>>(groupSize[KernelCalcNeurons]),
-                       [](const std::pair<std::string, NeuronGroup> &n){ return n.second.getNumNeurons(); });
+                       [](const NNmodel::NeuronGroupValueType &n){ return n.second.getNumNeurons(); });
 
 
         // Populate the init group size
         // **TODO** synapses
         std::transform(model.getNeuronGroups().cbegin(), model.getNeuronGroups().cend(),
                        std::back_insert_iterator<vector<unsigned int>>(groupSize[KernelInit]),
-                       [](const std::pair<std::string, NeuronGroup> &n){ return n.second.getNumNeurons(); });
+                       [](const NNmodel::NeuronGroupValueType &n){ return n.second.getNumNeurons(); });
 
 #ifdef BLOCKSZ_DEBUG
         for (int i= 0; i < KernelMax; i++) {

--- a/lib/src/generateCPU.cc
+++ b/lib/src/generateCPU.cc
@@ -567,7 +567,7 @@ void genSynapseFunction(const NNmodel &model, //!< Model description
 
         // If any synapse groups have sparse connectivity
         if(any_of(begin(model.getSynapseGroups()), end(model.getSynapseGroups()),
-            [](const std::pair<string, SynapseGroup> &s)
+            [](const NNmodel::SynapseGroupValueType &s)
             {
                 return (s.second.getMatrixType() & SynapseMatrixConnectivity::SPARSE);
 

--- a/lib/src/generateRunner.cc
+++ b/lib/src/generateRunner.cc
@@ -1187,7 +1187,7 @@ void genRunner(const NNmodel &model, //!< Model description
 #ifndef CPU_ONLY
     os << "void initializeAllSparseArrays() {" << std::endl;
     if(any_of(begin(model.getSynapseGroups()), end(model.getSynapseGroups()),
-        [](const std::pair<string, SynapseGroup> &s)
+        [](const NNmodel::SynapseGroupValueType &s)
         {
             return (s.second.getMatrixType() & SynapseMatrixConnectivity::SPARSE);
 

--- a/lib/src/modelSpec.cc
+++ b/lib/src/modelSpec.cc
@@ -231,8 +231,9 @@ NeuronGroup *NNmodel::addNeuronPopulation(
     }
 
     // Add neuron group
-    auto result = m_NeuronGroups.insert(
-        pair<string, NeuronGroup>(name, NeuronGroup(name, nNo, new NeuronModels::LegacyWrapper(type), p, ini)));
+    auto result = m_NeuronGroups.emplace(std::piecewise_construct,
+        std::forward_as_tuple(name),
+        std::forward_as_tuple(name, nNo, new NeuronModels::LegacyWrapper(type), p, ini));
 
     if(!result.second)
     {

--- a/lib/src/modelSpec.cc
+++ b/lib/src/modelSpec.cc
@@ -50,8 +50,6 @@ void initGeNN()
 NNmodel::NNmodel() 
 {
     final= false;
-    needSt= false;
-    needSynapseDelay = false;
     setDT(0.5);
     setPrecision(GENN_FLOAT);
     setTiming(false);
@@ -78,14 +76,14 @@ bool NNmodel::zeroCopyInUse() const
 {
     // If any neuron groups use zero copy return true
     if(any_of(begin(m_NeuronGroups), end(m_NeuronGroups),
-        [](const std::pair<string, NeuronGroup> &n){ return n.second.isZeroCopyEnabled(); }))
+        [](const NeuronGroupValueType &n){ return n.second.isZeroCopyEnabled(); }))
     {
         return true;
     }
 
     // If any synapse groups use zero copy return true
     if(any_of(begin(m_SynapseGroups), end(m_SynapseGroups),
-        [](const std::pair<string, SynapseGroup> &s){ return s.second.isZeroCopyEnabled(); }))
+        [](const SynapseGroupValueType &s){ return s.second.isZeroCopyEnabled(); }))
     {
         return true;
     }
@@ -97,7 +95,7 @@ bool NNmodel::isRNGRequired() const
 {
     // If any neuron groups require an RNG return true
     if(any_of(begin(m_NeuronGroups), end(m_NeuronGroups),
-        [](const std::pair<string, NeuronGroup> &n){ return n.second.isRNGRequired(); }))
+        [](const NeuronGroupValueType &n){ return n.second.isRNGRequired(); }))
     {
         return true;
     }
@@ -483,19 +481,14 @@ SynapseGroup *NNmodel::addSynapsePopulation(
     auto srcNeuronGrp = findNeuronGroup(src);
     auto trgNeuronGrp = findNeuronGroup(trg);
 
-    srcNeuronGrp->checkNumDelaySlots(delaySteps);
-    if (delaySteps != NO_DELAY)
-    {
-        needSynapseDelay = true;
-    }
-
     // Add synapse group
-    auto result = m_SynapseGroups.insert(
-        pair<string, SynapseGroup>(
-            name, SynapseGroup(name, mtype, delaySteps,
-                               new WeightUpdateModels::LegacyWrapper(syntype), p, synini,
-                               new PostsynapticModels::LegacyWrapper(postsyn), ps, PSVini,
-                               srcNeuronGrp, trgNeuronGrp)));
+    auto result = m_SynapseGroups.emplace(
+        std::piecewise_construct,
+        std::forward_as_tuple(name),
+        std::forward_as_tuple(name, mtype, delaySteps,
+                              new WeightUpdateModels::LegacyWrapper(syntype), p, synini,
+                              new PostsynapticModels::LegacyWrapper(postsyn), ps, PSVini,
+                              srcNeuronGrp, trgNeuronGrp));
 
     if(!result.second)
     {
@@ -504,29 +497,7 @@ SynapseGroup *NNmodel::addSynapsePopulation(
     }
     else
     {
-        // Get pointer to new synapse group
-        SynapseGroup *newSynapseGroup = &result.first->second;
-
-        // If the weight update model requires presynaptic
-        // spike times, set flag in source neuron group
-        if (newSynapseGroup->getWUModel()->isPreSpikeTimeRequired()) {
-            srcNeuronGrp->setSpikeTimeRequired(true);
-            needSt = true;
-        }
-
-        // If the weight update model requires postsynaptic
-        // spike times, set flag in target neuron group
-        if (newSynapseGroup->getWUModel()->isPostSpikeTimeRequired()) {
-            trgNeuronGrp->setSpikeTimeRequired(true);
-            needSt = true;
-        }
-
-        // Add references to target and source neuron groups
-        trgNeuronGrp->addInSyn(newSynapseGroup);
-        srcNeuronGrp->addOutSyn(newSynapseGroup);
-
-        // Return
-        return newSynapseGroup;
+        return &result.first->second;
     }
 }
 
@@ -729,8 +700,7 @@ void NNmodel::setPopulationSums()
 
             // Add this synapse group to map of synapse groups with postsynaptic learning
             // or update the existing entry with the new block sizes
-            m_SynapsePostLearnGroups[s.first] = std::pair<unsigned int, unsigned int>(
-                startID, paddedSynapsePostLearnIDStart);
+            m_SynapsePostLearnGroups[s.first] = std::make_pair(startID, paddedSynapsePostLearnIDStart);
         }
 
          if (!s.second.getWUModel()->getSynapseDynamicsCode().empty()) {
@@ -739,8 +709,7 @@ void NNmodel::setPopulationSums()
 
             // Add this synapse group to map of synapse groups with dynamics
             // or update the existing entry with the new block sizes
-            m_SynapseDynamicsGroups[s.first] = std::pair<unsigned int, unsigned int>(
-                startID, paddedSynapseDynamicsIDStart);
+            m_SynapseDynamicsGroups[s.first] = std::make_pair(startID, paddedSynapseDynamicsIDStart);
          }
     }
 }


### PR DESCRIPTION
This came about from an attempt to tidy up the growing number of ``NNmodel::addSynapsePopulation`` methods by moving some of the common code into the ``SynapseGroup`` constructor. However this started crashing which turns out to be because this code was causing temporary objects to be created:
```c++
auto result = m_SynapseGroups.insert(
            pair<string, SynapseGroup>(
                name, SynapseGroup(name, mtype, delaySteps,
                                   WeightUpdateModel::getInstance(), weightParamValues.getValues(), weightVarValues.getValues(),
                                   PostsynapticModel::getInstance(), postsynapticParamValues.getValues(), postsynapticVarValues.getValues(),
                                   srcNeuronGrp, trgNeuronGrp)));
```
Therefore the pointers I was adding to the in and outgoing synapse population lists in the pre and postsynaptic neuron groups were invalid as they pointed to the temporary object. Luckily C++11 adds 'emplace' methods to containers to add objects without temporary object creation however the syntax is a little unpleasant:

```c++
auto result = m_SynapseGroups.emplace(
            std::piecewise_construct,
            std::forward_as_tuple(name),
            std::forward_as_tuple(name, mtype, delaySteps,
                                  WeightUpdateModel::getInstance(), weightParamValues.getValues(), weightVarValues.getValues(),
                                  PostsynapticModel::getInstance(), postsynapticParamValues.getValues(), postsynapticVarValues.getValues(),
                                  srcNeuronGrp, trgNeuronGrp));
```
It works though! To prevent these issues happening again I also deleted the copy constructors in ``SynapseGroup`` (and ``NeuronGroup``). 

I was slightly worried about the compiler compatibility with this as it feels a little bleeding edge but I tested manually on Visual C++ 2013 and the automatic tests cover GCC 4.8, GCC 5 and whatever Clang Thomas's Mac has.