### PR TITLE
More precise writing of very large and small floating point values

### DIFF
--- a/lib/include/codeGenUtils.h
+++ b/lib/include/codeGenUtils.h
@@ -194,7 +194,9 @@ void writePreciseString(std::ostream &os, T value)
     os << value;
 
     // Reset to default formatting
-    os << std::defaultfloat;
+    // **YUCK** GCC 4.8.X doesn't seem to include std::defaultfloat
+    os.unsetf(std::ios_base::floatfield)
+    //os << std::defaultfloat;
 
     // Restore previous precision
     os << std::setprecision(previousPrecision);

--- a/lib/include/codeGenUtils.h
+++ b/lib/include/codeGenUtils.h
@@ -1,6 +1,7 @@
 #pragma once
 
 // Standard includes
+#include <iomanip>
 #include <limits>
 #include <string>
 #include <sstream>
@@ -177,6 +178,28 @@ inline void name_substitutions(string &code, const string &prefix, const vector<
 }
 
 
+template<class T, typename std::enable_if<std::is_floating_point<T>::value>::type* = nullptr>
+void writePreciseString(std::ostream &os, T value)
+{
+    // Cache previous precision
+    const std::streamsize previousPrecision = os.precision();
+
+    // Set scientific formatting
+    os << std::scientific;
+
+    // Set precision to what is required to fully represent T
+    os << std::setprecision(std::numeric_limits<T>::max_digits10);
+
+    // Write value to stream
+    os << value;
+
+    // Reset to default formatting
+    os << std::defaultfloat;
+
+    // Restore previous precision
+    os << std::setprecision(previousPrecision);
+}
+
 //--------------------------------------------------------------------------
 //! \brief This function performs a list of value substitutions for parameters in code snippets.
 //--------------------------------------------------------------------------
@@ -187,8 +210,7 @@ inline void value_substitutions(string &code, NameIter namesBegin, NameIter name
     auto v = values.cbegin();
     for (;n != namesEnd && v != values.cend(); n++, v++) {
         stringstream stream;
-        stream.precision(std::numeric_limits<double>::max_digits10);
-        stream << std::scientific << *v;
+        writePreciseString(stream, *v);
         substitute(code,
                    "$(" + *n + ext + ")",
                    "(" + stream.str() + ")");

--- a/lib/include/codeGenUtils.h
+++ b/lib/include/codeGenUtils.h
@@ -195,7 +195,7 @@ void writePreciseString(std::ostream &os, T value)
 
     // Reset to default formatting
     // **YUCK** GCC 4.8.X doesn't seem to include std::defaultfloat
-    os.unsetf(std::ios_base::floatfield)
+    os.unsetf(std::ios_base::floatfield);
     //os << std::defaultfloat;
 
     // Restore previous precision

--- a/lib/src/generateRunner.cc
+++ b/lib/src/generateRunner.cc
@@ -363,18 +363,6 @@ void genDefinitions(const NNmodel &model,   //!< Model description
                     const string &path,     //!< Path for code generationn
                     int localHostID)        //!< Host ID of local machine
 {
-    string SCLR_MIN;
-    string SCLR_MAX;
-    if (model.getPrecision() == "float") {
-        SCLR_MIN= to_string(FLT_MIN)+"f";
-        SCLR_MAX= to_string(FLT_MAX)+"f";
-    }
-
-    if (model.getPrecision() == "double") {
-        SCLR_MIN= to_string(DBL_MIN);
-        SCLR_MAX= to_string(DBL_MAX);
-    }
-
     //=======================
     // generate definitions.h
     //=======================
@@ -457,10 +445,26 @@ void genDefinitions(const NNmodel &model,   //!< Model description
     os << "typedef " << model.getPrecision() << " scalar;" << std::endl;
     os << "#endif" << std::endl;
     os << "#ifndef SCALAR_MIN" << std::endl;
-    os << "#define SCALAR_MIN " << SCLR_MIN << std::endl;
+    os << "#define SCALAR_MIN ";
+    if (model.getPrecision() == "float") {
+        writePreciseString(os, std::numeric_limits<float>::min());
+        os << "f" << std::endl;
+    }
+    else {
+        writePreciseString(os, std::numeric_limits<double>::min());
+        os << std::endl;
+    }
     os << "#endif" << std::endl;
     os << "#ifndef SCALAR_MAX" << std::endl;
-    os << "#define SCALAR_MAX " << SCLR_MAX << std::endl;
+    os << "#define SCALAR_MAX ";
+    if (model.getPrecision() == "float") {
+        writePreciseString(os, std::numeric_limits<float>::max());
+        os << "f" << std::endl;
+    }
+    else {
+        writePreciseString(os, std::numeric_limits<double>::max());
+        os << std::endl;
+    }
     os << "#endif" << std::endl;
     os << std::endl;
   


### PR DESCRIPTION
Fixes #194
* New ``writePreciseString`` function which sets scientific format and large enough width to print full precision (the same formatting we were previously using in ``value_substitutions``)
* Used this in ``value_substitutions``
* Used this for writing better-formatted ``SCALAR_MIN`` and ``SCALAR_MAX`` values

For double precision this results in 
```c++
#ifndef SCALAR_MIN
#define SCALAR_MIN 2.22507385850720138e-308
#endif
#ifndef SCALAR_MAX
#define SCALAR_MAX 1.79769313486231571e+308
#endif
```

And for single precision:
```c++
#ifndef SCALAR_MIN
#define SCALAR_MIN 1.175494351e-38f
#endif
#ifndef SCALAR_MAX
#define SCALAR_MAX 3.402823466e+38f
#endif
```