### PR TITLE
Option to pass include flags from genn-buildmodels - allow models to include headers from other directories

### DIFF
--- a/lib/GNUmakefile
+++ b/lib/GNUmakefile
@@ -55,39 +55,39 @@ ifeq ($(DARWIN),DARWIN)
     CXX                  :=clang++
 endif
 ifndef CPU_ONLY
-    CXXFLAGS             :=-std=c++11 -Wall -Wextra -DNVCC=\"$(NVCC)\"
+    override CXXFLAGS             +=-std=c++11 -Wall -Wextra -DNVCC=\"$(NVCC)\"
 else
-    CXXFLAGS             :=-std=c++11 -Wall -Wextra -DCPU_ONLY
+    override CXXFLAGS             +=-std=c++11 -Wall -Wextra -DCPU_ONLY
 endif
 ifdef DEBUG
-    CXXFLAGS             +=-g -O0 -DDEBUG
+    override CXXFLAGS             +=-g -O0 -DDEBUG
 endif
 
 ARFLAGS                  :=-rcs
 
 # Global include and link flags
 ifndef CPU_ONLY
-    INCLUDE_FLAGS        :=-I"$(INC_PATH)" -I"$(CUDA_PATH)/include"
+    override INCLUDE_FLAGS        +=-I"$(INC_PATH)" -I"$(CUDA_PATH)/include"
     ifeq ($(DARWIN),DARWIN)
-        LINK_FLAGS       :=-rpath $(CUDA_PATH)/lib -L"$(LIBGENN_PATH)" -L"$(CUDA_PATH)/lib" -lgenn -lcuda -lcudart -lstdc++ -lc++
+        override LINK_FLAGS       +=-rpath $(CUDA_PATH)/lib -L"$(LIBGENN_PATH)" -L"$(CUDA_PATH)/lib" -lgenn -lcuda -lcudart -lstdc++ -lc++
     else
         ifeq ($(OS_SIZE),32)
-            LINK_FLAGS   :=-L"$(LIBGENN_PATH)" -L"$(CUDA_PATH)/lib" -lgenn -lcuda -lcudart
+            override LINK_FLAGS   +=-L"$(LIBGENN_PATH)" -L"$(CUDA_PATH)/lib" -lgenn -lcuda -lcudart
         else
-            LINK_FLAGS   :=-L"$(LIBGENN_PATH)" -L"$(CUDA_PATH)/lib64" -lgenn -lcuda -lcudart
+            override LINK_FLAGS   +=-L"$(LIBGENN_PATH)" -L"$(CUDA_PATH)/lib64" -lgenn -lcuda -lcudart
         endif
     endif
 else
-    INCLUDE_FLAGS        :=-I"$(INC_PATH)"
-    LINK_FLAGS           :=-L"$(LIBGENN_PATH)" -lgenn_CPU_ONLY
+    override INCLUDE_FLAGS        +=-I"$(INC_PATH)"
+    override LINK_FLAGS           +=-L"$(LIBGENN_PATH)" -lgenn_CPU_ONLY
     ifeq ($(DARWIN),DARWIN)
-        LINK_FLAGS       :=-L"$(LIBGENN_PATH)" -lgenn_CPU_ONLY -lstdc++ -lc++
+        override LINK_FLAGS       +=-L"$(LIBGENN_PATH)" -lgenn_CPU_ONLY -lstdc++ -lc++
     endif
 endif
 
 ifdef COVERAGE
-    CXXFLAGS             +=-O0 --coverage
-    LINK_FLAGS           +=--coverage
+    override CXXFLAGS             +=-O0 --coverage
+    override LINK_FLAGS           +=--coverage
 endif
 
 # Target rules

--- a/lib/GNUmakefile
+++ b/lib/GNUmakefile
@@ -65,6 +65,10 @@ endif
 
 ARFLAGS                  :=-rcs
 
