### PR TITLE
GlobalG, Individual PSM

### DIFF
--- a/lib/include/synapseMatrixType.h
+++ b/lib/include/synapseMatrixType.h
@@ -14,18 +14,22 @@ enum class SynapseMatrixConnectivity : unsigned int
 //!< Flags defining different types of synaptic matrix connectivity
 enum class SynapseMatrixWeight : unsigned int
 {
-    GLOBAL      = (1 << 3),
-    INDIVIDUAL  = (1 << 4),
+    GLOBAL          = (1 << 3),
+    INDIVIDUAL      = (1 << 4),
+    INDIVIDUAL_PSM  = (1 << 5),
 };
 
 //!< Supported combinations of SynapticMatrixConnectivity and SynapticMatrixWeight
 enum class SynapseMatrixType : unsigned int
 {
-    SPARSE_GLOBALG       = static_cast<unsigned int>(SynapseMatrixConnectivity::SPARSE) | static_cast<unsigned int>(SynapseMatrixWeight::GLOBAL),
-    SPARSE_INDIVIDUALG   = static_cast<unsigned int>(SynapseMatrixConnectivity::SPARSE) | static_cast<unsigned int>(SynapseMatrixWeight::INDIVIDUAL),
-    DENSE_GLOBALG        = static_cast<unsigned int>(SynapseMatrixConnectivity::DENSE) | static_cast<unsigned int>(SynapseMatrixWeight::GLOBAL),
-    DENSE_INDIVIDUALG    = static_cast<unsigned int>(SynapseMatrixConnectivity::DENSE) | static_cast<unsigned int>(SynapseMatrixWeight::INDIVIDUAL),
-    BITMASK_GLOBALG      = static_cast<unsigned int>(SynapseMatrixConnectivity::BITMASK) | static_cast<unsigned int>(SynapseMatrixWeight::GLOBAL),
+    SPARSE_GLOBALG                  = static_cast<unsigned int>(SynapseMatrixConnectivity::SPARSE) | static_cast<unsigned int>(SynapseMatrixWeight::GLOBAL),
+    SPARSE_GLOBALG_INDIVIDUAL_PSM   = static_cast<unsigned int>(SynapseMatrixConnectivity::SPARSE) | static_cast<unsigned int>(SynapseMatrixWeight::GLOBAL) | static_cast<unsigned int>(SynapseMatrixWeight::INDIVIDUAL_PSM),
+    SPARSE_INDIVIDUALG              = static_cast<unsigned int>(SynapseMatrixConnectivity::SPARSE) | static_cast<unsigned int>(SynapseMatrixWeight::INDIVIDUAL) | static_cast<unsigned int>(SynapseMatrixWeight::INDIVIDUAL_PSM),
+    DENSE_GLOBALG                   = static_cast<unsigned int>(SynapseMatrixConnectivity::DENSE) | static_cast<unsigned int>(SynapseMatrixWeight::GLOBAL),
+    DENSE_GLOBALG_INDIVIDUAL_PSM    = static_cast<unsigned int>(SynapseMatrixConnectivity::DENSE) | static_cast<unsigned int>(SynapseMatrixWeight::GLOBAL) | static_cast<unsigned int>(SynapseMatrixWeight::INDIVIDUAL_PSM),
+    DENSE_INDIVIDUALG               = static_cast<unsigned int>(SynapseMatrixConnectivity::DENSE) | static_cast<unsigned int>(SynapseMatrixWeight::INDIVIDUAL) | static_cast<unsigned int>(SynapseMatrixWeight::INDIVIDUAL_PSM),
+    BITMASK_GLOBALG                 = static_cast<unsigned int>(SynapseMatrixConnectivity::BITMASK) | static_cast<unsigned int>(SynapseMatrixWeight::GLOBAL),
+    BITMASK_GLOBALG_INDIVIDUAL_PSM  = static_cast<unsigned int>(SynapseMatrixConnectivity::BITMASK) | static_cast<unsigned int>(SynapseMatrixWeight::GLOBAL) | static_cast<unsigned int>(SynapseMatrixWeight::INDIVIDUAL_PSM),
 };
 
 //----------------------------------------------------------------------------

