### PR TITLE
Added Compute Capability 7.0 limits to optimizer

### DIFF
--- a/lib/src/generateALL.cc
+++ b/lib/src/generateALL.cc
@@ -254,9 +254,16 @@ void chooseDevice(NNmodel &model,       //!< the nn model we are generating code
                 break;
 
             case 6:
-            latest:
                 smemAllocGran = 256;
                 warpAllocGran = (deviceProp[theDevice].minor == 0) ? 2 : 4;
+                regAllocGran = 256;
+                maxBlocksPerSM = 32;
+                break;
+
+            case 7:
+            latest:
+                smemAllocGran = 256;
+                warpAllocGran = 4;
                 regAllocGran = 256;
                 maxBlocksPerSM = 32;
                 break;


### PR DESCRIPTION
We got access to a super-fancy Tesla V100 as part of a collaboration which has compute capability 7.0! The official spreadsheet doesn't seem to have been updated for 7.0 but I got these numbers from http://lxkarthi.github.io/cuda-calculator/ - am I doing this right?