+# BUILD_MODEL_INCLUDE contains a colon-seperated list of additional include paths.
+# substitute :s for spaces and then prepend each path with -I so it gets turned into an include directory
+INCLUDE_FLAGS            +=$(patsubst %,-I%,$(subst :, ,$(BUILD_MODEL_INCLUDE)))
+
 # Global include and link flags
 ifndef CPU_ONLY
     INCLUDE_FLAGS        +=-I"$(INC_PATH)" -I"$(CUDA_PATH)/include"

--- a/lib/GNUmakefile
+++ b/lib/GNUmakefile
@@ -55,39 +55,39 @@ ifeq ($(DARWIN),DARWIN)
     CXX                  :=clang++
 endif
 ifndef CPU_ONLY
-    override CXXFLAGS             +=-std=c++11 -Wall -Wextra -DNVCC=\"$(NVCC)\"
+    CXXFLAGS             :=-std=c++11 -Wall -Wextra -DNVCC=\"$(NVCC)\"
 else
-    override CXXFLAGS             +=-std=c++11 -Wall -Wextra -DCPU_ONLY
+    CXXFLAGS             :=-std=c++11 -Wall -Wextra -DCPU_ONLY
 endif
 ifdef DEBUG
-    override CXXFLAGS             +=-g -O0 -DDEBUG
+    CXXFLAGS             +=-g -O0 -DDEBUG
 endif
 
 ARFLAGS                  :=-rcs
 
 # Global include and link flags
 ifndef CPU_ONLY
-    override INCLUDE_FLAGS        +=-I"$(INC_PATH)" -I"$(CUDA_PATH)/include"
+    INCLUDE_FLAGS        :=-I"$(INC_PATH)" -I"$(CUDA_PATH)/include"
     ifeq ($(DARWIN),DARWIN)
-        override LINK_FLAGS       +=-rpath $(CUDA_PATH)/lib -L"$(LIBGENN_PATH)" -L"$(CUDA_PATH)/lib" -lgenn -lcuda -lcudart -lstdc++ -lc++
+        LINK_FLAGS       :=-rpath $(CUDA_PATH)/lib -L"$(LIBGENN_PATH)" -L"$(CUDA_PATH)/lib" -lgenn -lcuda -lcudart -lstdc++ -lc++
     else
         ifeq ($(OS_SIZE),32)
-            override LINK_FLAGS   +=-L"$(LIBGENN_PATH)" -L"$(CUDA_PATH)/lib" -lgenn -lcuda -lcudart
+            LINK_FLAGS   :=-L"$(LIBGENN_PATH)" -L"$(CUDA_PATH)/lib" -lgenn -lcuda -lcudart
         else
-            override LINK_FLAGS   +=-L"$(LIBGENN_PATH)" -L"$(CUDA_PATH)/lib64" -lgenn -lcuda -lcudart
+            LINK_FLAGS   :=-L"$(LIBGENN_PATH)" -L"$(CUDA_PATH)/lib64" -lgenn -lcuda -lcudart
         endif
     endif
 else
-    override INCLUDE_FLAGS        +=-I"$(INC_PATH)"
-    override LINK_FLAGS           +=-L"$(LIBGENN_PATH)" -lgenn_CPU_ONLY
+    INCLUDE_FLAGS        :=-I"$(INC_PATH)"
+    LINK_FLAGS           :=-L"$(LIBGENN_PATH)" -lgenn_CPU_ONLY
     ifeq ($(DARWIN),DARWIN)
-        override LINK_FLAGS       +=-L"$(LIBGENN_PATH)" -lgenn_CPU_ONLY -lstdc++ -lc++
+        LINK_FLAGS       :=-L"$(LIBGENN_PATH)" -lgenn_CPU_ONLY -lstdc++ -lc++
     endif
 endif
 
 ifdef COVERAGE
-    override CXXFLAGS             +=-O0 --coverage
-    override LINK_FLAGS           +=--coverage
+    CXXFLAGS             +=-O0 --coverage
+    LINK_FLAGS           +=--coverage
 endif
 
 # Target rules

--- a/lib/bin/genn-buildmodel.bat
+++ b/lib/bin/genn-buildmodel.bat
@@ -6,11 +6,11 @@ goto :genn_begin
 rem :: display genn-buildmodel.bat help
 echo genn-buildmodel.bat script usage:
 echo genn-buildmodel.bat [cdho] model