--- a/lib/src/generateCPU.cc
+++ b/lib/src/generateCPU.cc
@@ -254,7 +254,7 @@ void genNeuronFunction(const NNmodel &model, //!< Model description
                     for(const auto *sg : n.second.getInSyn()) {
                         const auto *psm = sg->getPSModel();
 
-                        if (sg->getMatrixType() & SynapseMatrixWeight::INDIVIDUAL) {
+                        if (sg->getMatrixType() & SynapseMatrixWeight::INDIVIDUAL_PSM) {
                             for(const auto &v : psm->getVars()) {
                                 os << v.second << " lps" << v.first << sg->getName();
                                 os << " = " <<  v.first << sg->getName() << "[n];" << std::endl;

--- a/lib/src/generateInit.cc
+++ b/lib/src/generateInit.cc
@@ -344,18 +344,16 @@ unsigned int genInitializeDeviceKernel(CodeStream &os, const NNmodel &model, int
 
                             // If matrix has individual state variables
                             // **THINK** should this REALLY also apply to postsynaptic models
-                            if(s->getMatrixType() & SynapseMatrixWeight::INDIVIDUAL) {
-                                auto psmVars = s->getPSModel()->getVars();
-                                for(size_t j = 0; j < psmVars.size(); j++) {
-                                    const auto &varInit = s->getPSVarInitialisers()[j];
-                                    const VarMode varMode = s->getPSVarMode(j);
+                            auto psmVars = s->getPSModel()->getVars();
+                            for(size_t j = 0; j < psmVars.size(); j++) {
+                                const auto &varInit = s->getPSVarInitialisers()[j];
+                                const VarMode varMode = s->getPSVarMode(j);
 
-                                    // Initialise directly into device variable
-                                    if((varMode & VarInit::DEVICE) && !varInit.getSnippet()->getCode().empty()) {
-                                        CodeStream::Scope b(os);
-                                        os << StandardSubstitutions::initVariable(varInit, "dd_" + psmVars[j].first + s->getName() + "[lid]",
-                                                                                cudaFunctions, model.getPrecision(), "&initRNG") << std::endl;
-                                    }
+                                // Initialise directly into device variable
+                                if((varMode & VarInit::DEVICE) && !varInit.getSnippet()->getCode().empty()) {
+                                    CodeStream::Scope b(os);
+                                    os << StandardSubstitutions::initVariable(varInit, "dd_" + psmVars[j].first + s->getName() + "[lid]",
+                                                                            cudaFunctions, model.getPrecision(), "&initRNG") << std::endl;
                                 }
                             }
                         }
@@ -744,9 +742,8 @@ void genInit(const NNmodel &model,      //!< Model description
                 }
             }
 
-            // If matrix has individual state variables
-            // **THINK** should this REALLY also apply to postsynaptic models
-            if (s.second.getMatrixType() & SynapseMatrixWeight::INDIVIDUAL) {
+            // If matrix has individual postsynaptic variables
+            if (s.second.getMatrixType() & SynapseMatrixWeight::INDIVIDUAL_PSM) {
                 auto psmVars = psm->getVars();
                 for (size_t k= 0, l= psmVars.size(); k < l; k++) {
                     const auto &varInit = s.second.getPSVarInitialisers()[k];

--- a/lib/src/generateKernels.cc
+++ b/lib/src/generateKernels.cc
@@ -535,7 +535,7 @@ void genNeuronKernel(const NNmodel &model, //!< Model description
 
                     os << "// pull inSyn values in a coalesced access" << std::endl;
                     os << model.getPrecision() << " linSyn" << sg->getName() << " = dd_inSyn" << sg->getName() << "[" << localID << "];" << std::endl;
-                    if (sg->getMatrixType() & SynapseMatrixWeight::INDIVIDUAL) {
+                    if (sg->getMatrixType() & SynapseMatrixWeight::INDIVIDUAL_PSM) {
                         for(const auto &v : psm->getVars()) {
                             os << v.second << " lps" << v.first << sg->getName();
                             os << " = dd_" <<  v.first << sg->getName() << "[" << localID << "];" << std::endl;

--- a/lib/src/standardSubstitutions.cc
+++ b/lib/src/standardSubstitutions.cc
@@ -30,7 +30,7 @@ void StandardSubstitutions::postSynapseApplyInput(
     value_substitutions(psCode, ng.getNeuronModel()->getParamNames(), ng.getParams());
     value_substitutions(psCode, nmDerivedParams.nameBegin, nmDerivedParams.nameEnd, ng.getDerivedParams());
 
-    if (sg->getMatrixType() & SynapseMatrixWeight::INDIVIDUAL) {
+    if (sg->getMatrixType() & SynapseMatrixWeight::INDIVIDUAL_PSM) {
         name_substitutions(psCode, "lps", psmVars.nameBegin, psmVars.nameEnd, sg->getName());
     }
     else {

--- a/lib/src/synapseGroup.cc
+++ b/lib/src/synapseGroup.cc
@@ -313,7 +313,7 @@ bool SynapseGroup::isPSDeviceVarInitRequired() const
 {
     // If this synapse group has per-synapse state variables,
     // return true if any of the postsynapse variables are initialised on the device
-    if (getMatrixType() & SynapseMatrixWeight::INDIVIDUAL) {
+    if (getMatrixType() & SynapseMatrixWeight::INDIVIDUAL_PSM) {
         return std::any_of(m_PSVarMode.cbegin(), m_PSVarMode.cend(),
                         [](const VarMode mode){ return (mode & VarInit::DEVICE); });
     }

--- a/spineml/generator/main.cc
+++ b/spineml/generator/main.cc
@@ -469,9 +469,6 @@ int main(int argc, char *argv[])
                     const auto &weightUpdateModel = getCreateModel(weightUpdateModelParams, weightUpdateModels,
                                                                    neuronModel, trgNeuronModel);
 
-                    // Global weight value can be used if there are no state variables
-                    const bool globalG = weightUpdateModel.getVars().empty();
-
                     // Get post synapse
                     auto postSynapse = synapse.child("LL:PostSynapse");
                     if(!postSynapse) {
@@ -496,6 +493,10 @@ int main(int argc, char *argv[])
                     // Either get existing postsynaptic model or create new one of no suitable models are available
                     const auto &postsynapticModel = getCreateModel(postsynapticModelParams, postsynapticModels,
                                                                    trgNeuronModel, &weightUpdateModel);
+
+                    // Global weight value can be used if there are no state variables
+                    // **TODO** seperate individualness for PSM and WUM should be used here
+                    const bool globalG = weightUpdateModel.getVars().empty() && postsynapticModel.getVars().empty();
 
                     // Determine the GeNN matrix type and number of delay steps
                     SynapseMatrixType mtype;


### PR DESCRIPTION
Basically, when building networks where the postsynaptic models have additional state variables e.g. [alpha synapses](https://github.com/BrainsOnBoard/GeNN_Robotics/blob/ragged_matrix/common/alpha_curr.h), you might well want your weights to be GLOBAL but not the post synaptic variables.

This PR adds an additional flag (``SynapseMatrixWeight::INDIVIDUAL_PSM``) which can be combined with ``SynapseMatrixWeight::GLOBAL`` to achieve this. The user specifies this using one of the following new matrix modes:

- SPARSE_GLOBALG_INDIVIDUAL_PSM
- DENSE_GLOBALG_INDIVIDUAL_PSM
- BITMASK_GLOBALG_INDIVIDUAL_PSM
