### PR TITLE
Code substitution fix ``a*a``

### DIFF
--- a/spineml/generator/modelCommon.cc
+++ b/spineml/generator/modelCommon.cc
@@ -183,10 +183,12 @@ void SpineMLGenerator::replaceVariableNames(std::string &code, const std::string
 {
     // Build a regex to match variable name with at least one
     // character that can't be in a variable name on either side (or an end/beginning of string)
-    std::regex regex("(^|[^a-zA-Z_])" + variableName + "($|[^a-zA-Z_])");
+    // **NOTE** the suffix is non-capturing so two instances of variables separated by a single character are matched e.g. a*a
+    std::regex regex("(^|[^a-zA-Z_])" + variableName + "(?=$|[^a-zA-Z_])");
 
     // Replace variable within code string
-    code = std::regex_replace(code, regex, "$1" + replaceText + "$2");
+    // **NOTE** preceding character is captured as C++ regex doesn't support lookbehind so this needs to be replaced in
+    code = std::regex_replace(code, regex, "$1" + replaceText);
 }
 //----------------------------------------------------------------------------
 void SpineMLGenerator::wrapAndReplaceVariableNames(std::string &code, const std::string &variableName,


### PR DESCRIPTION
So we use regular expressions to wrap variables in GeNN's ``$(XXX)`` markers using ``std::regex_replace``. Variables are delimited by  a beginning or end of line; or any characters that isn't alphabetical or an underscore so we were matching for this on either side of the variable name. 

However these matches were **consuming** characters so, if only one character separated two references to the same variable name, the second one wasn't getting matched as the first delimited character had already been consumed. The solution to this is to make one of the groups that matches the delimiters non-capturing so the characters get matched but not consumed. C++ doesn't support _lookbehind_ (prefix) non-capturing groups so this needs to the _lookahead_ (suffix).