-echo -c            only generate simulation code for the CPU
-echo -d            enables the debugging mode
-echo -h            shows this help message
-echo -o outpath    changes the output directory
-echo -i include    add additional include directories (seperated by semicolons)
+echo -c             only generate simulation code for the CPU
+echo -d             enables the debugging mode
+echo -h             shows this help message
+echo -o outpath     changes the output directory
+echo -i includepath add additional include directories (seperated by semicolons)
 goto :eof
 
 :genn_begin

--- a/lib/bin/genn-buildmodel.bat
+++ b/lib/bin/genn-buildmodel.bat
@@ -10,6 +10,7 @@ echo -c            only generate simulation code for the CPU
 echo -d            enables the debugging mode
 echo -h            shows this help message
 echo -o outpath    changes the output directory
+echo -i include    add additional include directories (seperated by semicolons)
 goto :eof
 
 :genn_begin
@@ -17,7 +18,7 @@ rem :: define genn-buildmodel.bat options separated by spaces
 rem :: -<option>:              option
 rem :: -<option>:""            option with argument
 rem :: -<option>:"<default>"   option with argument and default value
-set "OPTIONS=-o:"%CD%" -d: -c: -h:"
+set "OPTIONS=-o:"%CD%" -i:"" -d: -c: -h:"
 for %%O in (%OPTIONS%) do for /f "tokens=1,* delims=:" %%A in ("%%O") do set "%%A=%%~B"
 
 :genn_option
@@ -55,7 +56,8 @@ if not defined MODEL (
     goto :eof
 )
 for /f %%I in ("%-o%") do set "-o=%%~fI"
-for /f %%I in ("%MODEL%") do set "MACROS=/p:ModelFile=%%~fI /p:GeneratePath=%-o%"
+for /f %%I in ("%-i%") do set "-i=%%~fI"
+for /f %%I in ("%MODEL%") do set "MACROS=/p:ModelFile=%%~fI /p:GeneratePath=%-o% /p:BuildModelInclude=%-i%"
 
 if defined -d (
 	if defined -c (

--- a/lib/bin/genn-buildmodel.sh
+++ b/lib/bin/genn-buildmodel.sh
@@ -9,6 +9,7 @@ genn_help () {
     echo "-v            generates coverage information"
     echo "-h            shows this help message"
     echo "-o outpath    changes the output directory"
+    echo "-i flags      prepend compiler options with flags"
 }
 
 # handle script errors
@@ -20,14 +21,16 @@ trap 'genn_error $LINENO 50 "command failure"' ERR
 
 # parse command options
 OUT_PATH="$PWD";
+INCLUDE_FLAGS=""
 while [[ -n "${!OPTIND}" ]]; do
-    while getopts "cdvo:h" option; do
+    while getopts "cdvo:i:h" option; do
     case $option in
         c) CPU_ONLY=1;;
         d) DEBUG=1;;
         v) COVERAGE=1;;
         h) genn_help; exit;;
         o) OUT_PATH="$OPTARG";;
+        i) INCLUDE_FLAGS="$OPTARG";;
         ?) genn_help; exit;;
     esac
     done
@@ -59,7 +62,7 @@ pushd $OUT_PATH > /dev/null
 OUT_PATH="$PWD"
 popd > /dev/null
 pushd $(dirname $MODEL) > /dev/null
-MACROS="MODEL=$PWD/$(basename $MODEL) GENERATEALL_PATH=$OUT_PATH"
+MACROS="MODEL=$PWD/$(basename $MODEL) GENERATEALL_PATH=$OUT_PATH INCLUDE_FLAGS=$INCLUDE_FLAGS"
 popd > /dev/null
 if [[ -n "$DEBUG" ]]; then
     MACROS="$MACROS DEBUG=1";

