### PR TITLE
Runner now always gets compiled as C++11

### DIFF
--- a/lib/src/generateALL.cc
+++ b/lib/src/generateALL.cc
@@ -273,8 +273,7 @@ void chooseDevice(NNmodel &model, //!< the nn model we are generating code for
             string nvccCommand = "\"\"" NVCC "\" " + nvccFlags;
             nvccCommand += " -o \"" + cubinPath + "\" \"" + runnerPath + "\"\"";
 #else
-            if (model.isRNGRequired()) nvccFlags += " -std=c++11";
-            nvccFlags += " -I\"$GENN_PATH/lib/include\"";
+            nvccFlags += " -std=c++11 -I\"$GENN_PATH/lib/include\"";
             string runnerPath = path + "/" + model.getName() + "_CODE/runner.cc";
             string cubinPath = path + "/runner.cubin";
             string nvccCommand = "\"" NVCC "\" " + nvccFlags;

--- a/lib/src/generateRunner.cc
+++ b/lib/src/generateRunner.cc
@@ -2219,11 +2219,9 @@ void genMakefile(const NNmodel &model, //!< Model description
 #else // UNIX
 
 #ifdef CPU_ONLY
-    string cxxFlags = "-c -DCPU_ONLY";
-    cxxFlags += " " + GENN_PREFERENCES::userCxxFlagsGNU;
+    string cxxFlags = "-c -DCPU_ONLY -std=c++11 " + GENN_PREFERENCES::userCxxFlagsGNU;
     if (GENN_PREFERENCES::optimizeCode) cxxFlags += " -O3 -ffast-math";
     if (GENN_PREFERENCES::debugCode) cxxFlags += " -O0 -g";
-    if (model.isRNGRequired()) cxxFlags += " -std=c++11";
     os << endl;
     os << "CXXFLAGS       :=" << cxxFlags << endl;
     os << endl;
@@ -2237,13 +2235,12 @@ void genMakefile(const NNmodel &model, //!< Model description
     os << "clean:" << endl;
     os << "\trm -f runner.o" << endl;
 #else
-    string nvccFlags = "-c -x cu -arch sm_";
+    string nvccFlags = "-std=c++11 -c -x cu -arch sm_";
     nvccFlags += to_string(deviceProp[theDevice].major) + to_string(deviceProp[theDevice].minor);
     nvccFlags += " " + GENN_PREFERENCES::userNvccFlags;
     if (GENN_PREFERENCES::optimizeCode) nvccFlags += " -O3 -use_fast_math -Xcompiler \"-ffast-math\"";
     if (GENN_PREFERENCES::debugCode) nvccFlags += " -O0 -g -G";
     if (GENN_PREFERENCES::showPtxInfo) nvccFlags += " -Xptxas \"-v\"";
-    if (model.isRNGRequired()) nvccFlags += " -std=c++11";
 
     os << endl;
     os << "NVCC           :=\"" << NVCC << "\"" << endl;


### PR DESCRIPTION
Using the new RNG support previously toggled C++11 compilation (as it used C++11 RNGs for CPU_ONLY mode).  As discussed in #161, this seemed a bit weird - we should be using C++11 to compile generated code as the generator itself requires it *and* the user project makefile also compiles everything else in the user project as C++11.