### PR TITLE
Sanity fix

### DIFF
--- a/lib/src/generateCPU.cc
+++ b/lib/src/generateCPU.cc
@@ -49,8 +49,6 @@ void generate_process_presynaptic_events_code_CPU(
     const string &ftype)
 {
     bool evnt = postfix == "Evnt";
-    int UIntSz = sizeof(unsigned int) * 8;
-    int logUIntSz = (int) (logf((float) UIntSz) / logf(2.0f) + 1e-5f);
 
     if ((evnt && sg.isSpikeEventRequired()) || (!evnt && sg.isTrueSpikeRequired())) {
         const auto *wu = sg.getWUModel();
@@ -92,7 +90,7 @@ void generate_process_presynaptic_events_code_CPU(
         if (evnt) {
             os << "if ";
             if (sg.getMatrixType() & SynapseMatrixConnectivity::BITMASK) {
-                os << "((B(gp" << sgName << "[gid >> " << logUIntSz << "], gid & " << UIntSz - 1 << ")) && ";
+                os << "((B(gp" << sgName << "[gid / 32], gid & 31)) && ";
             }
 
             // code substitutions ----
@@ -113,7 +111,7 @@ void generate_process_presynaptic_events_code_CPU(
             os << CodeStream::OB(2041);
         }
         else if (sg.getMatrixType() & SynapseMatrixConnectivity::BITMASK) {
-            os << "if (B(gp" << sgName << "[gid >> " << logUIntSz << "], gid & " << UIntSz - 1 << "))" << CodeStream::OB(2041);
+            os << "if (B(gp" << sgName << "[gid / 32], gid & 31))" << CodeStream::OB(2041);
         }
 
         // Code substitutions ----------------------------------------------------------------------------------
@@ -146,7 +144,7 @@ void generate_process_presynaptic_events_code_CPU(
             os << CodeStream::CB(2041); // end if (eCode)
         }
         else if (sg.getMatrixType() & SynapseMatrixConnectivity::BITMASK) {
-            os << CodeStream::CB(2041); // end if (B(gp" << sgName << "[gid >> " << logUIntSz << "], gid
+            os << CodeStream::CB(2041); // end if (B(gp" << sgName << "[gid / 32], gid
         }
         os << CodeStream::CB(202);
         os << CodeStream::CB(201);

--- a/lib/src/generateKernels.cc
+++ b/lib/src/generateKernels.cc
@@ -105,7 +105,7 @@ a max possible number of connections via the model.setMaxConn() function.\n");
         os << "if ";
         if (sg.getMatrixType() & SynapseMatrixConnectivity::BITMASK) {
             // Note: we will just access global mem. For compute >= 1.2 simultaneous access to same global mem in the (half-)warp will be coalesced - no worries
-            os << "((B(dd_gp" << sg.getName() << "[gid / 32], gid & 31")) && ";
+            os << "((B(dd_gp" << sg.getName() << "[gid / 32], gid & 31)) && ";
         }
 
         // code substitutions ----

--- a/lib/src/generateKernels.cc
+++ b/lib/src/generateKernels.cc
@@ -59,8 +59,6 @@ void generatePreParallelisedSparseCode(
     const string &ftype)
 {
     const bool evnt = (postfix == "Evnt");
-    const int UIntSz = sizeof(unsigned int) * 8;
-    const int logUIntSz = (int) (logf((float) UIntSz) / logf(2.0f) + 1e-5f);
     const auto *wu = sg.getWUModel();
 
     // Create iteration context to iterate over the variables; derived and extra global parameters
@@ -107,7 +105,7 @@ a max possible number of connections via the model.setMaxConn() function.\n");
         os << "if ";
         if (sg.getMatrixType() & SynapseMatrixConnectivity::BITMASK) {
             // Note: we will just access global mem. For compute >= 1.2 simultaneous access to same global mem in the (half-)warp will be coalesced - no worries
-            os << "((B(dd_gp" << sg.getName() << "[gid >> " << logUIntSz << "], gid & " << UIntSz - 1 << ")) && ";
+            os << "((B(dd_gp" << sg.getName() << "[gid / 32], gid & 31")) && ";
         }
 
         // code substitutions ----
@@ -124,7 +122,7 @@ a max possible number of connections via the model.setMaxConn() function.\n");
         os << CodeStream::OB(130);
     }
     else if (sg.getMatrixType() & SynapseMatrixConnectivity::BITMASK) {
-        os << "if (B(dd_gp" << sg.getName() << "[gid >> " << logUIntSz << "], gid & " << UIntSz - 1 << "))" << CodeStream::OB(135);
+        os << "if (B(dd_gp" << sg.getName() << "[gid / 32], gid & 31))" << CodeStream::OB(135);
     }
 
     os << "for (int i = 0; i < npost; ++i)" << CodeStream::OB(103);
