### PR TITLE
Neuron Vm was driven to NaN in the SynDelay example

### DIFF
--- a/lib/include/newNeuronModels.h
+++ b/lib/include/newNeuronModels.h
@@ -194,9 +194,9 @@ public:
         "$(V)+=0.5*(0.04*$(V)*$(V)+5.0*$(V)+140.0-$(U)+$(Isyn))*DT; //at two times for numerical stability\n"
         "$(V)+=0.5*(0.04*$(V)*$(V)+5.0*$(V)+140.0-$(U)+$(Isyn))*DT;\n"
         "$(U)+=$(a)*($(b)*$(V)-$(U))*DT;\n"
-        "//if ($(V) > 30.0){   //keep this only for visualisation -- not really necessaary otherwise \n"
-        "//  $(V)=30.0; \n"
-        "//}\n");
+        "if ($(V) > 30.0){   //keep this to not confuse users with unrealistiv voltage values \n"
+        "  $(V)=30.0; \n"
+        "}\n");
 
     SET_THRESHOLD_CONDITION_CODE("$(V) >= 29.99");
 

--- a/userproject/SynDelay_project/SynDelay.cc
+++ b/userproject/SynDelay_project/SynDelay.cc
@@ -10,8 +10,6 @@
 //--------------------------------------------------------------------------
 
 #include "modelSpec.h"
-#include "global.h"
-
 
 class MyIzhikevich : public NeuronModels::Izhikevich
 {
@@ -57,21 +55,17 @@ void modelDefinition(NNmodel &model)
         0.2,   // 1 - b
         -65,   // 2 - c
         6,      // 3 - d
-        4.0     // 4 - I0 (input current)
-                              );
+        4.0);   // 4 - I0 (input current)
 
     MyIzhikevich::VarValues input_ini( // Izhikevich variables - tonic spiking
         -65,   // 0 - V
-        -20    // 1 - U
-    );
+        -20);  // 1 - U
 
     PostsynapticModels::ExpCond::ParamValues postExpInp(
         1.0,            // 0 - tau_S: decay time constant for S [ms]
-        0.0              // 1 - Erev: Reversal potential
-    );
+        0.0);            // 1 - Erev: Reversal potential
 
     model.addNeuronPopulation<MyIzhikevich>("Input", 500, input_p, input_ini);
-
 
     // INTERNEURONS
     //=============
@@ -79,18 +73,16 @@ void modelDefinition(NNmodel &model)
         0.02,      // 0 - a
         0.2,       // 1 - b
         -65,       // 2 - c
-        6      // 3 - d
-    );
+        6);    // 3 - d
+
 
     NeuronModels::Izhikevich::VarValues inter_ini( // Izhikevich variables - tonic spiking
         -65,       // 0 - V
-        -20        // 1 - U
-    );
+        -20);      // 1 - U
 
     PostsynapticModels::ExpCond::ParamValues postExpInt(
         1.0,            // 0 - tau_S: decay time constant for S [ms]
-        0.0               // 1 - Erev: Reversal potential
-    );
+        0.0);             // 1 - Erev: Reversal potential
 
     model.addNeuronPopulation<NeuronModels::Izhikevich>("Inter", 500, inter_p, inter_ini);
 
@@ -102,17 +94,13 @@ void modelDefinition(NNmodel &model)
         0.02,      // 0 - a
         0.2,       // 1 - b
         -65,       // 2 - c
-        6          // 3 - d
-    );
+        6);        // 3 - d
+
 
     NeuronModels::Izhikevich::VarValues output_ini( // Izhikevich variables - tonic spiking
         -65,    // 0 - V
-        -20     // 1 - U
-    );
-    PostsynapticModels::ExpCond::ParamValues postExpOut(
-        1.0,            // 0 - tau_S: decay time constant for S [ms]
-        0.0             // 1 - Erev: Reversal potential
-    );
+        -20);   // 1 - U
+
 
     model.addNeuronPopulation<NeuronModels::Izhikevich>("Output", 500, output_p, output_ini);
 
@@ -120,29 +108,26 @@ void modelDefinition(NNmodel &model)
     // INPUT-INTER, INPUT-OUTPUT & INTER-OUTPUT SYNAPSES
     //==================================================
     WeightUpdateModels::StaticPulse::VarValues inputInter_ini(
-        0.001   // 0 - default synaptic conductance
-    );
+        0.06); // 0 - default synaptic conductance
 
     WeightUpdateModels::StaticPulse::VarValues inputOutput_ini(
-        0.001   // 0 - default synaptic conductance
-    );
+        0.03); // 0 - default synaptic conductance
 
     WeightUpdateModels::StaticPulse::VarValues interOutput_ini(
-        0.001   // 0 - default synaptic conductance
-    );
+        0.03); // 0 - default synaptic conductance
 