--- a/lib/bin/genn-buildmodel.sh
+++ b/lib/bin/genn-buildmodel.sh
@@ -4,12 +4,12 @@
 genn_help () {
     echo "genn-buildmodel.sh script usage:"
     echo "genn-buildmodel.sh [cdho] model"
-    echo "-c            only generate simulation code for the CPU"
-    echo "-d            enables the debugging mode"
-    echo "-v            generates coverage information"
-    echo "-h            shows this help message"
-    echo "-o outpath    changes the output directory"
-    echo "-i flags      prepend compiler options with flags"
+    echo "-c                only generate simulation code for the CPU"
+    echo "-d                enables the debugging mode"
+    echo "-v                generates coverage information"
+    echo "-h                shows this help message"
+    echo "-o outpath        changes the output directory"
+    echo "-i includepath    add additional include directories (seperated by semicolons)"
 }
 
 # handle script errors
@@ -21,7 +21,7 @@ trap 'genn_error $LINENO 50 "command failure"' ERR
 
 # parse command options
 OUT_PATH="$PWD";
-INCLUDE_FLAGS=""
+BUILD_MODEL_INCLUDE=""
 while [[ -n "${!OPTIND}" ]]; do
     while getopts "cdvo:i:h" option; do
     case $option in
@@ -30,7 +30,7 @@ while [[ -n "${!OPTIND}" ]]; do
         v) COVERAGE=1;;
         h) genn_help; exit;;
         o) OUT_PATH="$OPTARG";;
-        i) INCLUDE_FLAGS="$OPTARG";;
+        i) BUILD_MODEL_INCLUDE="$OPTARG";;
         ?) genn_help; exit;;
     esac
     done
@@ -62,7 +62,7 @@ pushd $OUT_PATH > /dev/null
 OUT_PATH="$PWD"
 popd > /dev/null
 pushd $(dirname $MODEL) > /dev/null
-MACROS="MODEL=$PWD/$(basename $MODEL) GENERATEALL_PATH=$OUT_PATH INCLUDE_FLAGS=$INCLUDE_FLAGS"
+MACROS="MODEL=$PWD/$(basename $MODEL) GENERATEALL_PATH=$OUT_PATH BUILD_MODEL_INCLUDE=$BUILD_MODEL_INCLUDE"
 popd > /dev/null
 if [[ -n "$DEBUG" ]]; then
     MACROS="$MACROS DEBUG=1";

--- a/lib/bin/genn-buildmodel.sh
+++ b/lib/bin/genn-buildmodel.sh
@@ -9,7 +9,7 @@ genn_help () {
     echo "-v                generates coverage information"
     echo "-h                shows this help message"
     echo "-o outpath        changes the output directory"
-    echo "-i includepath    add additional include directories (seperated by semicolons)"
+    echo "-i includepath    add additional include directories (seperated by colons)"
 }
 
 # handle script errors

--- a/lib/generate.vcxproj
+++ b/lib/generate.vcxproj
@@ -40,8 +40,9 @@
   <!-- Customise C++  compilation and linking tasks -->
   <ItemDefinitionGroup>
     <ClCompile>
-      <AdditionalIncludeDirectories Condition=" $(Configuration.Contains('CPU_ONLY')) ">include</AdditionalIncludeDirectories>
-      <AdditionalIncludeDirectories Condition=" !$(Configuration.Contains('CPU_ONLY')) ">include;$(CUDA_PATH)\include</AdditionalIncludeDirectories>
+      <!-- Set additional include directories **NOTE** these can be modified from command line using the BuildModelInclude property -->
+      <AdditionalIncludeDirectories Condition=" $(Configuration.Contains('CPU_ONLY')) ">$(BuildModelInclude);include</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories Condition=" !$(Configuration.Contains('CPU_ONLY')) ">$(BuildModelInclude);include;$(CUDA_PATH)\include</AdditionalIncludeDirectories>
       <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
       <DebugInformationFormat Condition=" $(Configuration.Contains('Debug')) ">ProgramDatabase</DebugInformationFormat>
       <Optimization Condition=" $(Configuration.Contains('Debug')) ">Disabled</Optimization>


### PR DESCRIPTION
Changes in master to use += to append to ``CXXFLAGS`` etc in GNUmakefile didn't SEEM to work from command line without ``override`` directive - am I being stupid @tnowotny or was this intended for another purpose?