### PR TITLE
More current source

### DIFF
--- a/lib/src/generateKernels.cc
+++ b/lib/src/generateKernels.cc
@@ -436,6 +436,9 @@ void genNeuronKernel(const NNmodel &model, //!< Model description
     for(const auto &p : model.getNeuronKernelParameters()) {
         os << p.second << " " << p.first << ", ";
     }
+    for(const auto &p : model.getCurrentSourceKernelParameters()) {
+        os << p.second << " " << p.first << ", ";
+    }
     os << model.getPrecision() << " t)" << std::endl;
     {
         // kernel code

--- a/lib/src/generateRunner.cc
+++ b/lib/src/generateRunner.cc
@@ -2701,6 +2701,9 @@ void genRunnerGPU(const NNmodel &model, //!< Model description
         for(const auto &p : model.getNeuronKernelParameters()) {
             os << p.first << ", ";
         }
+        for(const auto &p : model.getCurrentSourceKernelParameters()) {
+            os << p.first << ", ";
+        }
         os << "t);" << std::endl;
         if (model.isTimingEnabled()) {
             os << "cudaEventRecord(neuronStop);" << std::endl;

--- a/lib/src/standardSubstitutions.cc
+++ b/lib/src/standardSubstitutions.cc
@@ -308,7 +308,7 @@ void StandardSubstitutions::currentSourceInjection(
     const std::string &rng)
 {
     substitute(iCode, "$(t)", "t");
-    name_substitutions(iCode, "l", csmVars.nameBegin, csmVars.nameEnd, cs->getName());
+    name_substitutions(iCode, "l", csmVars.nameBegin, csmVars.nameEnd);
     value_substitutions(iCode, cs->getCurrentSourceModel()->getParamNames(), cs->getParams());
     value_substitutions(iCode, csmDerivedParams.nameBegin, csmDerivedParams.nameEnd, cs->getDerivedParams());
     name_substitutions(iCode, "", csmExtraGlobalParams.nameBegin, csmExtraGlobalParams.nameEnd, cs->getName());

--- a/tests/features/var_init/test.cc
+++ b/tests/features/var_init/test.cc
@@ -85,6 +85,7 @@ TEST_P(SimTest, Vars)
 
     // Test host-generated vars
     PROB_TEST(, Pop, 10000)
+    PROB_TEST(, CurrSource, 10000)
     PROB_TEST(p, Dense, 10000)
     PROB_TEST(, Dense, 10000)
     PROB_TEST(, Sparse, 10000)
@@ -93,12 +94,14 @@ TEST_P(SimTest, Vars)
 #ifndef CPU_ONLY
     // Pull device-generated vars back to host
     pullPopGPUStateFromDevice();
+    pullCurrSourceGPUStateFromDevice();
     pullDenseGPUStateFromDevice();
     pullSparseGPUStateFromDevice();
     pullRaggedGPUStateFromDevice();
 
     // Test device-generated vars
     PROB_TEST(, PopGPU, 10000)
+    PROB_TEST(, CurrSourceGPU, 10000)
     PROB_TEST(p, DenseGPU, 10000)
     PROB_TEST(, DenseGPU, 10000)
     PROB_TEST(, SparseGPU, 10000)


### PR DESCRIPTION
I started switching some of my models over to using current sources and found a few issues:

1. State variables can be initialised on either the GPU or CPU (largely for CPU_ONLY mode/legacy) - in CPU mode, current source variables weren't initialised
2. Current source variables were being read from global memory into registers, but never being written back if they got updated

I fixed both of these as well as updating one of the tests to cover initialising current source variables.