@@ -175,8 +173,6 @@ void generatePostParallelisedCode(
     const string &ftype)
 {
     const bool evnt = (postfix == "Evnt");
-    const int UIntSz = sizeof(unsigned int) * 8;
-    const int logUIntSz = (int) (logf((float) UIntSz) / logf(2.0f) + 1e-5f);
     const auto *wu = sg.getWUModel();
 
     // Create iteration context to iterate over the variables; derived and extra global parameters
@@ -228,7 +224,7 @@ a max possible number of connections via the model.setMaxConn() function.\n");
         os << "if ";
         if (sg.getMatrixType() & SynapseMatrixConnectivity::BITMASK) {
             // Note: we will just access global mem. For compute >= 1.2 simultaneous access to same global mem in the (half-)warp will be coalesced - no worries
-            os << "((B(dd_gp" << sg.getName() << "[gid >> " << logUIntSz << "], gid & " << UIntSz - 1 << ")) && ";
+            os << "((B(dd_gp" << sg.getName() << "[gid / 32], gid & 31)) && ";
         }
 
         // code substitutions ----
@@ -245,7 +241,7 @@ a max possible number of connections via the model.setMaxConn() function.\n");
         os << CodeStream::OB(130);
     }
     else if (sg.getMatrixType() & SynapseMatrixConnectivity::BITMASK) {
-        os << "if (B(dd_gp" << sg.getName() << "[gid >> " << logUIntSz << "], gid & " << UIntSz - 1 << "))" << CodeStream::OB(135);
+        os << "if (B(dd_gp" << sg.getName() << "[gid / 32], gid & 31))" << CodeStream::OB(135);
     }
 
     if (sg.getMatrixType() & SynapseMatrixConnectivity::SPARSE) { // SPARSE
@@ -299,7 +295,7 @@ a max possible number of connections via the model.setMaxConn() function.\n");
         os << CodeStream::CB(130); // end if (eCode)
     }
     else if (sg.getMatrixType() & SynapseMatrixConnectivity::BITMASK) {
-        os << CodeStream::CB(135); // end if (B(dd_gp" << sg.getName() << "[gid >> " << logUIntSz << "], gid
+        os << CodeStream::CB(135); // end if (B(dd_gp" << sg.getName() << "[gid / 32], gid
     }
     os << CodeStream::CB(120) << std::endl;
 


### PR DESCRIPTION
I saw this when I was trying to do some stuff with bitmask connectivity and, while the origins of this code are lost in the mists of time beyond the reach of even git blame, you copied it around so you get this PR :)
```cpp
int UIntSz = sizeof(unsigned int) * 8;
int logUIntSz = (int) (logf((float) UIntSz) / logf(2.0f) + 1e-5f);
```
HOWEVER:
1. These values are used exclusively for indexing connectivity bitmasks which don't use ``unsigned int`` at all, but ``uint32_t``. Therefore ``UIntSz`` **should** be 32 by definition whereas ``unsigned int``doesn't actually have a guaranteed size (although I think we'd be very unlucky to locate a device that can run GeNN but has non-32-bit integers...)
2. Any compiler will replace ``gid / 32`` with the appropriate shift operation and it saves the floating point log-horror (C++ does also provide ``log2``!)