### PR TITLE
Turns out we didn't fix the regex issue at all -

### DIFF
--- a/lib/include/codeGenUtils.h
+++ b/lib/include/codeGenUtils.h
@@ -131,9 +131,14 @@ const std::vector<FunctionTemplate> cpuFunctions = {
 void substitute(string &s, const string &trg, const string &rep);
 
 //--------------------------------------------------------------------------
-//! \brief Tool for substituting variable or function names in the neuron code strings or other templates using regular expressions
+//! \brief Tool for substituting variable  names in the neuron code strings or other templates using regular expressions
 //--------------------------------------------------------------------------
 bool regexVarSubstitute(string &s, const string &trg, const string &rep);
+
+//--------------------------------------------------------------------------
+//! \brief Tool for substituting function names in the neuron code strings or other templates using regular expressions
+//--------------------------------------------------------------------------
+bool regexFuncSubstitute(string &s, const string &trg, const string &rep);
 
 //--------------------------------------------------------------------------
 //! \brief Does the code string contain any functions requiring random number generator

--- a/tests/unit/codeGenUtils.cc
+++ b/tests/unit/codeGenUtils.cc
@@ -40,6 +40,14 @@ TEST(EnsureMathFunctionFtype, not2well) {
     ASSERT_EQ(code, substitutedCode);
 }
 
+// Test based on my own discovering this wasn't actually working
+TEST(EnsureMathFunctionFtype, rint) {
+    const std::string code = "$(value) = (uint8_t)rint(normal / DT);";
+
+    std::string substitutedCode = ensureFtype(code, "float");
+    ASSERT_EQ(substitutedCode, "$(value) = (uint8_t)rintf(normal / DT);");
+}
+
 //--------------------------------------------------------------------------
 // SingleValueSubstitutionTest
 //--------------------------------------------------------------------------


### PR DESCRIPTION
 it didn't work for function calls we actually **did** want fs adding to  as they should have optional whitespace followed by an open bracket on the right as part of the regex.