### PR TITLE
Fix sparse synapse pre parallelism and shared memory usage

### DIFF
--- a/lib/include/synapseGroup.h
+++ b/lib/include/synapseGroup.h
@@ -139,10 +139,6 @@ public:
     //! Get variable mode used by postsynaptic model state variable
     VarMode getPSVarMode(size_t index) const{ return m_PSVarMode[index]; }
 
-    //! Is this synapse group too large to use shared memory for combining postsynaptic output
-    // **THINK** this is very cuda-specific
-    bool isPSAtomicAddRequired(unsigned int blockSize) const;
-
     void addExtraGlobalNeuronParams(std::map<string, string> &kernelParameters) const;
     void addExtraGlobalSynapseParams(std::map<string, string> &kernelParameters) const;
     void addExtraGlobalPostLearnParams(std::map<string, string> &kernelParameters) const;

--- a/lib/src/generateKernels.cc
+++ b/lib/src/generateKernels.cc
@@ -128,11 +128,14 @@ void generatePreParallelisedSparseCode(
             string wCode = evnt ? wu->getEventCode() : wu->getSimCode();
             substitute(wCode, "$(t)", "t");
 
-            if (sg.isPSAtomicAddRequired(synapseBlkSz)) { // SPARSE using atomicAdd
+            // If postsynaptic input should be accumulated directly in global memory
+            if (sg.isPSAtomicAddRequired(synapseBlkSz)) {
                 substitute(wCode, "$(updatelinsyn)", getFloatAtomicAdd(ftype) + "(&$(inSyn), $(addtoinSyn))");
                 substitute(wCode, "$(inSyn)", "dd_inSyn" + sg.getName() + "[ipost]");
             }
-            else { // using shared memory
+            // Otherwise, if it should be accumulated in shared memory
+            // **THINK** should this actually be using shared memory atomics here?
+            else {
                 substitute(wCode, "$(updatelinsyn)", "$(inSyn) += $(addtoinSyn)");
                 substitute(wCode, "$(inSyn)", "shLg[ipost]");
             }

--- a/lib/src/generateKernels.cc
+++ b/lib/src/generateKernels.cc
@@ -66,13 +66,6 @@ void generatePreParallelisedSparseCode(
     ExtraGlobalParamNameIterCtx wuExtraGlobalParams(wu->getExtraGlobalParams());
     VarNameIterCtx wuVars(wu->getVars());
 
-    //int maxConnections;
-    if (sg.isPSAtomicAddRequired(synapseBlkSz)) {
-        if (sg.getMaxConnections() < 1) {
-            fprintf(stderr, "Model Generation warning: for every SPARSE synapse group used you must also supply (in your model) a max possible number of connections via the model.setMaxConn() function.\n");
-        }
-    }
-
     os << "if (" << localID << " < " ;
     if (sg.getSrcNeuronGroup()->isDelayRequired()) {
         os << "dd_glbSpkCnt" << postfix << sg.getSrcNeuronGroup()->getName() << "[delaySlot])";
@@ -202,19 +195,6 @@ void generatePostParallelisedCode(
         }
         os << "__syncthreads();" << std::endl;
 
-        int maxConnections;
-        if ((sg.getMatrixType() & SynapseMatrixConnectivity::SPARSE) && sg.isPSAtomicAddRequired(synapseBlkSz)) {
-            if (sg.getMaxConnections() < 1) {
-                fprintf(stderr, "Model Generation warning: for every SPARSE synapse group used you must also supply (in your model) a max possible number of connections via the model.setMaxConn() function.\n");
-                maxConnections = sg.getTrgNeuronGroup()->getNumNeurons();
-            }
-            else {
-                maxConnections = sg.getMaxConnections();
-            }
-        }
-        else {
-            maxConnections = sg.getTrgNeuronGroup()->getNumNeurons();
-        }
         os << "// loop through all incoming spikes" << std::endl;
         os << "for (j = 0; j < lmax; j++)";
         {

--- a/lib/src/generateKernels.cc
+++ b/lib/src/generateKernels.cc
@@ -61,7 +61,7 @@ bool shouldAccumulateInSharedMemory(const SynapseGroup &sg)
 {
     // If parallelism is presynaptic i.e. atomics are required and device is older than Maxwell, we shouldn't use shared memory as atomics are emulated
     // and actually slower than global memory (see https://devblogs.nvidia.com/gpu-pro-tip-fast-histograms-using-shared-atomics-maxwell/)
-    if(sg.getSpanType() == SynapseGroup::SpanType::PRESYNAPTIC && deviceProp[theDevice].major < 6) {
+    if(sg.getSpanType() == SynapseGroup::SpanType::PRESYNAPTIC && deviceProp[theDevice].major < 5) {
         return false;
     }
     // Otherwise, we should accumulate each postsynaptic neuron's input in shared menory if matrix is sparse

--- a/lib/src/generateKernels.cc
+++ b/lib/src/generateKernels.cc
@@ -50,6 +50,17 @@ string getFloatAtomicAdd(const string &ftype)
         return "atomicAdd";
     }
 }
+
+bool shouldAccumulateInLinSyn(const SynapseGroup &sg)
+{
+    // We should accumulate each postsynaptic neuron's input in a register if either
+    // 1) Matrix type is dense or bitfield (where each thread represents an individual neuron)
+    // 2) Or the synapse projection doesn't require atomic add i.e. is small enough to used shared memory
+    return ((sg.getMatrixType() & SynapseMatrixConnectivity::DENSE) 
+        || (sg.getMatrixType() & SynapseMatrixConnectivity::BITMASK) 
+        || !sg.isPSAtomicAddRequired(synapseBlkSz));
+}
+
 // parallelisation along pre-synaptic spikes, looped over post-synaptic neurons
 void generatePreParallelisedSparseCode(
     CodeStream &os, //!< output stream for code
@@ -880,7 +891,7 @@ void genSynapseKernel(const NNmodel &model, //!< Model description
 
         // case-dependent variables
         for(const auto &s : model.getLocalSynapseGroups()) {
-            if (!(s.second.getMatrixType() & SynapseMatrixConnectivity::SPARSE) || !s.second.isPSAtomicAddRequired(synapseBlkSz)){
+            if (shouldAccumulateInLinSyn(s.second)) {
                 os << model.getPrecision() << " linSyn;" << std::endl;
                 break;
             }
@@ -934,7 +945,7 @@ void genSynapseKernel(const NNmodel &model, //!< Model description
                     os << ") % " << s->second.getSrcNeuronGroup()->getNumDelaySlots() << ";" << std::endl;
                 }
 
-                if (!(s->second.getMatrixType() & SynapseMatrixConnectivity::SPARSE) || !s->second.isPSAtomicAddRequired(synapseBlkSz)){
+                if (shouldAccumulateInLinSyn(s->second)) {
                     os << "// only do this for existing neurons" << std::endl;
                     os << "if (" << localID << " < " << s->second.getTrgNeuronGroup()->getNumNeurons() << ")";
                     {
@@ -976,7 +987,7 @@ void genSynapseKernel(const NNmodel &model, //!< Model description
                 }
                 os << std::endl;
 
-                if (!(s->second.getMatrixType() & SynapseMatrixConnectivity::SPARSE) || !s->second.isPSAtomicAddRequired(synapseBlkSz)) {
+                if (shouldAccumulateInLinSyn(s->second)) {
                     os << "// only do this for existing neurons" << std::endl;
                     os << "if (" << localID << " < " << s->second.getTrgNeuronGroup()->getNumNeurons() << ")";
                     {

--- a/lib/src/synapseGroup.cc
+++ b/lib/src/synapseGroup.cc
@@ -210,18 +210,6 @@ VarMode SynapseGroup::getPSVarMode(const std::string &var) const
     return m_PSVarMode[getPSModel()->getVarIndex(var)];
 }
 
-bool SynapseGroup::isPSAtomicAddRequired(unsigned int blockSize) const
-{
-    // Return true if this synapse group has sparse connectivity i.e. each postsynaptic thread can't just accumulate into a register
-    // and there are too many target neurons for their input to be accumulated in shared memory array
-    if ((getMatrixType() & SynapseMatrixConnectivity::SPARSE) && getTrgNeuronGroup()->getNumNeurons() > blockSize) {
-        return true;
-    }
-    else {
-        return false;
-    }
-}
-
 void SynapseGroup::addExtraGlobalNeuronParams(std::map<std::string, std::string> &kernelParameters) const
 {
     // Loop through list of extra global weight update parameters

--- a/lib/src/synapseGroup.cc
+++ b/lib/src/synapseGroup.cc
@@ -212,15 +212,14 @@ VarMode SynapseGroup::getPSVarMode(const std::string &var) const
 
 bool SynapseGroup::isPSAtomicAddRequired(unsigned int blockSize) const
 {
-    if (getMatrixType() & SynapseMatrixConnectivity::SPARSE) {
-        if (getSpanType() == SpanType::POSTSYNAPTIC && getTrgNeuronGroup()->getNumNeurons() > blockSize) {
-            return true;
-        }
-        if (getSpanType()  == SpanType::PRESYNAPTIC && getSrcNeuronGroup()->getNumNeurons() > blockSize) {
-            return true;
-        }
+    // Return true if this synapse group has sparse connectivity i.e. each postsynaptic thread can't just accumulate into a register
+    // and there are too many target neurons for their input to be accumulated in shared memory array
+    if ((getMatrixType() & SynapseMatrixConnectivity::SPARSE) && getTrgNeuronGroup()->getNumNeurons() > blockSize) {
+        return true;
     }
-    return false;
+    else {
+        return false;
+    }
 }
 
 void SynapseGroup::addExtraGlobalNeuronParams(std::map<std::string, std::string> &kernelParameters) const

--- a/tests/.gitignore
+++ b/tests/.gitignore
@@ -4,6 +4,7 @@
 
 # Ignore test executables
 **/test
+**/test_wrapper
 **/test.exe
 
 # Ignore GCOV output

--- a/tests/features/decode_matrix_globalg_sparse_pre/Makefile
+++ b/tests/features/decode_matrix_globalg_sparse_pre/Makefile
@@ -1,0 +1,1 @@
+../../utils/Makefile

--- a/tests/features/decode_matrix_globalg_sparse_pre/model.cc
+++ b/tests/features/decode_matrix_globalg_sparse_pre/model.cc
@@ -1,0 +1,47 @@
+#include "modelSpec.h"
+
+// NEURONS
+//==============
+
+double neuron_ini[1] = { // one neuron variable
+    0.0  // 0 - individual shift
+};
+
+
+// Synapses
+//==================================================
+
+double synapses_ini[1]= {
+    1.0 // the weight
+};
+
+
+void modelDefinition(NNmodel &model)
+{
+    initGeNN();
+
+    model.setDT(0.1);
+    model.setName("decode_matrix_globalg_sparse_pre");
+
+    neuronModel n;
+    n.varNames = {"x", "shift"};
+    n.varTypes = {"scalar", "scalar"};
+    n.simCode= "$(x)= $(Isyn);\n";
+
+    const int DUMMYNEURON= nModels.size();
+    nModels.push_back(n);
+
+    // Static synapse parameters
+    WeightUpdateModels::StaticPulse::VarValues staticSynapseInit(1.0);    // 0 - Wij (nA)
+
+    model.addNeuronPopulation("Pre", 10, SPIKESOURCE, NULL, NULL);
+    model.addNeuronPopulation("Post", 4, DUMMYNEURON, NULL, neuron_ini);
+
+
+    model.addSynapsePopulation("Syn", NSYNAPSE, SPARSE, GLOBALG, NO_DELAY, IZHIKEVICH_PS, "Pre", "Post",
+                               synapses_ini, NULL,
+                               NULL, NULL);
+    model.setSpanTypeToPre("Syn");
+    model.setPrecision(GENN_FLOAT);
+    model.finalize();
+}

--- a/tests/features/decode_matrix_globalg_sparse_pre/model_new.cc
+++ b/tests/features/decode_matrix_globalg_sparse_pre/model_new.cc
@@ -1,0 +1,41 @@
+#include "modelSpec.h"
+
+//----------------------------------------------------------------------------
+// Neuron
+//----------------------------------------------------------------------------
+class Neuron : public NeuronModels::Base
+{
+public:
+    DECLARE_MODEL(Neuron, 0, 1);
+
+    SET_SIM_CODE("$(x)= $(Isyn);\n");
+
+    SET_VARS({{"x", "scalar"}});
+};
+
+IMPLEMENT_MODEL(Neuron);
+
+
+void modelDefinition(NNmodel &model)
+{
+    initGeNN();
+
+    model.setDT(0.1);
+    model.setName("decode_matrix_globalg_sparse_pre_new");
+
+    // Static synapse parameters
+    WeightUpdateModels::StaticPulse::VarValues staticSynapseInit(1.0);    // 0 - Wij (nA)
+
+    model.addNeuronPopulation<NeuronModels::SpikeSource>("Pre", 10, {}, {});
+    model.addNeuronPopulation<Neuron>("Post", 4, {}, Neuron::VarValues(0.0));
+
+
+    model.addSynapsePopulation<WeightUpdateModels::StaticPulse, PostsynapticModels::DeltaCurr>(
+        "Syn", SynapseMatrixType::SPARSE_GLOBALG, NO_DELAY, "Pre", "Post",
+        {}, staticSynapseInit,
+        {}, {});
+
+    model.setSpanTypeToPre("Syn");
+    model.setPrecision(GENN_FLOAT);
+    model.finalize();
+}

--- a/tests/features/decode_matrix_globalg_sparse_pre/test.cc
+++ b/tests/features/decode_matrix_globalg_sparse_pre/test.cc
@@ -1,0 +1,68 @@
+// Google test includes
+#include "gtest/gtest.h"
+
+// Auto-generated simulation code includess
+#include DEFINITIONS_HEADER
+
+// **NOTE** base-class for simulation tests must be
+// included after auto-generated globals are includes
+#include "../../utils/simulation_test_decoder_matrix.h"
+
+//----------------------------------------------------------------------------
+// SimTest
+//----------------------------------------------------------------------------
+class SimTest : public SimulationTestDecoderMatrix
+{
+public:
+    //----------------------------------------------------------------------------
+    // SimulationTest virtuals
+    //----------------------------------------------------------------------------
+    virtual void Init()
+    {
+        // Allocate sparse matrix
+        allocateSyn(17);
+
+        // Loop through presynaptic neurons
+        unsigned int c = 0;
+        for(unsigned int i = 0; i < 10; i++)
+        {
+            // Set start index for this presynaptic neuron's weight matrix row
+            CSyn.indInG[i] = c;
+            for(unsigned int j = 0; j < 4; j++)
+            {
+                // Get value this post synaptic neuron represents
+                const unsigned int j_value = (1 << j);
+
+                // If this postsynaptic neuron should be connected, add index
+                if(((i + 1) & j_value) != 0)
+                {
+                    CSyn.ind[c++] = j;
+                }
+            }
+        }
+
+        // Add end index
+        CSyn.indInG[10] = c;
+    }
+};
+
+TEST_P(SimTest, CorrectDecoding)
+{
+#ifndef CPU_ONLY
+    // Initialize sparse arrays
+    initializeAllSparseArrays();
+#endif  // CPU_ONLY
+
+    // Check total error is less than some tolerance
+    EXPECT_TRUE(Simulate());
+}
+
+#ifndef CPU_ONLY
+auto simulatorBackends = ::testing::Values(true, false);
+#else
+auto simulatorBackends = ::testing::Values(false);
+#endif
+
+WRAPPED_INSTANTIATE_TEST_CASE_P(MODEL_NAME,
+                                SimTest,
+                                simulatorBackends);

--- a/tests/features/decode_matrix_individualg_sparse_pre/Makefile
+++ b/tests/features/decode_matrix_individualg_sparse_pre/Makefile
@@ -1,0 +1,1 @@
+../../utils/Makefile

--- a/tests/features/decode_matrix_individualg_sparse_pre/model.cc
+++ b/tests/features/decode_matrix_individualg_sparse_pre/model.cc
@@ -1,0 +1,47 @@
+#include "modelSpec.h"
+
+// NEURONS
+//==============
+
+double neuron_ini[1] = { // one neuron variable
+    0.0  // 0 - individual shift
+};
+
+
+// Synapses
+//==================================================
+
+double synapses_ini[1]= {
+    1.0 // the weight
+};
+
+
+void modelDefinition(NNmodel &model)
+{
+    initGeNN();
+
+    model.setDT(0.1);
+    model.setName("decode_matrix_individualg_sparse_pre");
+
+    neuronModel n;
+    n.varNames = {"x", "shift"};
+    n.varTypes = {"scalar", "scalar"};
+    n.simCode= "$(x)= $(Isyn);\n";
+
+    const int DUMMYNEURON= nModels.size();
+    nModels.push_back(n);
+
+    // Static synapse parameters
+    WeightUpdateModels::StaticPulse::VarValues staticSynapseInit(1.0);    // 0 - Wij (nA)
+
+    model.addNeuronPopulation("Pre", 10, SPIKESOURCE, NULL, NULL);
+    model.addNeuronPopulation("Post", 4, DUMMYNEURON, NULL, neuron_ini);
+
+
+    model.addSynapsePopulation("Syn", NSYNAPSE, SPARSE, INDIVIDUALG, NO_DELAY, IZHIKEVICH_PS, "Pre", "Post",
+                               synapses_ini, NULL,
+                               NULL, NULL);
+    model.setSpanTypeToPre("Syn");
+    model.setPrecision(GENN_FLOAT);
+    model.finalize();
+}

--- a/tests/features/decode_matrix_individualg_sparse_pre/model_new.cc
+++ b/tests/features/decode_matrix_individualg_sparse_pre/model_new.cc
@@ -1,0 +1,40 @@
+#include "modelSpec.h"
+
+//----------------------------------------------------------------------------
+// Neuron
+//----------------------------------------------------------------------------
+class Neuron : public NeuronModels::Base
+{
+public:
+    DECLARE_MODEL(Neuron, 0, 1);
+
+    SET_SIM_CODE("$(x)= $(Isyn);\n");
+
+    SET_VARS({{"x", "scalar"}});
+};
+
+IMPLEMENT_MODEL(Neuron);
+
+
+void modelDefinition(NNmodel &model)
+{
+    initGeNN();
+
+    model.setDT(0.1);
+    model.setName("decode_matrix_individualg_sparse_pre_new");
+
+    // Static synapse parameters
+    WeightUpdateModels::StaticPulse::VarValues staticSynapseInit(1.0);    // 0 - Wij (nA)
+
+    model.addNeuronPopulation<NeuronModels::SpikeSource>("Pre", 10, {}, {});
+    model.addNeuronPopulation<Neuron>("Post", 4, {}, Neuron::VarValues(0.0));
+
+
+    model.addSynapsePopulation<WeightUpdateModels::StaticPulse, PostsynapticModels::DeltaCurr>(
+        "Syn", SynapseMatrixType::SPARSE_INDIVIDUALG, NO_DELAY, "Pre", "Post",
+        {}, staticSynapseInit,
+        {}, {});
+    model.setSpanTypeToPre("Syn");
+    model.setPrecision(GENN_FLOAT);
+    model.finalize();
+}

--- a/tests/features/decode_matrix_individualg_sparse_pre/test.cc
+++ b/tests/features/decode_matrix_individualg_sparse_pre/test.cc
@@ -1,0 +1,71 @@
+// Google test includes
+#include "gtest/gtest.h"
+
+// Auto-generated simulation code includess
+#include DEFINITIONS_HEADER
+
+// **NOTE** base-class for simulation tests must be
+// included after auto-generated globals are includes
+#include "../../utils/simulation_test_decoder_matrix.h"
+
+//----------------------------------------------------------------------------
+// SimTest
+//----------------------------------------------------------------------------
+class SimTest : public SimulationTestDecoderMatrix
+{
+public:
+    //----------------------------------------------------------------------------
+    // SimulationTest virtuals
+    //----------------------------------------------------------------------------
+    virtual void Init()
+    {
+        // Allocate sparse matrix
+        allocateSyn(17);
+
+        // Loop through presynaptic neurons
+        unsigned int c = 0;
+        for(unsigned int i = 0; i < 10; i++)
+        {
+            // Set start index for this presynaptic neuron's weight matrix row
+            CSyn.indInG[i] = c;
+            for(unsigned int j = 0; j < 4; j++)
+            {
+                // Get value this post synaptic neuron represents
+                const unsigned int j_value = (1 << j);
+
+                // If this postsynaptic neuron should be connected, add index
+                if(((i + 1) & j_value) != 0)
+                {
+                    CSyn.ind[c++] = j;
+                }
+            }
+        }
+
+        // Add end index
+        CSyn.indInG[10] = c;
+
+        // Fill weights
+        std::fill(&gSyn[0], &gSyn[17], 1.0f);
+    }
+};
+
+TEST_P(SimTest, CorrectDecoding)
+{
+#ifndef CPU_ONLY
+    // Initialize sparse arrays
+    initializeAllSparseArrays();
+#endif  // CPU_ONLY
+
+    // Check total error is less than some tolerance
+    EXPECT_TRUE(Simulate());
+}
+
+#ifndef CPU_ONLY
+auto simulatorBackends = ::testing::Values(true, false);
+#else
+auto simulatorBackends = ::testing::Values(false);
+#endif
+
+WRAPPED_INSTANTIATE_TEST_CASE_P(MODEL_NAME,
+                                SimTest,
+                                simulatorBackends);


### PR DESCRIPTION
Basically I was adding some tests to test the new ragged matrix connectivity in presynaptic span mode and realised it was broken for small populations (i.e. when it tries to used shared memory to accumulate postsynaptic input).

Many of the isses that caused this are likely to be the fault of past me but:
- If span type was presynaptic, we were toggling the shared memory based on the source population size which is definitely wrong
- We were never initialising the shared memory array if the span type was presynaptic.
- Previously  when postsynaptic parallelism was used, what happens was:
  ```
  linsyn (register) = dd_inSyn (global memory)
  for each spike block {
    shLg (shared mem) = 0
    **accumulate spikes into shLg**
    **synch**
    linsyn += shLg
    **synch**
  }
  dd_inSyn = linsyn
  ```
  Unless I'm missing something, it's unnecessary to synch all the threads and copy back to linsyn after   every block of spikes and, furthermore, it's unnecessary to involve linsyn at all in the sparse case meaning we can just do:
    ```
  shLg (shared mem) = dd_inSyn (global memory)
  for each spike block {
    **accumulate  spikes into shLg**
  }
  dd_inSyn = shLg
  ```

My only remaining concern is that, with presynaptic parallelism, we should perhaps use shared memory atomics to update the shared memory array as it's definitely possible that two threads could try and add input to the same postsynaptic neuron at once.
