### PR TITLE
Fix for issues with CUDA 9 on Windows

### DIFF
--- a/lib/src/generateRunner.cc
+++ b/lib/src/generateRunner.cc
@@ -2548,7 +2548,9 @@ void genMSBuild(const NNmodel &model,   //!< Model description
     os << "  <!-- Compile runner using CUDA compiler -->" << endl;
     os << "  <ItemGroup>" << endl;
     os << "    <CudaCompile Include=\"" << model.getName() + "_CODE\\runner.cc\">" << endl;
-    os << "        <AdditionalOptions Condition=\" !$(AdditionalOptions.Contains('-x cu')) \">-x cu %(AdditionalOptions)</AdditionalOptions>" << endl;
+    // **YUCK** for some reasons you can't call .Contains on %(BaseCommandLineTemplate) directly
+    // Solution suggested by https://stackoverflow.com/questions/9512577/using-item-functions-on-metadata-values
+    os << "      <AdditionalOptions Condition=\" !$([System.String]::new('%(BaseCommandLineTemplate)').Contains('-x cu')) \">-x cu %(AdditionalOptions)</AdditionalOptions>" << endl;
     os << "    </CudaCompile>" << endl;
     os << "  </ItemGroup>" << endl;
 #endif  // !CPU_ONLY

--- a/lib/src/generateRunner.cc
+++ b/lib/src/generateRunner.cc
@@ -2548,7 +2548,7 @@ void genMSBuild(const NNmodel &model,   //!< Model description
     os << "  <!-- Compile runner using CUDA compiler -->" << endl;
     os << "  <ItemGroup>" << endl;
     os << "    <CudaCompile Include=\"" << model.getName() + "_CODE\\runner.cc\">" << endl;
-    os << "        <AdditionalOptions>-x cu %(AdditionalOptions)</AdditionalOptions>" << endl;
+    os << "        <AdditionalOptions Condition=\" !$(AdditionalOptions.Contains('-x cu')) \">-x cu %(AdditionalOptions)</AdditionalOptions>" << endl;
     os << "    </CudaCompile>" << endl;
     os << "  </ItemGroup>" << endl;
 #endif  // !CPU_ONLY


### PR DESCRIPTION
Previously we were manually adding ``-x cu`` to the ``nvcc.exe`` command line. However, in CUDA 9.1 and 9.2 (presumably 9.0 as well), this is already included, resulting in bug #188.

Rather than change this behaviour based on the CUDA version this change instead applies the fix based on the root cause of the problem - ``-x cu``being in the template string used invoke ``nvcc.exe``. This has been tested on the following configurations:

- [x] CUDA 9.2 and Visual Studio 2013 (professional) - Additional ``-x cu`` is **not required**
- [x] CUDA 7.5 and Visual Studio 2013 (professional) - Additional ``-x cu`` **is required**