### PR TITLE
Glibc bug warning

### DIFF
--- a/lib/src/generateInit.cc
+++ b/lib/src/generateInit.cc
@@ -115,7 +115,7 @@ void genInit(const NNmodel &model,          //!< Model description
     os << "#if defined(__GNUG__) && !defined(__clang__) && defined(__x86_64__) && __GLIBC__ == 2 && (__GLIBC_MINOR__ == 23 || __GLIBC_MINOR__ == 24)" << std::endl;
     os << "    const char *ldBindNow = std::getenv(\"LD_BIND_NOW\");" << std::endl;
     os << "    if(ldBindNow == NULL || strcmp(ldBindNow, \"1\") != 0) {" << std::endl;
-    os << "        fprintf(stderr, \"Warning: a bug has been found in glibc 2.23 or glibc 2.24 (https://bugs.launchpad.net/ubuntu/+source/glibc/+bug/1663280)\"" << std::endl;
+    os << "        fprintf(stderr, \"Warning: a bug has been found in glibc 2.23 or glibc 2.24 (https://bugs.launchpad.net/ubuntu/+source/glibc/+bug/1663280) \"" << std::endl;
     os << "                        \"which results in poor CPU maths performance. We recommend setting the environment variable LD_BIND_NOW=1 to work around this issue.\\n\");" << std::endl;
     os << "    }" << std::endl;
     os << "#endif" << std::endl;

--- a/lib/src/generateInit.cc
+++ b/lib/src/generateInit.cc
@@ -7,8 +7,6 @@
 #include <cmath>
 #include <cstdlib>
 
-
-
 // GeNN includes
 #include "codeStream.h"
 #include "global.h"
@@ -113,8 +111,7 @@ void genInit(const NNmodel &model,          //!< Model description
     // **NOTE** if we are using GCC on x86_64, bugs in some version of glibc can cause bad performance issues.
     // Best solution involves setting LD_BIND_NOW=1 so check whether this has been applied
     os << "#if defined(__GNUG__) && !defined(__clang__) && defined(__x86_64__) && __GLIBC__ == 2 && (__GLIBC_MINOR__ == 23 || __GLIBC_MINOR__ == 24)" << std::endl;
-    os << "    const char *ldBindNow = std::getenv(\"LD_BIND_NOW\");" << std::endl;
-    os << "    if(ldBindNow == NULL || strcmp(ldBindNow, \"1\") != 0) {" << std::endl;
+    os << "    if(std::getenv(\"LD_BIND_NOW\") == NULL) {" << std::endl;
     os << "        fprintf(stderr, \"Warning: a bug has been found in glibc 2.23 or glibc 2.24 (https://bugs.launchpad.net/ubuntu/+source/glibc/+bug/1663280) \"" << std::endl;
     os << "                        \"which results in poor CPU maths performance. We recommend setting the environment variable LD_BIND_NOW=1 to work around this issue.\\n\");" << std::endl;
     os << "    }" << std::endl;

--- a/lib/src/generateInit.cc
+++ b/lib/src/generateInit.cc
@@ -5,6 +5,9 @@
 
 // Standard C includes
 #include <cmath>
+#include <cstdlib>
+
+
 
 // GeNN includes
 #include "codeStream.h"
@@ -106,6 +109,16 @@ void genInit(const NNmodel &model,          //!< Model description
 #else
     std::string oB = "", cB = "";
 #endif // _WIN32
+
+    // **NOTE** if we are using GCC on x86_64, bugs in some version of glibc can cause bad performance issues.
+    // Best solution involves setting LD_BIND_NOW=1 so check whether this has been applied
+    os << "#if defined(__GNUG__) && !defined(__clang__) && defined(__x86_64__) && __GLIBC__ == 2 && (__GLIBC_MINOR__ == 23 || __GLIBC_MINOR__ == 24)" << std::endl;
+    os << "    const char *ldBindNow = std::getenv(\"LD_BIND_NOW\");" << std::endl;
+    os << "    if(ldBindNow == NULL || strcmp(ldBindNow, \"1\") != 0) {" << std::endl;
+    os << "        fprintf(stderr, \"Warning: a bug has been found in glibc 2.23 or glibc 2.24 (https://bugs.launchpad.net/ubuntu/+source/glibc/+bug/1663280)\"" << std::endl;
+    os << "                        \"which results in poor CPU maths performance. We recommend setting the environment variable LD_BIND_NOW=1 to work around this issue.\\n\");" << std::endl;
+    os << "    }" << std::endl;
+    os << "#endif" << std::endl;
 
     if (model.getSeed() == 0) {
         os << "    srand((unsigned int) time(NULL));" << std::endl;

--- a/lib/src/generateRunner.cc
+++ b/lib/src/generateRunner.cc
@@ -778,6 +778,12 @@ void genRunner(const NNmodel &model, //!< Model description
     os << "#include <ctime>" << std::endl;
     os << "#include <cassert>" << std::endl;
     os << "#include <stdint.h>" << std::endl;
+
+    // **NOTE** if we are using GCC on x86_64, bugs in some version of glibc can cause
+    // bad performance issues so need this to allow us to perform a runtime check
+    os << "#if defined(__GNUG__) && !defined(__clang__) && defined(__x86_64__)" << std::endl;
+    os << "    #include <gnu/libc-version.h>" << std::endl;
+    os << "#endif" << std::endl;
     os << std::endl;
 
 

--- a/userproject/include/makefile_common_gnu.mk
+++ b/userproject/include/makefile_common_gnu.mk
@@ -106,7 +106,7 @@ all: $(EXECUTABLE)
 ifdef LIBC_BUG
 $(EXECUTABLE): $(OBJECTS)
 	$(CXX) $(CXXFLAGS) -o $@_wrapper $(OBJECTS) $(LINK_FLAGS)
-	@echo "#!/bin/bash\nexport LD_BIND_NOW=1\n./$@_wrapper \"\$$@\"" >> $@
+	@echo "#!/bin/bash\nexport LD_BIND_NOW=1\nSCRIPT_PATH=\$$(dirname \"\$$0\")\n\$$SCRIPT_PATH/$@_wrapper \"\$$@\"" >> $@
 	@chmod +x $@
 else
 $(EXECUTABLE): $(OBJECTS)


### PR DESCRIPTION
Based on discussions with Marcel the best solution and most general solution I can think of for GeNN in general is a runtime check. As GeNN isn't set up to static link Glibc the only solution is to set the LD_BIND_NOW environment variable at runtime so, if we're building with G++ (seemingly clang sets this flag too so we have to explicitly test NOT clang) on x86_64 and linking against one of the effected Glibc versions we perform a runtime check on the LD_BIND_NOW environment variable in the initialize function.

Machines tested:

- [x] x86_64 Ubuntu 16 desktop - warning should be shown if LD_BIND_NOW isn't set
- [x] Jetson TX1 Ubuntu 16 - warning shouldn't be shown because architecture isn't correct (aarch64)
- [x] x86_64 Windows machine - warning shouldn't be shown 
- [x] x86_64 Ubuntu 14 laptop - warning shouldn't be shown because Glibc is older (2.19)
- [x] Mac OSX machine using Clang - warning shouldn't be shown because alternative libc is used