### PR TITLE
Regex fix

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -105,13 +105,7 @@ for(b = 0; b < builderNodes.size; b++) {
                     
                     echo pwd()
                     echo env.PATH;
-                    
-                    // **YUCK** if dev_toolset is in node label - enable it to get newer GCC
-                    if("dev_toolset" in nodeLabel) {
-                        echo "Enabling devtoolset 6 version of GCC";
-                        sh "source /opt/rh/devtoolset-6/enable"
-                    }
-    
+
                     // Deleting existing checked out version of GeNN
                     sh "rm -rf genn";
                     
@@ -146,6 +140,12 @@ for(b = 0; b < builderNodes.size; b++) {
                     // Run automatic tests
                     if (isUnix()) {
                         dir("genn/tests") {
+                            // **YUCK** if dev_toolset is in node label - enable it to get newer GCC
+                            if("dev_toolset" in nodeLabel) {
+                                echo "Enabling devtoolset 6 version of GCC";
+                                sh "source /opt/rh/devtoolset-6/enable"
+                            }
+                            
                             // Run tests
                             if("cpu_only" in nodeLabel) {
                                 sh "./run_tests.sh -c";

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -140,19 +140,20 @@ for(b = 0; b < builderNodes.size; b++) {
                     // Run automatic tests
                     if (isUnix()) {
                         dir("genn/tests") {
-                            // **YUCK** if dev_toolset is in node label - enable it to get newer GCC
+                            // **YUCK** if dev_toolset is in node label - add flag to enable newer GCC using dev_toolset (CentOS)
+                            def runTestArguments = "";
                             if("dev_toolset" in nodeLabel) {
                                 echo "Enabling devtoolset 6 version of GCC";
-                                sh "source /opt/rh/devtoolset-6/enable"
+                                runTestArguments += " -d";
+                            }
+                            
+                            // If node is a CPU_ONLY node add -c option 
+                            if("cpu_only" in nodeLabel) {
+                                runTestArguments += " -c";
                             }
                             
                             // Run tests
-                            if("cpu_only" in nodeLabel) {
-                                sh "./run_tests.sh -c";
-                            }
-                            else {
-                                sh "./run_tests.sh";
-                            }
+                            sh "./run_tests.sh" + runTestArguments;
                             
                             // Parse test output for GCC warnings
                             // **NOTE** driving WarningsPublisher from pipeline is entirely undocumented

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -2,14 +2,17 @@
 
 // All the types of build we'll ideally run if suitable nodes exist
 def desiredBuilds = [
+    ["cuda9", "linux", "x86_64"] as Set,
     ["cuda8", "linux", "x86_64"] as Set,
     ["cuda7", "linux", "x86_64"] as Set, 
     ["cuda6", "linux", "x86_64"] as Set, 
-    ["cpu_only", "linux", "x86_64"] as Set, 
+    ["cpu_only", "linux", "x86_64"] as Set,
+    ["cuda9", "linux", "x86"] as Set,
     ["cuda8", "linux", "x86"] as Set,
     ["cuda7", "linux", "x86"] as Set, 
     ["cuda6", "linux", "x86"] as Set, 
     ["cpu_only", "linux", "x86"] as Set,
+    ["cuda9", "mac"] as Set,
     ["cuda8", "mac"] as Set,
     ["cuda7", "mac"] as Set, 
     ["cuda6", "mac"] as Set, 

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -109,7 +109,7 @@ for(b = 0; b < builderNodes.size; b++) {
                     // **YUCK** if dev_toolset is in node label - enable it to get newer GCC
                     if("dev_toolset" in nodeLabel) {
                         echo "Enabling devtoolset 6 version of GCC";
-                        sh ". /opt/rh/devtoolset-6/enable"
+                        sh "source /opt/rh/devtoolset-6/enable"
                     }
     
                     // Deleting existing checked out version of GeNN

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -105,6 +105,12 @@ for(b = 0; b < builderNodes.size; b++) {
                     
                     echo pwd()
                     echo env.PATH;
+                    
+                    // **YUCK** if dev_toolset is in node label - enable it to get newer GCC
+                    if("dev_toolset" in nodeLabel) {
+                        echo "Enabling devtoolset 6 version of GCC";
+                        sh ". /opt/rh/devtoolset-6/enable"
+                    }
     
                     // Deleting existing checked out version of GeNN
                     sh "rm -rf genn";

--- a/lib/include/codeGenUtils.h
+++ b/lib/include/codeGenUtils.h
@@ -130,6 +130,10 @@ const std::vector<FunctionTemplate> cpuFunctions = {
 //--------------------------------------------------------------------------
 void substitute(string &s, const string &trg, const string &rep);
 
+//--------------------------------------------------------------------------
+//! \brief Tool for substituting strings in the neuron code strings or other templates using regular expressions
+//--------------------------------------------------------------------------
+bool regexSubstitute(string &s, const string &trg, const string &rep);
 
 //--------------------------------------------------------------------------
 //! \brief Does the code string contain any functions requiring random number generator

--- a/lib/include/codeGenUtils.h
+++ b/lib/include/codeGenUtils.h
@@ -131,9 +131,9 @@ const std::vector<FunctionTemplate> cpuFunctions = {
 void substitute(string &s, const string &trg, const string &rep);
 
 //--------------------------------------------------------------------------
-//! \brief Tool for substituting strings in the neuron code strings or other templates using regular expressions
+//! \brief Tool for substituting variable or function names in the neuron code strings or other templates using regular expressions
 //--------------------------------------------------------------------------
-bool regexSubstitute(string &s, const string &trg, const string &rep);
+bool regexVarSubstitute(string &s, const string &trg, const string &rep);
 
 //--------------------------------------------------------------------------
 //! \brief Does the code string contain any functions requiring random number generator

--- a/lib/src/codeGenUtils.cc
+++ b/lib/src/codeGenUtils.cc
@@ -11,12 +11,9 @@
     __GNUC__ > 4 || \
     (__GNUC__ == 4 && (__GNUC_MINOR__ > 9 || \
                       (__GNUC_MINOR__ == 9 && __GNUC_PATCHLEVEL__ >= 1)))
-    #define REGEX_OPERATIONAL
-#endif
-
-// Standard C++ includes
-#ifdef REGEX_OPERATIONAL
-#include <regex>
+    #include <regex>
+#else
+    #error "GeNN now requires a functioning std::regex implementation - please upgrade your version of GCC to at least 4.9.1"
 #endif
 
 // Standard C includes
@@ -117,13 +114,13 @@ void ensureMathFunctionFtype(string &code, const string &type)
     // If type is double, substitute any single precision maths functions for double precision version
     if (type == "double") {
         for(const auto &m : mathsFuncs) {
-            substitute(code, string(m[MathsFuncSingle])+string("("), string(m[MathsFuncDouble])+string("("));
+            regexSubstitute(code, m[MathsFuncSingle] + string("\\("), m[MathsFuncDouble] + string("\\("));
         }
     }
     // Otherwise, substitute any double precision maths functions for single precision version
     else {
         for(const auto &m : mathsFuncs) {
-            substitute(code, string(m[MathsFuncDouble])+string("("), string(m[MathsFuncSingle])+string("("));
+            regexSubstitute(code, m[MathsFuncDouble] + string("\\("), m[MathsFuncSingle] + string("\\("));
         }
     }
 }
@@ -500,9 +497,6 @@ string ensureFtype(const string &oldcode, const string &type)
     return code;
 }
 
-
-#ifdef REGEX_OPERATIONAL
-
 //--------------------------------------------------------------------------
 /*! \brief This function checks for unknown variable definitions and returns a gennError if any are found
  */
@@ -522,11 +516,6 @@ void checkUnreplacedVariables(const string &code, const string &codeName)
         gennError("The "+vars+"undefined in code "+codeName+".");
     }
 }
-#else
-void checkUnreplacedVariables(const string &, const string &)
-{
-}
-#endif
 
 //--------------------------------------------------------------------------
 /*! \brief This function returns the 32-bit hash of a string - because these are used across MPI nodes which may have different libstdc++ it would be risky to use std::hash

--- a/lib/src/codeGenUtils.cc
+++ b/lib/src/codeGenUtils.cc
@@ -172,7 +172,7 @@ bool regexSubstitute(string &s, const string &trg, const string &rep)
     // Build a regex to match variable name with at least one
     // character that can't be in a variable name on either side (or an end/beginning of string)
     // **NOTE** the suffix is non-capturing so two instances of variables separated by a single character are matched e.g. a*a
-    std::regex regex("(^|[^a-zA-Z_])" + trg + "(?=$|[^a-zA-Z_])");
+    std::regex regex("(^|[^0-9a-zA-Z_])" + trg + "(?=$|[^a-zA-Z0-9_])");
 
     // Create format string to replace in text
     // **NOTE** preceding character is captured as C++ regex doesn't support lookbehind so this needs to be replaced in

--- a/lib/src/codeGenUtils.cc
+++ b/lib/src/codeGenUtils.cc
@@ -2,18 +2,20 @@
 
 // Is C++ regex library operational?
 // We assume it is for:
-// 1) Non GCC compilers
-// 2) GCC 5.X.X and future
-// 3) Any future (4.10.X?) releases
-// 4) 4.9.1 and subsequent patch releases (GCC fully implemented regex in 4.9.0
-// BUT bug 61227 https://gcc.gnu.org/bugzilla/show_bug.cgi?id=61227 prevented \w from working)
+// 1) Compilers that don't define __GNUCC__
+// 2) Clang
+// 3) GCC 5.X.Y and future
+// 4) Any future (4.10.Y?) GCC 4.X.Y releases
+// 5) GCC 4.9.1 and subsequent patch releases (GCC fully implemented regex in 4.9.0
+// BUT bug 61227 https://gcc.gnu.org/bugzilla/show_bug.cgi?id=61227 prevented \w from working until 4.9.1)
 #if !defined(__GNUC__) || \
+    __clang__ || \
     __GNUC__ > 4 || \
     (__GNUC__ == 4 && (__GNUC_MINOR__ > 9 || \
                       (__GNUC_MINOR__ == 9 && __GNUC_PATCHLEVEL__ >= 1)))
     #include <regex>
 #else
-    #error "GeNN now requires a functioning std::regex implementation - please upgrade your version of GCC to at least 4.9.1"
+    #error "GeNN now requires a functioning std::regex implementation - please upgrade your version of GCC to at least 4.9.1, currently"
 #endif
 
 // Standard C includes

--- a/lib/src/codeGenUtils.cc
+++ b/lib/src/codeGenUtils.cc
@@ -15,7 +15,7 @@
                       (__GNUC_MINOR__ == 9 && __GNUC_PATCHLEVEL__ >= 1)))
     #include <regex>
 #else
-    #error "GeNN now requires a functioning std::regex implementation - please upgrade your version of GCC to at least 4.9.1, currently"
+    #error "GeNN now requires a functioning std::regex implementation - please upgrade your version of GCC to at least 4.9.1"
 #endif
 
 // Standard C includes

--- a/lib/src/codeGenUtils.cc
+++ b/lib/src/codeGenUtils.cc
@@ -116,13 +116,13 @@ void ensureMathFunctionFtype(string &code, const string &type)
     // If type is double, substitute any single precision maths functions for double precision version
     if (type == "double") {
         for(const auto &m : mathsFuncs) {
-            regexSubstitute(code, m[MathsFuncSingle] + string("\\("), m[MathsFuncDouble] + string("\\("));
+            regexVarSubstitute(code, m[MathsFuncSingle] + string("\\("), m[MathsFuncDouble] + string("\\("));
         }
     }
     // Otherwise, substitute any double precision maths functions for single precision version
     else {
         for(const auto &m : mathsFuncs) {
-            regexSubstitute(code, m[MathsFuncDouble] + string("\\("), m[MathsFuncSingle] + string("\\("));
+            regexVarSubstitute(code, m[MathsFuncDouble] + string("\\("), m[MathsFuncSingle] + string("\\("));
         }
     }
 }
@@ -169,7 +169,7 @@ void substitute(string &s, const string &trg, const string &rep)
 //--------------------------------------------------------------------------
 //! \brief Tool for substituting strings in the neuron code strings or other templates using regular expressions
 //--------------------------------------------------------------------------
-bool regexSubstitute(string &s, const string &trg, const string &rep)
+bool regexVarSubstitute(string &s, const string &trg, const string &rep)
 {
     // Build a regex to match variable name with at least one
     // character that can't be in a variable name on either side (or an end/beginning of string)

--- a/lib/src/codeGenUtils.cc
+++ b/lib/src/codeGenUtils.cc
@@ -569,10 +569,10 @@ uint32_t hashString(const std::string &string)
     // Handle the last few bytes of the input array
     switch(len)
     {
-        case 3: h ^= data[2] << 16;
-        case 2: h ^= data[1] << 8;
+        case 3: h ^= data[2] << 16; // falls through
+        case 2: h ^= data[1] << 8;  // falls through
         case 1: h ^= data[0];
-                h *= m;
+                h *= m;             // falls through
     };
 
     // Do a few final mixes of the hash to ensure the last few

--- a/spineml/generator/modelCommon.cc
+++ b/spineml/generator/modelCommon.cc
@@ -185,7 +185,7 @@ void SpineMLGenerator::wrapAndReplaceVariableNames(std::string &code, const std:
                                                    const std::string &replaceVariableName)
 {
     // Replace variable name with replacement variable name, within GeNN $(XXXX) wrapper
-    regexSubstitute(code, variableName, "$(" + replaceVariableName + ")");
+    regexVarSubstitute(code, variableName, "$(" + replaceVariableName + ")");
 }
 //----------------------------------------------------------------------------
 void SpineMLGenerator::wrapVariableNames(std::string &code, const std::string &variableName)
@@ -319,7 +319,7 @@ bool SpineMLGenerator::expandAliases(std::string &code, const std::map<std::stri
     // Replace all alias names with their code string
     bool aliasesExpanded = false;
     for(const auto &alias : aliases) {
-        aliasesExpanded |= regexSubstitute(code, alias.first, alias.second);
+        aliasesExpanded |= regexVarSubstitute(code, alias.first, alias.second);
     }
     return aliasesExpanded;
 }

--- a/spineml/generator/modelCommon.cc
+++ b/spineml/generator/modelCommon.cc
@@ -4,6 +4,9 @@
 #include <iostream>
 #include <regex>
 
+// GeNN includes
+#include "codeGenUtils.h"
+
 // SpineML generator includes
 #include "objectHandler.h"
 
@@ -178,64 +181,11 @@ std::pair<bool, unsigned int> SpineMLGenerator::generateModelCode(const pugi::xm
     return std::make_pair(multipleRegimes, initialRegime->second);
 }
 //----------------------------------------------------------------------------
-bool SpineMLGenerator::replaceVariableNames(std::string &code, const std::string &variableName,
-                                            const std::string &replaceText)
-{
-    // Build a regex to match variable name with at least one
-    // character that can't be in a variable name on either side (or an end/beginning of string)
-    // **NOTE** the suffix is non-capturing so two instances of variables separated by a single character are matched e.g. a*a
-    std::regex regex("(^|[^a-zA-Z_])" + variableName + "(?=$|[^a-zA-Z_])");
-
-    // Create format string to replace in text
-    // **NOTE** preceding character is captured as C++ regex doesn't support lookbehind so this needs to be replaced in
-    const std::string format = "$1" + replaceText;
-
-    // **NOTE** the following code performs the same function as std::regex_replace 
-    // but has a return value indicating whether any replacements are made
-    // see http://en.cppreference.com/w/cpp/regex/regex_replace
-
-    // Create regex iterator to iterate over matches found in code
-    std::sregex_iterator matchesBegin(code.cbegin(), code.cend(), regex);
-    std::sregex_iterator matchesEnd;
-
-    // If there are no matches, leave code unmodified and return false
-    if(matchesBegin == matchesEnd) {
-        return false;
-    }
-    // Otherwise
-    else {
-        // Loop through matches
-        std::string outputCode;
-        for(std::sregex_iterator m = matchesBegin;;) {
-            // Copy the non-matched subsequence (m->prefix()) onto output
-            std::copy(m->prefix().first, m->prefix().second, std::back_inserter(outputCode));
-
-            // Then replaces the matched subsequence with the formatted replacement string 
-            m->format(std::back_inserter(outputCode), format);
-
-            // If there are no subsequent matches
-            if(std::next(m) == matchesEnd) {
-                // Copy the remaining non-matched characters onto output
-                std::copy(m->suffix().first, m->suffix().second, std::back_inserter(outputCode)); 
-                break;
-            }
-            // Otherwise go onto next match
-            else {
-                m++;
-            }
-        }
-
-        // Set code reference to newly processed version and return true
-        code = outputCode;
-        return true;
-    }
-}
-//----------------------------------------------------------------------------
 void SpineMLGenerator::wrapAndReplaceVariableNames(std::string &code, const std::string &variableName,
                                                    const std::string &replaceVariableName)
 {
     // Replace variable name with replacement variable name, within GeNN $(XXXX) wrapper
-    replaceVariableNames(code, variableName, "$(" + replaceVariableName + ")");
+    regexSubstitute(code, variableName, "$(" + replaceVariableName + ")");
 }
 //----------------------------------------------------------------------------
 void SpineMLGenerator::wrapVariableNames(std::string &code, const std::string &variableName)
@@ -369,7 +319,7 @@ bool SpineMLGenerator::expandAliases(std::string &code, const std::map<std::stri
     // Replace all alias names with their code string
     bool aliasesExpanded = false;
     for(const auto &alias : aliases) {
-        aliasesExpanded |= replaceVariableNames(code, alias.first, alias.second);
+        aliasesExpanded |= regexSubstitute(code, alias.first, alias.second);
     }
     return aliasesExpanded;
 }

--- a/spineml/generator/modelCommon.h
+++ b/spineml/generator/modelCommon.h
@@ -197,10 +197,6 @@ std::pair<bool, unsigned int> generateModelCode(const pugi::xml_node &componentC
                                                 ObjectHandler::Base *objectHandlerTimeDerivative,
                                                 std::function<void(bool, unsigned int)> regimeEndFunc);
 
-//!< Search through code for references to named variable and replace it with text
-bool replaceVariableNames(std::string &code, const std::string &variableName,
-                          const std::string &replaceText);
-
 //!< Search through code for references to named variable, rename it and wrap in GeNN's $(XXXX) tags
 void wrapAndReplaceVariableNames(std::string &code, const std::string &variableName,
                                  const std::string &replaceVariableName);

--- a/tests/run_tests.sh
+++ b/tests/run_tests.sh
@@ -27,12 +27,14 @@ REPORT=0
 
 # Parse command line arguments
 OPTIND=1
-while getopts "cr" opt; do
+while getopts "crd" opt; do
     case "$opt" in
     c)  BUILD_FLAGS="-c"
         MAKE_FLAGS="CPU_ONLY=1"
         ;;
     r) REPORT=1
+        ;;
+    d) source /opt/rh/devtoolset-6/enable
         ;;
     esac
 done

--- a/tests/unit/codeGenUtils.cc
+++ b/tests/unit/codeGenUtils.cc
@@ -27,7 +27,7 @@ TEST(EnsureMathFunctionFtype, foo123) {
     const std::string code = "int foo123 = 6;";
 
     std::string substitutedCode = code;
-    regexSubstitute(substitutedCode, "foo", "bar");
+    regexVarSubstitute(substitutedCode, "foo", "bar");
     ASSERT_EQ(code, substitutedCode);
 }
 
@@ -36,7 +36,7 @@ TEST(EnsureMathFunctionFtype, not2well) {
     const std::string code = "int not2well = 6;";
 
     std::string substitutedCode = code;
-    regexSubstitute(substitutedCode, "well", "hell");
+    regexVarSubstitute(substitutedCode, "well", "hell");
     ASSERT_EQ(code, substitutedCode);
 }
 

--- a/tests/unit/codeGenUtils.cc
+++ b/tests/unit/codeGenUtils.cc
@@ -11,7 +11,7 @@
 // GeNN includes
 #include "codeGenUtils.h"
 
-// Test based on https://github.com/brian-team/brian2genn/pull/60 to make sure that ensureFtype doesn't break functions it shouldn't
+// Test based on original issue found in https://github.com/brian-team/brian2genn/pull/60 to make sure that ensureFtype doesn't break functions it shouldn't
 TEST(EnsureMathFunctionFtype, ISinF) {
     const std::string code =
         "const int _infinity_int  = 1073741823;  // maximum 32bit integer divided by 2\n"
@@ -19,6 +19,24 @@ TEST(EnsureMathFunctionFtype, ISinF) {
         "{\n";
 
     std::string substitutedCode = ensureFtype(code, "double");
+    ASSERT_EQ(code, substitutedCode);
+}
+
+// Test based on comments by Marcel in https://github.com/brian-team/brian2genn/pull/60
+TEST(EnsureMathFunctionFtype, foo123) {
+    const std::string code = "int foo123 = 6;";
+
+    std::string substitutedCode = code;
+    regexSubstitute(substitutedCode, "foo", "bar");
+    ASSERT_EQ(code, substitutedCode);
+}
+
+// Test based on comments by Thomas in https://github.com/brian-team/brian2genn/pull/60
+TEST(EnsureMathFunctionFtype, not2well) {
+    const std::string code = "int not2well = 6;";
+
+    std::string substitutedCode = code;
+    regexSubstitute(substitutedCode, "well", "hell");
     ASSERT_EQ(code, substitutedCode);
 }
 

--- a/tests/unit/codeGenUtils.cc
+++ b/tests/unit/codeGenUtils.cc
@@ -11,6 +11,17 @@
 // GeNN includes
 #include "codeGenUtils.h"
 
+// Test based on https://github.com/brian-team/brian2genn/pull/60 to make sure that ensureFtype doesn't break functions it shouldn't
+TEST(EnsureMathFunctionFtype, ISinF) {
+    const std::string code =
+        "const int _infinity_int  = 1073741823;  // maximum 32bit integer divided by 2\n"
+        "if (std::isinf(t))\n"
+        "{\n";
+
+    std::string substitutedCode = ensureFtype(code, "double");
+    ASSERT_EQ(code, substitutedCode);
+}
+
 //--------------------------------------------------------------------------
 // SingleValueSubstitutionTest
 //--------------------------------------------------------------------------


### PR DESCRIPTION
Aside from hacking at Jenkins to, in turn, hack at Centos to enable a newer version of GCC this fixes the substitution issues found by @mstimberg in https://github.com/brian-team/brian2genn/pull/60. What I have done is:

1. Moved the SpineML regex-based variable replace function into libgenn
2. Used it in ``ensureMathFunctionFtype``
3. Updated regex to treat numbers as legitimate parts of variable names
4. Added tests to test the various cases @tnowotny  and @mstimberg  came up with