-    model.addSynapsePopulation<WeightUpdateModels::StaticPulse, PostsynapticModels::ExpCond>("InputInter", SynapseMatrixType::DENSE_GLOBALG, 3,
-                                                                                             "Input", "Inter",
-                                                                                             {}, inputInter_ini,
-                                                                                             postExpInp, {});
-    model.addSynapsePopulation<WeightUpdateModels::StaticPulse, PostsynapticModels::ExpCond>("InputOutput", SynapseMatrixType::DENSE_GLOBALG, 6,
-                                                                                             "Input", "Output",
-                                                                                             {}, inputOutput_ini,
-                                                                                             postExpOut, {});
-    model.addSynapsePopulation<WeightUpdateModels::StaticPulse, PostsynapticModels::ExpCond>("InterOutput", SynapseMatrixType::DENSE_GLOBALG, NO_DELAY,
-                                                                                             "Inter", "Output",
-                                                                                             {}, interOutput_ini,
-                                                                                             postExpInt, {});
+    model.addSynapsePopulation<WeightUpdateModels::StaticPulse, PostsynapticModels::DeltaCurr>("InputInter", SynapseMatrixType::DENSE_GLOBALG, 3,
+                                                                                               "Input", "Inter",
+                                                                                               {}, inputInter_ini,
+                                                                                               {}, {});
+    model.addSynapsePopulation<WeightUpdateModels::StaticPulse, PostsynapticModels::DeltaCurr>("InputOutput", SynapseMatrixType::DENSE_GLOBALG, 6,
+                                                                                               "Input", "Output",
+                                                                                               {}, inputOutput_ini,
+                                                                                               {}, {});
+    model.addSynapsePopulation<WeightUpdateModels::StaticPulse, PostsynapticModels::DeltaCurr>("InterOutput", SynapseMatrixType::DENSE_GLOBALG, NO_DELAY,
+                                                                                               "Inter", "Output",
+                                                                                               {}, interOutput_ini,
+                                                                                               {}, {});
 
 
     model.finalize();

--- a/userproject/SynDelay_project/SynDelay.cc
+++ b/userproject/SynDelay_project/SynDelay.cc
@@ -26,9 +26,9 @@ public:
         "$(V) += 0.5*(0.04*$(V)*$(V)+5.0*$(V)+140.0-$(U)+$(I0)+$(Isyn))*DT; //at two times for numerical stability\n"
         "$(V) += 0.5*(0.04*$(V)*$(V)+5.0*$(V)+140.0-$(U)+$(I0)+$(Isyn))*DT;\n"
         "$(U) += $(a)*($(b)*$(V)-$(U))*DT;\n"
-        "//if ($(V) > 30.0) { // keep this only for visualisation -- not really necessaary otherwise\n"
-        "//    $(V) = 30.0;\n"
-        "//}\n");
+        "if ($(V) > 30.0) {   //keep this to not confuse users with unrealistiv voltage values \n"
+        "    $(V) = 30.0;\n"
+        "}\n");
     SET_PARAM_NAMES({"a", "b", "c", "d", "I0"});
 };
 IMPLEMENT_MODEL(MyIzhikevich);
@@ -120,15 +120,15 @@ void modelDefinition(NNmodel &model)
     // INPUT-INTER, INPUT-OUTPUT & INTER-OUTPUT SYNAPSES
     //==================================================
     WeightUpdateModels::StaticPulse::VarValues inputInter_ini(
-        0.06   // 0 - default synaptic conductance
+        0.001   // 0 - default synaptic conductance
     );
 
     WeightUpdateModels::StaticPulse::VarValues inputOutput_ini(
-        0.03   // 0 - default synaptic conductance
+        0.001   // 0 - default synaptic conductance
     );
 
     WeightUpdateModels::StaticPulse::VarValues interOutput_ini(
-        0.03   // 0 - default synaptic conductance
+        0.001   // 0 - default synaptic conductance
     );
 
     model.addSynapsePopulation<WeightUpdateModels::StaticPulse, PostsynapticModels::ExpCond>("InputInter", SynapseMatrixType::DENSE_GLOBALG, 3,


### PR DESCRIPTION
Changed Izhikevich neuron model to not output unrealistically high Voltage values when driven to spike. Also changed the SynDelay project so that neurons are not fried through too strong synapses.