### PR TITLE
Merging of compatible postsynaptic models

### DIFF
--- a/lib/include/global.h
+++ b/lib/include/global.h
@@ -48,6 +48,7 @@ namespace GENN_PREFERENCES {
     extern bool showPtxInfo; //!< Request that PTX assembler information be displayed for each CUDA kernel during compilation
     extern bool buildSharedLibrary; //!< Should generated code and Makefile build into a shared library e.g. for use in SpineML simulator
     extern bool autoInitSparseVars; //!< Previously, variables associated with sparse synapse populations were not automatically initialised. If this flag is set this now occurs in the initMODEL_NAME function and copyStateToDevice is deferred until here
+    extern bool mergePostsynapticModels; //!< Should compatible postsynaptic models and dendritic delay buffers be merged? This can significantly reduce the cost of updating neuron population but means that per-synapse group inSyn arrays can not be retrieved
     extern VarMode defaultVarMode;  //!< What is the default behaviour for model state variables? Historically, everything was allocated on both host AND device and initialised on HOST.
     extern double asGoodAsZero; //!< Global variable that is used when detecting close to zero values, for example when setting sparse connectivity from a dense matrix
     extern int defaultDevice; //! default GPU device; used to determine which GPU to use if chooseDevice is 0 (off)

--- a/lib/include/neuronGroup.h
+++ b/lib/include/neuronGroup.h
@@ -96,6 +96,9 @@ public:
     void initDerivedParams(double dt);
     void calcSizes(unsigned int blockSize, unsigned int &idStart, unsigned int &paddedIDStart);
 
+    //! Merge incoming postsynaptic models
+    void mergeIncomingPSM();
+
     //------------------------------------------------------------------------
     // Public const methods
     //------------------------------------------------------------------------
@@ -115,6 +118,7 @@ public:
 
     //! Gets pointers to all synapse groups which provide input to this neuron group
     const std::vector<SynapseGroup*> &getInSyn() const{ return m_InSyn; }
+    const std::vector<std::pair<SynapseGroup*, std::vector<SynapseGroup*>>> &getMergedInSyn() const{ return m_MergedInSyn; }
 
     //! Gets pointers to all synapse groups emanating from this neuron group
     const std::vector<SynapseGroup*> &getOutSyn() const{ return m_OutSyn; }
@@ -202,6 +206,7 @@ private:
     std::vector<NewModels::VarInit> m_VarInitialisers;
     std::vector<SynapseGroup*> m_InSyn;
     std::vector<SynapseGroup*> m_OutSyn;
+    std::vector<std::pair<SynapseGroup*, std::vector<SynapseGroup*>>> m_MergedInSyn;
     bool m_SpikeTimeRequired;
     bool m_TrueSpikeRequired;
     bool m_SpikeEventRequired;

--- a/lib/include/standardGeneratedSections.h
+++ b/lib/include/standardGeneratedSections.h
@@ -42,7 +42,7 @@ void neuronSpikeEventTest(
     const VarNameIterCtx &nmVars,
     const ExtraGlobalParamNameIterCtx &nmExtraGlobalParams,
     const std::string &localID,
-    const std::vector<FunctionTemplate> functions,
+    const std::vector<FunctionTemplate> &functions,
     const std::string &ftype,
     const std::string &rng);
 }   // namespace StandardGeneratedSections

--- a/lib/include/standardSubstitutions.h
+++ b/lib/include/standardSubstitutions.h
@@ -47,7 +47,7 @@ void postSynapseApplyInput(
     const VarNameIterCtx &nmVars,
     const DerivedParamNameIterCtx &nmDerivedParams,
     const ExtraGlobalParamNameIterCtx &nmExtraGlobalParams, //!
-    const std::vector<FunctionTemplate> functions,          //! Appropriate array of platform-specific function templates used to implement platform-specific functions e.g. gennrand_uniform
+    const std::vector<FunctionTemplate> &functions,         //! Appropriate array of platform-specific function templates used to implement platform-specific functions e.g. gennrand_uniform
     const std::string &ftype,                               //! Floating point type used by model e.g. "float"
     const std::string &rng);                                //! Name of the RNG to use for any probabilistic operations
 
@@ -59,7 +59,7 @@ void postSynapseDecay(
     const VarNameIterCtx &nmVars,
     const DerivedParamNameIterCtx &nmDerivedParams,
     const ExtraGlobalParamNameIterCtx &nmExtraGlobalParams,
-    const std::vector<FunctionTemplate> functions,
+    const std::vector<FunctionTemplate> &functions,
     const std::string &ftype,
     const std::string &rng);
 
@@ -70,7 +70,7 @@ void neuronThresholdCondition(
     const VarNameIterCtx &nmVars,
     const DerivedParamNameIterCtx &nmDerivedParams,
     const ExtraGlobalParamNameIterCtx &nmExtraGlobalParams,
-    const std::vector<FunctionTemplate> functions,
+    const std::vector<FunctionTemplate> &functions,
     const std::string &ftype,
     const std::string &rng);
 
@@ -80,7 +80,7 @@ void neuronSim(
     const VarNameIterCtx &nmVars,
     const DerivedParamNameIterCtx &nmDerivedParams,
     const ExtraGlobalParamNameIterCtx &nmExtraGlobalParams,
-    const std::vector<FunctionTemplate> functions,
+    const std::vector<FunctionTemplate> &functions,
     const std::string &ftype,
     const std::string &rng);
 
@@ -89,7 +89,7 @@ void neuronSpikeEventCondition(
     const NeuronGroup &ng,
     const VarNameIterCtx &nmVars,
     const ExtraGlobalParamNameIterCtx &nmExtraGlobalParams,
-    const std::vector<FunctionTemplate> functions,
+    const std::vector<FunctionTemplate> &functions,
     const std::string &ftype,
     const std::string &rng);
 
@@ -99,7 +99,7 @@ void neuronReset(
     const VarNameIterCtx &nmVars,
     const DerivedParamNameIterCtx &nmDerivedParams,
     const ExtraGlobalParamNameIterCtx &nmExtraGlobalParams,
-    const std::vector<FunctionTemplate> functions,
+    const std::vector<FunctionTemplate> &functions,
     const std::string &ftype,
     const std::string &rng);
 
@@ -111,7 +111,7 @@ void weightUpdateThresholdCondition(
     const string &preIdx, //!< index of the pre-synaptic neuron to be accessed for _pre variables; differs for different Span)
     const string &postIdx, //!< index of the post-synaptic neuron to be accessed for _post variables; differs for different Span)
     const string &devPrefix,
-    const std::vector<FunctionTemplate> functions,
+    const std::vector<FunctionTemplate> &functions,
     const std::string &ftype);
 
 void weightUpdateSim(
@@ -123,7 +123,7 @@ void weightUpdateSim(
     const string &preIdx, //!< index of the pre-synaptic neuron to be accessed for _pre variables; differs for different Span)
     const string &postIdx, //!< index of the post-synaptic neuron to be accessed for _post variables; differs for different Span)
     const string &devPrefix,
-    const std::vector<FunctionTemplate> functions,
+    const std::vector<FunctionTemplate> &functions,
     const std::string &ftype);
 
 void weightUpdateDynamics(
@@ -135,7 +135,7 @@ void weightUpdateDynamics(
     const string &preIdx, //!< index of the pre-synaptic neuron to be accessed for _pre variables; differs for different Span)
     const string &postIdx, //!< index of the post-synaptic neuron to be accessed for _post variables; differs for different Span)
     const string &devPrefix,
-    const std::vector<FunctionTemplate> functions,
+    const std::vector<FunctionTemplate> &functions,
     const std::string &ftype);
 
 void weightUpdatePostLearn(
@@ -146,13 +146,13 @@ void weightUpdatePostLearn(
     const string &preIdx, //!< index of the pre-synaptic neuron to be accessed for _pre variables; differs for different Span)
     const string &postIdx, //!< index of the post-synaptic neuron to be accessed for _post variables; differs for different Span)
     const string &devPrefix,
-    const std::vector<FunctionTemplate> functions,
+    const std::vector<FunctionTemplate> &functions,
     const std::string &ftype);
 
 std::string initVariable(
     const NewModels::VarInit &varInit,
     const std::string &varName,
-    const std::vector<FunctionTemplate> functions,
+    const std::vector<FunctionTemplate> &functions,
     const std::string &ftype,
     const std::string &rng);
 

--- a/lib/include/synapseGroup.h
+++ b/lib/include/synapseGroup.h
@@ -44,6 +44,8 @@ public:
     void setSpikeEventRequired(bool req){ m_SpikeEventRequired = req; }
     void setEventThresholdReTestRequired(bool req){ m_EventThresholdReTestRequired = req; }
 
+    void setTargetMergedPSMName(const std::string &targetMergedPSMName){ m_TargetMergedPSMName = targetMergedPSMName; }
+
     //!< Function to enable the use of zero-copied memory for a particular weight update model state variable (deprecated use SynapseGroup::setWUVarMode):
     /*! May improve IO performance at the expense of kernel performance */
     void setWUVarZeroCopyEnabled(const std::string &varName, bool enabled)
@@ -140,6 +142,8 @@ public:
     const std::vector<double> &getPSDerivedParams() const{ return m_PSDerivedParams; }
     const std::vector<NewModels::VarInit> &getPSVarInitialisers() const{ return m_PSVarInitialisers; }
     const std::vector<double> getPSConstInitVals() const;
+
+    const std::string &getTargetMergedPSMName() const{ return m_TargetMergedPSMName; }
 
     bool isZeroCopyEnabled() const;
     bool isWUVarZeroCopyEnabled(const std::string &var) const{ return (getWUVarMode(var) & VarLocation::ZERO_COPY); }
@@ -271,4 +275,7 @@ private:
 
     //!< Whether indidividual state variables of post synapse should use zero-copied memory
     std::vector<VarMode> m_PSVarMode;
+
+    //! Because
+    std::string m_TargetMergedPSMName;
 };

--- a/lib/include/synapseGroup.h
+++ b/lib/include/synapseGroup.h
@@ -44,11 +44,9 @@ public:
     void setSpikeEventRequired(bool req){ m_SpikeEventRequired = req; }
     void setEventThresholdReTestRequired(bool req){ m_EventThresholdReTestRequired = req; }
 
-    void setPSModelMergeOrigin(){ m_PSModelMerged = true; }
-    void setPSModelMergeTarget(const std::string &targetSynapseGroup)
+    void setPSModelMergeTarget(const std::string &targetName)
     {
-        m_PSModelMerged = true;
-        m_PSModelTargetName = targetSynapseGroup;
+        m_PSModelTargetName = targetName;
     }
 
     //!< Function to enable the use of zero-copied memory for a particular weight update model state variable (deprecated use SynapseGroup::setWUVarMode):
@@ -147,7 +145,7 @@ public:
     const std::vector<double> getPSConstInitVals() const;
 
     const std::string &getPSModelTargetName() const{ return m_PSModelTargetName; }
-    bool isPSModelMerged() const{ return m_PSModelMerged; }
+    bool isPSModelMerged() const{ return m_PSModelTargetName != getName(); }
 
     bool isZeroCopyEnabled() const;
     bool isWUVarZeroCopyEnabled(const std::string &var) const{ return (getWUVarMode(var) & VarLocation::ZERO_COPY); }
@@ -286,7 +284,4 @@ private:
     //! Name of the synapse group in which postsynaptic model is located
     /*! This may not be the name of this group if it has been merged*/
     std::string m_PSModelTargetName;
-
-    //! Has this synapse group's output postsynaptic model been merged with another?
-    bool m_PSModelMerged;
 };

--- a/lib/include/synapseGroup.h
+++ b/lib/include/synapseGroup.h
@@ -44,7 +44,12 @@ public:
     void setSpikeEventRequired(bool req){ m_SpikeEventRequired = req; }
     void setEventThresholdReTestRequired(bool req){ m_EventThresholdReTestRequired = req; }
 
-    void setTargetMergedPSMName(const std::string &targetMergedPSMName){ m_TargetMergedPSMName = targetMergedPSMName; }
+    void setPSModelMergeOrigin(){ m_PSModelMerged = true; }
+    void setPSModelMergeTarget(const std::string &targetSynapseGroup)
+    {
+        m_PSModelMerged = true;
+        m_PSModelTargetName = targetSynapseGroup;
+    }
 
     //!< Function to enable the use of zero-copied memory for a particular weight update model state variable (deprecated use SynapseGroup::setWUVarMode):
     /*! May improve IO performance at the expense of kernel performance */
@@ -141,7 +146,8 @@ public:
     const std::vector<NewModels::VarInit> &getPSVarInitialisers() const{ return m_PSVarInitialisers; }
     const std::vector<double> getPSConstInitVals() const;
 
-    const std::string &getTargetMergedPSMName() const{ return m_TargetMergedPSMName; }
+    const std::string &getPSModelTargetName() const{ return m_PSModelTargetName; }
+    bool isPSModelMerged() const{ return m_PSModelMerged; }
 
     bool isZeroCopyEnabled() const;
     bool isWUVarZeroCopyEnabled(const std::string &var) const{ return (getWUVarMode(var) & VarLocation::ZERO_COPY); }
@@ -277,6 +283,10 @@ private:
     //!< Whether indidividual state variables of post synapse should use zero-copied memory
     std::vector<VarMode> m_PSVarMode;
 
-    //! Because
-    std::string m_TargetMergedPSMName;
+    //! Name of the synapse group in which postsynaptic model is located
+    /*! This may not be the name of this group if it has been merged*/
+    std::string m_PSModelTargetName;
+
+    //! Has this synapse group's output postsynaptic model been merged with another?
+    bool m_PSModelMerged;
 };

--- a/lib/src/generateCPU.cc
+++ b/lib/src/generateCPU.cc
@@ -134,15 +134,15 @@ void generate_process_presynaptic_events_code_CPU(
                 string wCode = evnt ? wu->getEventCode() : wu->getSimCode();
 
                 if(sg.isDendriticDelayRequired()) {
-                    functionSubstitute(wCode, "addToInSynDelay", 2, "denDelay" + sg.getTargetMergedPSMName() + "[" + sg.getDendriticDelayOffset("", "$(1)") + "ipost] += $(0)");
+                    functionSubstitute(wCode, "addToInSynDelay", 2, "denDelay" + sg.getPSModelTargetName() + "[" + sg.getDendriticDelayOffset("", "$(1)") + "ipost] += $(0)");
                 }
                 else {
-                    functionSubstitute(wCode, "addToInSyn", 1, "inSyn" + sg.getTargetMergedPSMName() + "[ipost] += $(0)");
+                    functionSubstitute(wCode, "addToInSyn", 1, "inSyn" + sg.getPSModelTargetName() + "[ipost] += $(0)");
 
                     // **DEPRECATED**
                     os << ftype << " addtoinSyn;" << std::endl;
                     substitute(wCode, "$(updatelinsyn)", "$(inSyn) += $(addtoinSyn)");
-                    substitute(wCode, "$(inSyn)", "inSyn" + sg.getTargetMergedPSMName() + "[ipost]");
+                    substitute(wCode, "$(inSyn)", "inSyn" + sg.getPSModelTargetName() + "[ipost]");
                 }
 
                 substitute(wCode, "$(t)", "t");
@@ -524,14 +524,14 @@ void genSynapseFunction(const NNmodel &model, //!< Model description
 
                                 const std::string postIdx = "C" + s.first + ".ind[n]";
                                 if(sg->isDendriticDelayRequired()) {
-                                    functionSubstitute(SDcode, "addToInSynDelay", 2, "denDelay" + sg->getTargetMergedPSMName() + "[" + sg->getDendriticDelayOffset("", "$(1)") + postIdx + "] += $(0)");
+                                    functionSubstitute(SDcode, "addToInSynDelay", 2, "denDelay" + sg->getPSModelTargetName() + "[" + sg->getDendriticDelayOffset("", "$(1)") + postIdx + "] += $(0)");
                                 }
                                 else {
-                                    functionSubstitute(SDcode, "addToInSyn", 1, "inSyn" + sg->getTargetMergedPSMName() + "[" + postIdx + "] += $(0)");
+                                    functionSubstitute(SDcode, "addToInSyn", 1, "inSyn" + sg->getPSModelTargetName() + "[" + postIdx + "] += $(0)");
 
                                     // **DEPRECATED**
                                     substitute(SDcode, "$(updatelinsyn)", "$(inSyn) += $(addtoinSyn)");
-                                    substitute(SDcode, "$(inSyn)", "inSyn" + sg->getTargetMergedPSMName() + "[" + postIdx + "]");
+                                    substitute(SDcode, "$(inSyn)", "inSyn" + sg->getPSModelTargetName() + "[" + postIdx + "]");
                                 }
 
                                 StandardSubstitutions::weightUpdateDynamics(SDcode, sg, wuVars, wuDerivedParams, wuExtraGlobalParams,
@@ -559,14 +559,14 @@ void genSynapseFunction(const NNmodel &model, //!< Model description
 
                                     const std::string postIdx = "C" + s.first + ".ind[n]";
                                     if(sg->isDendriticDelayRequired()) {
-                                        functionSubstitute(SDcode, "addToInSynDelay", 2, "denDelay" + sg->getTargetMergedPSMName() + "[" + sg->getDendriticDelayOffset("", "$(1)") + postIdx + "] += $(0)");
+                                        functionSubstitute(SDcode, "addToInSynDelay", 2, "denDelay" + sg->getPSModelTargetName() + "[" + sg->getDendriticDelayOffset("", "$(1)") + postIdx + "] += $(0)");
                                     }
                                     else {
-                                        functionSubstitute(SDcode, "addToInSyn", 1, "inSyn" + sg->getTargetMergedPSMName() + "[" + postIdx + "] += $(0)");
+                                        functionSubstitute(SDcode, "addToInSyn", 1, "inSyn" + sg->getPSModelTargetName() + "[" + postIdx + "] += $(0)");
 
                                         // **DEPRECATED**
                                         substitute(SDcode, "$(updatelinsyn)", "$(inSyn) += $(addtoinSyn)");
-                                        substitute(SDcode, "$(inSyn)", "inSyn" + sg->getTargetMergedPSMName() + "[" + postIdx + "]");
+                                        substitute(SDcode, "$(inSyn)", "inSyn" + sg->getPSModelTargetName() + "[" + postIdx + "]");
                                     }
 
                                     StandardSubstitutions::weightUpdateDynamics(SDcode, sg, wuVars, wuDerivedParams, wuExtraGlobalParams,
@@ -590,14 +590,14 @@ void genSynapseFunction(const NNmodel &model, //!< Model description
                                     }
 
                                     if(sg->isDendriticDelayRequired()) {
-                                        functionSubstitute(SDcode, "addToInSynDelay", 2, "denDelay" + sg->getTargetMergedPSMName() + "[" + sg->getDendriticDelayOffset("", "$(1)") + "j] += $(0)");
+                                        functionSubstitute(SDcode, "addToInSynDelay", 2, "denDelay" + sg->getPSModelTargetName() + "[" + sg->getDendriticDelayOffset("", "$(1)") + "j] += $(0)");
                                     }
                                     else {
-                                        functionSubstitute(SDcode, "addToInSyn", 1, "inSyn" + sg->getTargetMergedPSMName() + "[j] += $(0)");
+                                        functionSubstitute(SDcode, "addToInSyn", 1, "inSyn" + sg->getPSModelTargetName() + "[j] += $(0)");
 
                                         // **DEPRECATED**
                                         substitute(SDcode, "$(updatelinsyn)", "$(inSyn) += $(addtoinSyn)");
-                                        substitute(SDcode, "$(inSyn)", "inSyn" + sg->getTargetMergedPSMName() + "[j]");
+                                        substitute(SDcode, "$(inSyn)", "inSyn" + sg->getPSModelTargetName() + "[j]");
                                     }
 
                                     StandardSubstitutions::weightUpdateDynamics(SDcode, sg, wuVars, wuDerivedParams, wuExtraGlobalParams,

--- a/lib/src/generateCPU.cc
+++ b/lib/src/generateCPU.cc
@@ -281,26 +281,26 @@ void genNeuronFunction(const NNmodel &model, //!< Model description
                         // If dendritic delay is required
                         if(sg->isDendriticDelayRequired()) {
                             // Get reference to dendritic delay buffer input for this timestep
-                            os << model.getPrecision() << " &denDelayFront" << sg->getName() << " = denDelay" + sg->getName() + "[" + sg->getDendriticDelayOffset("") + "n];" << std::endl;
+                            os << model.getPrecision() << " &denDelayFront" << sg->getPSModelTargetName() << " = denDelay" + sg->getPSModelTargetName() + "[" + sg->getDendriticDelayOffset("") + "n];" << std::endl;
 
                             // Add delayed input from buffer into inSyn
-                            os << "inSyn" + sg->getName() + "[n] += denDelayFront" << sg->getName() << ";" << std::endl;
+                            os << "inSyn" + sg->getPSModelTargetName() + "[n] += denDelayFront" << sg->getPSModelTargetName() << ";" << std::endl;
 
                             // Zero delay buffer slot
-                            os << "denDelayFront" << sg->getName() << " = " << model.scalarExpr(0.0) << ";" << std::endl;
+                            os << "denDelayFront" << sg->getPSModelTargetName() << " = " << model.scalarExpr(0.0) << ";" << std::endl;
                         }
 
                         if (sg->getMatrixType() & SynapseMatrixWeight::INDIVIDUAL_PSM) {
                             for(const auto &v : psm->getVars()) {
-                                os << v.second << " lps" << v.first << sg->getName();
-                                os << " = " <<  v.first << sg->getName() << "[n];" << std::endl;
+                                os << v.second << " lps" << v.first << sg->getPSModelTargetName();
+                                os << " = " <<  v.first << sg->getPSModelTargetName() << "[n];" << std::endl;
                             }
                         }
 
                         // Apply substitutions to current converter code
                         string psCode = psm->getApplyInputCode();
                         substitute(psCode, "$(id)", "n");
-                        substitute(psCode, "$(inSyn)", "inSyn" + sg->getName() + "[n]");
+                        substitute(psCode, "$(inSyn)", "inSyn" + sg->getPSModelTargetName() + "[n]");
                         StandardSubstitutions::postSynapseApplyInput(psCode, sg, n.second,
                             nmVars, nmDerivedParams, nmExtraGlobalParams, cpuFunctions, model.getPrecision(), "rng");
 

--- a/lib/src/generateInit.cc
+++ b/lib/src/generateInit.cc
@@ -341,7 +341,7 @@ unsigned int genInitializeDeviceKernel(CodeStream &os, const NNmodel &model, int
 
                             // If this synapse group's input variable should be initialised on device
                             if(sg->getInSynVarMode() & VarInit::DEVICE) {
-                                os << "dd_inSyn" << sg->getName() << "[lid] = " << model.scalarExpr(0.0) << ";" << std::endl;
+                                os << "dd_inSyn" << sg->getPSModelTargetName() << "[lid] = " << model.scalarExpr(0.0) << ";" << std::endl;
                             }
 
                             // If dendritic delays are required and these should be initialised on device
@@ -350,7 +350,7 @@ unsigned int genInitializeDeviceKernel(CodeStream &os, const NNmodel &model, int
                                 {
                                     CodeStream::Scope b(os);
                                     const std::string denDelayIndex = "(i * " + std::to_string(n.second.getNumNeurons()) + ") + lid";
-                                    os << "dd_denDelay" << sg->getName() << "[" << denDelayIndex << "] = " << model.scalarExpr(0.0) << ";" << std::endl;
+                                    os << "dd_denDelay" << sg->getPSModelTargetName() << "[" << denDelayIndex << "] = " << model.scalarExpr(0.0) << ";" << std::endl;
                                 }
                             }
 
@@ -809,15 +809,15 @@ void genInit(const NNmodel &model,      //!< Model description
                     os << "for (int i = 0; i < " << n.second.getNumNeurons() << "; i++)";
                     {
                         CodeStream::Scope b(os);
-                        os << "inSyn" << sg->getName() << "[i] = " << model.scalarExpr(0.0) << ";" << std::endl;
+                        os << "inSyn" << sg->getPSModelTargetName() << "[i] = " << model.scalarExpr(0.0) << ";" << std::endl;
                     }
                 }
 
                 if(sg->isDendriticDelayRequired()) {
-                    os << "denDelayPtr" << sg->getName() << " = 0;" << std::endl;
+                    os << "denDelayPtr" << sg->getPSModelTargetName() << " = 0;" << std::endl;
 #ifndef CPU_ONLY
-                    os << "CHECK_CUDA_ERRORS(cudaMemcpyToSymbol(dd_denDelayPtr" << sg->getName();
-                    os << ", &denDelayPtr" << sg->getName();
+                    os << "CHECK_CUDA_ERRORS(cudaMemcpyToSymbol(dd_denDelayPtr" << sg->getPSModelTargetName();
+                    os << ", &denDelayPtr" << sg->getPSModelTargetName();
                     os << ", sizeof(unsigned int), 0, cudaMemcpyHostToDevice));" << std::endl;
 #endif
 
@@ -827,7 +827,7 @@ void genInit(const NNmodel &model,      //!< Model description
                         os << "for (int i = 0; i < " << n.second.getNumNeurons() * sg->getMaxDendriticDelayTimesteps() << "; i++)";
                         {
                             CodeStream::Scope b(os);
-                            os << "denDelay" << sg->getName() << "[i] = " << model.scalarExpr(0.0) << ";" << std::endl;
+                            os << "denDelay" << sg->getPSModelTargetName() << "[i] = " << model.scalarExpr(0.0) << ";" << std::endl;
                         }
                     }
                 }
@@ -846,7 +846,7 @@ void genInit(const NNmodel &model,      //!< Model description
                             os << "for (int i = 0; i < " << n.second.getNumNeurons() << "; i++)";
                             {
                                 CodeStream::Scope b(os);
-                                os << StandardSubstitutions::initVariable(varInit, psmVars[k].first + sg->getName() + "[i]",
+                                os << StandardSubstitutions::initVariable(varInit, psmVars[k].first + sg->getPSModelTargetName() + "[i]",
                                                                           cpuFunctions, model.getPrecision(), "rng") << std::endl;
                             }
                         }

--- a/lib/src/generateKernels.cc
+++ b/lib/src/generateKernels.cc
@@ -576,29 +576,29 @@ void genNeuronKernel(const NNmodel &model, //!< Model description
                     const auto *psm = sg->getPSModel();
 
                     os << "// pull inSyn values in a coalesced access" << std::endl;
-                    os << model.getPrecision() << " linSyn" << sg->getName() << " = dd_inSyn" << sg->getName() << "[" << localID << "];" << std::endl;
+                    os << model.getPrecision() << " linSyn" << sg->getPSModelTargetName() << " = dd_inSyn" << sg->getPSModelTargetName() << "[" << localID << "];" << std::endl;
 
                     // If dendritic delay is required
                     if(sg->isDendriticDelayRequired()) {
                         // Get reference to dendritic delay buffer input for this timestep
-                        os << model.getPrecision() << " &denDelayFront" << sg->getName() << " = dd_denDelay" + sg->getName() + "[" + sg->getDendriticDelayOffset("dd_") + localID + "];" << std::endl;
+                        os << model.getPrecision() << " &denDelayFront" << sg->getPSModelTargetName() << " = dd_denDelay" + sg->getPSModelTargetName() + "[" + sg->getDendriticDelayOffset("dd_") + localID + "];" << std::endl;
 
                         // Add delayed input from buffer into inSyn
-                        os << "linSyn" + sg->getName() + " += denDelayFront" << sg->getName() << ";" << std::endl;
+                        os << "linSyn" + sg->getPSModelTargetName() + " += denDelayFront" << sg->getPSModelTargetName() << ";" << std::endl;
 
                         // Zero delay buffer slot
-                        os << "denDelayFront" << sg->getName() << " = " << model.scalarExpr(0.0) << ";" << std::endl;
+                        os << "denDelayFront" << sg->getPSModelTargetName() << " = " << model.scalarExpr(0.0) << ";" << std::endl;
                     }
 
                     if (sg->getMatrixType() & SynapseMatrixWeight::INDIVIDUAL_PSM) {
                         for(const auto &v : psm->getVars()) {
-                            os << v.second << " lps" << v.first << sg->getName();
-                            os << " = dd_" <<  v.first << sg->getName() << "[" << localID << "];" << std::endl;
+                            os << v.second << " lps" << v.first << sg->getPSModelTargetName();
+                            os << " = dd_" <<  v.first << sg->getPSModelTargetName() << "[" << localID << "];" << std::endl;
                         }
                     }
                     string psCode = psm->getApplyInputCode();
                     substitute(psCode, "$(id)", localID);
-                    substitute(psCode, "$(inSyn)", "linSyn" + sg->getName());
+                    substitute(psCode, "$(inSyn)", "linSyn" + sg->getPSModelTargetName());
                     StandardSubstitutions::postSynapseApplyInput(psCode, sg, n->second,
                         nmVars, nmDerivedParams, nmExtraGlobalParams,
                         cudaFunctions, model.getPrecision(), rngName);
@@ -698,7 +698,7 @@ void genNeuronKernel(const NNmodel &model, //!< Model description
 
                     string pdCode = psm->getDecayCode();
                     substitute(pdCode, "$(id)", localID);
-                    substitute(pdCode, "$(inSyn)", "linSyn" + sg->getName());
+                    substitute(pdCode, "$(inSyn)", "linSyn" + sg->getPSModelTargetName());
                     StandardSubstitutions::postSynapseDecay(pdCode, sg, n->second,
                                                             nmVars, nmDerivedParams, nmExtraGlobalParams,
                                                             cudaFunctions, model.getPrecision(), rngName);
@@ -710,9 +710,9 @@ void genNeuronKernel(const NNmodel &model, //!< Model description
                         os << CodeStream::CB(29) << " // namespace bracket closed" << endl;
                     }
 
-                    os << "dd_inSyn"  << sg->getName() << "[" << localID << "] = linSyn" << sg->getName() << ";" << std::endl;
+                    os << "dd_inSyn"  << sg->getPSModelTargetName() << "[" << localID << "] = linSyn" << sg->getPSModelTargetName() << ";" << std::endl;
                     for(const auto &v : psm->getVars()) {
-                        os << "dd_" <<  v.first << sg->getName() << "[" << localID << "] = lps" << v.first << sg->getName() << ";"<< std::endl;
+                        os << "dd_" <<  v.first << sg->getPSModelTargetName() << "[" << localID << "] = lps" << v.first << sg->getPSModelTargetName() << ";"<< std::endl;
                     }
                 }
 
@@ -845,7 +845,7 @@ void genSynapseKernel(const NNmodel &model, //!< Model description
                         {
                             CodeStream::Scope b(os);
 
-                            os << "dd_denDelayPtr" << sg->getName() << " = (dd_denDelayPtr" << sg->getName() << " + 1) % " << sg->getMaxDendriticDelayTimesteps() << ";" << std::endl;
+                            os << "dd_denDelayPtr" << sg->getPSModelTargetName() << " = (dd_denDelayPtr" << sg->getPSModelTargetName() << " + 1) % " << sg->getMaxDendriticDelayTimesteps() << ";" << std::endl;
                         }
                     }
                 }

--- a/lib/src/generateKernels.cc
+++ b/lib/src/generateKernels.cc
@@ -163,7 +163,7 @@ void generatePreParallelisedSparseCode(
 
             // If dendritic delay is required, always use atomic operation to update dendritic delay buffer
             if(sg.isDendriticDelayRequired()) {
-                functionSubstitute(wCode, "addToInSynDelay", 2, getFloatAtomicAdd(ftype) + "(&dd_denDelay" + sg.getTargetMergedPSMName() + "[" + sg.getDendriticDelayOffset("dd_", "$(1)") + "ipost], $(0))");
+                functionSubstitute(wCode, "addToInSynDelay", 2, getFloatAtomicAdd(ftype) + "(&dd_denDelay" + sg.getPSModelTargetName() + "[" + sg.getDendriticDelayOffset("dd_", "$(1)") + "ipost], $(0))");
             }
             // Otherwise
             else {
@@ -178,9 +178,9 @@ void generatePreParallelisedSparseCode(
                 }
                 // Otherwise, substitute global memory array for $(inSyn)
                 else {
-                    functionSubstitute(wCode, "addToInSyn", 1, getFloatAtomicAdd(ftype) + "(&dd_inSyn" + sg.getTargetMergedPSMName() + "[ipost], $(0))");
+                    functionSubstitute(wCode, "addToInSyn", 1, getFloatAtomicAdd(ftype) + "(&dd_inSyn" + sg.getPSModelTargetName() + "[ipost], $(0))");
 
-                    substitute(wCode, "$(inSyn)", "dd_inSyn" + sg.getTargetMergedPSMName() + "[ipost]");
+                    substitute(wCode, "$(inSyn)", "dd_inSyn" + sg.getPSModelTargetName() + "[ipost]");
                 }
             }
 
@@ -301,7 +301,7 @@ void generatePostParallelisedCode(
 
                 // If dendritic delay is required, always use atomic operation to update dendritic delay buffer
                 if(sg.isDendriticDelayRequired()) {
-                    functionSubstitute(wCode, "addToInSynDelay", 2, getFloatAtomicAdd(ftype) + "(&dd_denDelay" + sg.getTargetMergedPSMName() + "[" + sg.getDendriticDelayOffset("dd_", "$(1)") + "ipost], $(0))");
+                    functionSubstitute(wCode, "addToInSynDelay", 2, getFloatAtomicAdd(ftype) + "(&dd_denDelay" + sg.getPSModelTargetName() + "[" + sg.getDendriticDelayOffset("dd_", "$(1)") + "ipost], $(0))");
                 }
                 // Otherwise
                 else {
@@ -315,11 +315,11 @@ void generatePostParallelisedCode(
                             substitute(wCode, "$(inSyn)", "shLg[ipost]");
                         }
                         else {
-                            functionSubstitute(wCode, "addToInSyn", 1, getFloatAtomicAdd(ftype) + "(&dd_inSyn" + sg.getTargetMergedPSMName() + "[ipost], $(0))");
+                            functionSubstitute(wCode, "addToInSyn", 1, getFloatAtomicAdd(ftype) + "(&dd_inSyn" + sg.getPSModelTargetName() + "[ipost], $(0))");
 
                             // **DEPRECATED**
                             substitute(wCode, "$(updatelinsyn)", getFloatAtomicAdd(ftype) + "(&$(inSyn), $(addtoinSyn))");
-                            substitute(wCode, "$(inSyn)", "dd_inSyn" + sg.getTargetMergedPSMName() + "[ipost]");
+                            substitute(wCode, "$(inSyn)", "dd_inSyn" + sg.getPSModelTargetName() + "[ipost]");
                         }
                     }
                     else {
@@ -947,15 +947,15 @@ void genSynapseKernel(const NNmodel &model, //!< Model description
 
                                 // If dendritic delay is required, always use atomic operation to update dendritic delay buffer
                                 if(sg->isDendriticDelayRequired()) {
-                                    functionSubstitute(SDcode, "addToInSynDelay", 2, getFloatAtomicAdd(model.getPrecision()) + "(&dd_denDelay" + sg->getTargetMergedPSMName() + "[" + sg->getDendriticDelayOffset("dd_", "$(1)") + postIdx + "], $(0))");
+                                    functionSubstitute(SDcode, "addToInSynDelay", 2, getFloatAtomicAdd(model.getPrecision()) + "(&dd_denDelay" + sg->getPSModelTargetName() + "[" + sg->getDendriticDelayOffset("dd_", "$(1)") + postIdx + "], $(0))");
                                 }
                                 // Otherwise
                                 else {
-                                    functionSubstitute(SDcode, "addToInSyn", 1, getFloatAtomicAdd(model.getPrecision()) + "(&dd_inSyn" + sg->getTargetMergedPSMName() + "[" + postIdx + "], $(0))");
+                                    functionSubstitute(SDcode, "addToInSyn", 1, getFloatAtomicAdd(model.getPrecision()) + "(&dd_inSyn" + sg->getPSModelTargetName() + "[" + postIdx + "], $(0))");
 
                                     // **DEPRECATED**
                                     substitute(SDcode, "$(updatelinsyn)", getFloatAtomicAdd(model.getPrecision()) + "(&$(inSyn), $(addtoinSyn))");
-                                    substitute(SDcode, "$(inSyn)", "dd_inSyn" + sg->getTargetMergedPSMName() + "[" + postIdx + "]");
+                                    substitute(SDcode, "$(inSyn)", "dd_inSyn" + sg->getPSModelTargetName() + "[" + postIdx + "]");
                                 }
 
                                 StandardSubstitutions::weightUpdateDynamics(SDcode, sg, wuVars, wuDerivedParams, wuExtraGlobalParams,
@@ -980,15 +980,15 @@ void genSynapseKernel(const NNmodel &model, //!< Model description
 
                                 // If dendritic delay is required, always use atomic operation to update dendritic delay buffer
                                 if(sg->isDendriticDelayRequired()) {
-                                    functionSubstitute(SDcode, "addToInSynDelay", 2, getFloatAtomicAdd(model.getPrecision()) + "(&dd_denDelay" + sg->getTargetMergedPSMName() + "[" + sg->getDendriticDelayOffset("dd_", "$(1)") + postIdx + "], $(0))");
+                                    functionSubstitute(SDcode, "addToInSynDelay", 2, getFloatAtomicAdd(model.getPrecision()) + "(&dd_denDelay" + sg->getPSModelTargetName() + "[" + sg->getDendriticDelayOffset("dd_", "$(1)") + postIdx + "], $(0))");
                                 }
                                 // Otherwise
                                 else {
-                                    functionSubstitute(SDcode, "addToInSyn", 1, getFloatAtomicAdd(model.getPrecision()) + "(&dd_inSyn" + sg->getTargetMergedPSMName() + "[" + postIdx + "], $(0))");
+                                    functionSubstitute(SDcode, "addToInSyn", 1, getFloatAtomicAdd(model.getPrecision()) + "(&dd_inSyn" + sg->getPSModelTargetName() + "[" + postIdx + "], $(0))");
 
                                     // **DEPRECATED**
                                     substitute(SDcode, "$(updatelinsyn)", getFloatAtomicAdd(model.getPrecision()) + "(&$(inSyn), $(addtoinSyn))");
-                                    substitute(SDcode, "$(inSyn)", "dd_inSyn" + sg->getTargetMergedPSMName() + "[" + postIdx + "]");
+                                    substitute(SDcode, "$(inSyn)", "dd_inSyn" + sg->getPSModelTargetName() + "[" + postIdx + "]");
                                 }
 
                                 StandardSubstitutions::weightUpdateDynamics(SDcode, sg, wuVars, wuDerivedParams, wuExtraGlobalParams,
@@ -1091,7 +1091,7 @@ void genSynapseKernel(const NNmodel &model, //!< Model description
                     os << "if (" << localID << " < " << s->second.getTrgNeuronGroup()->getNumNeurons() << ")";
                     {
                         CodeStream::Scope b(os);
-                        os << "linSyn = dd_inSyn" << s->second.getTargetMergedPSMName() << "[" << localID << "];" << std::endl;
+                        os << "linSyn = dd_inSyn" << s->second.getPSModelTargetName() << "[" << localID << "];" << std::endl;
                     }
                 }
                 // Otherwise, if we are going to accumulate into shared memory, copy current value into correct array index
@@ -1100,7 +1100,7 @@ void genSynapseKernel(const NNmodel &model, //!< Model description
                     os << "if (threadIdx.x < " << s->second.getTrgNeuronGroup()->getNumNeurons() << ")";
                     {
                         CodeStream::Scope b(os);
-                        os << "shLg[threadIdx.x] = dd_inSyn" << s->second.getTargetMergedPSMName() << "[threadIdx.x];"<< std::endl;
+                        os << "shLg[threadIdx.x] = dd_inSyn" << s->second.getPSModelTargetName() << "[threadIdx.x];"<< std::endl;
                     }
                     os << "__syncthreads();" << std::endl;
                 }
@@ -1144,7 +1144,7 @@ void genSynapseKernel(const NNmodel &model, //!< Model description
                     os << "if (" << localID << " < " << s->second.getTrgNeuronGroup()->getNumNeurons() << ")";
                     {
                         CodeStream::Scope b(os);
-                        os << "dd_inSyn" << s->second.getTargetMergedPSMName() << "[" << localID << "] = linSyn;" << std::endl;
+                        os << "dd_inSyn" << s->second.getPSModelTargetName() << "[" << localID << "] = linSyn;" << std::endl;
                     }
                 }
                 // Otherwise, if we have been accumulating into shared memory, write value back to global memory
@@ -1154,7 +1154,7 @@ void genSynapseKernel(const NNmodel &model, //!< Model description
                     os << "if (threadIdx.x < " << s->second.getTrgNeuronGroup()->getNumNeurons() << ")";
                     {
                         CodeStream::Scope b(os);
-                        os << "dd_inSyn" << s->second.getTargetMergedPSMName() << "[threadIdx.x] = shLg[threadIdx.x];"<< std::endl;
+                        os << "dd_inSyn" << s->second.getPSModelTargetName() << "[threadIdx.x] = shLg[threadIdx.x];"<< std::endl;
                     }
                 }
 

--- a/lib/src/generateRunner.cc
+++ b/lib/src/generateRunner.cc
@@ -661,6 +661,33 @@ void genDefinitions(const NNmodel &model,   //!< Model description
     }
     os << std::endl;
 
+    //----------------------------------
+    // HOST AND DEVICE POSTSYNAPTIC VARIABLES
+
+     os << "// ------------------------------------------------------------------------" << std::endl;
+    os << "// postsynaptic variables" << std::endl;
+    os << std::endl;
+    for(const auto &n : model.getLocalNeuronGroups()) {
+        // Loop through incoming synaptic populations
+        for(const auto &m : n.second.getMergedInSyn()) {
+            const auto *sg = m.first;
+
+            extern_variable_def(os, model.getPrecision() + " *", "inSyn" + sg->getName(), sg->getInSynVarMode());
+
+            if (sg->isDendriticDelayRequired()) {
+                extern_variable_def(os, model.getPrecision() + " *", "denDelay" + sg->getName(), sg->getDendriticDelayVarMode());
+                os << varExportPrefix << " unsigned int denDelayPtr" << sg->getName() << ";" << std::endl;
+            }
+
+            if (sg->getMatrixType() & SynapseMatrixWeight::INDIVIDUAL_PSM) {
+                for(const auto &v : sg->getPSModel()->getVars()) {
+                    extern_variable_def(os, v.second + " *", v.first + sg->getName(), sg->getPSVarMode(v.first));
+                }
+            }
+        }
+    }
+    os << std::endl;
+
 
     //----------------------------------
     // HOST AND DEVICE SYNAPSE VARIABLES
@@ -670,13 +697,6 @@ void genDefinitions(const NNmodel &model,   //!< Model description
     os << std::endl;
 
     for(const auto &s : model.getLocalSynapseGroups()) {
-        extern_variable_def(os, model.getPrecision() + " *", "inSyn" + s.first, s.second.getInSynVarMode());
-
-        if (s.second.isDendriticDelayRequired()) {
-            extern_variable_def(os, model.getPrecision() + " *", "denDelay" + s.first, s.second.getDendriticDelayVarMode());
-            os << varExportPrefix << " unsigned int denDelayPtr" << s.first << ";" << std::endl;
-        }
-
         if (s.second.getMatrixType() & SynapseMatrixConnectivity::BITMASK) {
             extern_variable_def(os, "uint32_t *", "gp" + s.first, VarMode::LOC_HOST_DEVICE_INIT_HOST);
         }
@@ -694,12 +714,6 @@ void genDefinitions(const NNmodel &model,   //!< Model description
             }
         }
         
-        if (s.second.getMatrixType() & SynapseMatrixWeight::INDIVIDUAL_PSM) {
-            for(const auto &v : s.second.getPSModel()->getVars()) {
-                extern_variable_def(os, v.second + " *", v.first + s.first, s.second.getPSVarMode(v.first));
-            }
-        }
-
         for(auto const &p : s.second.getWUModel()->getExtraGlobalParams()) {
             os << "extern " << p.second << " " << p.first + s.first << ";" << std::endl;
         }
@@ -1239,6 +1253,34 @@ void genRunner(const NNmodel &model,    //!< Model description
     }
     os << std::endl;
 
+    os << "// ------------------------------------------------------------------------" << std::endl;
+    os << "// postsynaptic variables" << std::endl;
+    for(const auto &n : model.getLocalNeuronGroups()) {
+        // Loop through incoming synaptic populations
+        for(const auto &m : n.second.getMergedInSyn()) {
+            const auto *sg = m.first;
+
+            variable_def(os, model.getPrecision() + " *", "inSyn" + sg->getName(), sg->getInSynVarMode());
+
+            if(sg->isDendriticDelayRequired()) {
+                variable_def(os, model.getPrecision() + " *", "denDelay" + sg->getName(), sg->getDendriticDelayVarMode());
+
+                os << "unsigned int denDelayPtr" << sg->getName() << ";" << std::endl;
+#ifndef CPU_ONLY
+                os << "__device__ volatile unsigned int dd_denDelayPtr" << sg->getName() << ";" << std::endl;
+#endif
+            }
+
+            // If postsynaptic model variables should be individual
+            if (sg->getMatrixType() & SynapseMatrixWeight::INDIVIDUAL_PSM) {
+                for(const auto &v : sg->getPSModel()->getVars()) {
+                    variable_def(os, v.second+" *", v.first + sg->getName(), sg->getPSVarMode(v.first));
+                }
+            }
+
+        }
+    }
+    os << std::endl;
 
     //----------------------------------
     // HOST AND DEVICE SYNAPSE VARIABLES
@@ -1249,18 +1291,6 @@ void genRunner(const NNmodel &model,    //!< Model description
 
    for(const auto &s : model.getLocalSynapseGroups()) {
         const auto *wu = s.second.getWUModel();
-        const auto *psm = s.second.getPSModel();
-
-        variable_def(os, model.getPrecision() + " *", "inSyn" + s.first, s.second.getInSynVarMode());
-
-        if(s.second.isDendriticDelayRequired()) {
-            variable_def(os, model.getPrecision() + " *", "denDelay" + s.first, s.second.getDendriticDelayVarMode());
-
-            os << "unsigned int denDelayPtr" << s.first << ";" << std::endl;
-#ifndef CPU_ONLY
-            os << "__device__ volatile unsigned int dd_denDelayPtr" << s.first << ";" << std::endl;
-#endif
-        }
 
         if (s.second.getMatrixType() & SynapseMatrixConnectivity::BITMASK) {
             variable_def(os, "uint32_t *", "gp"+s.first, VarMode::LOC_HOST_DEVICE_INIT_HOST);
@@ -1315,12 +1345,6 @@ void genRunner(const NNmodel &model,    //!< Model description
         if (s.second.getMatrixType() & SynapseMatrixWeight::INDIVIDUAL) {
             for(const auto &v : wu->getVars()) {
                 variable_def(os, v.second + " *", v.first + s.first, s.second.getWUVarMode(v.first));
-            }
-        }
-        // If postsynaptic model variables should be individual
-        if (s.second.getMatrixType() & SynapseMatrixWeight::INDIVIDUAL_PSM) {
-            for(const auto &v : psm->getVars()) {
-                variable_def(os, v.second+" *", v.first + s.first, s.second.getPSVarMode(v.first));
             }
         }
 
@@ -1526,23 +1550,40 @@ void genRunner(const NNmodel &model,    //!< Model description
                 mem += allocate_variable(os, v.second, v.first + n.first, n.second.getVarMode(v.first),
                                         n.second.isVarQueueRequired(v.first) ? n.second.getNumNeurons() * n.second.getNumDelaySlots() : n.second.getNumNeurons());
             }
+
             os << std::endl;
+        }
+
+        // ALLOCATE POSTSYNAPTIC VARIABLES
+        for(const auto &n : model.getLocalNeuronGroups()) {
+            // Loop through incoming synaptic populations
+            for(const auto &m : n.second.getMergedInSyn()) {
+                const auto *sg = m.first;
+
+                // Allocate buffer to hold input coming from this synapse population
+                mem += allocate_variable(os, model.getPrecision(), "inSyn" + sg->getName(), sg->getInSynVarMode(),
+                                         sg->getTrgNeuronGroup()->getNumNeurons());
+
+                // Allocate buffer to delay input coming from this synapse population
+                if(sg->isDendriticDelayRequired()) {
+                    mem += allocate_variable(os, model.getPrecision(), "denDelay" + sg->getName(), sg->getDendriticDelayVarMode(),
+                                             sg->getMaxDendriticDelaySlots() * sg->getTrgNeuronGroup()->getNumNeurons());
+                }
+
+                if (sg->getMatrixType() & SynapseMatrixWeight::INDIVIDUAL_PSM) {
+                    const size_t size = sg->getTrgNeuronGroup()->getNumNeurons();
+
+                    for(const auto &v : sg->getPSModel()->getVars()) {
+                        mem += allocate_variable(os, v.second, v.first + sg->getName(), sg->getPSVarMode(v.first), size);
+                    }
+                }
+            }
         }
 
         // ALLOCATE SYNAPSE VARIABLES
         for(const auto &s : model.getLocalSynapseGroups()) {
             const auto *wu = s.second.getWUModel();
-            const auto *psm = s.second.getPSModel();
 
-            // Allocate buffer to hold input coming from this synapse population
-            mem += allocate_variable(os, model.getPrecision(), "inSyn" + s.first, s.second.getInSynVarMode(),
-                                     s.second.getTrgNeuronGroup()->getNumNeurons());
-
-            // Allocate buffer to delay input coming from this synapse population
-            if(s.second.isDendriticDelayRequired()) {
-                mem += allocate_variable(os, model.getPrecision(), "denDelay" + s.first, s.second.getDendriticDelayVarMode(),
-                                         s.second.getMaxDendriticDelaySlots() * s.second.getTrgNeuronGroup()->getNumNeurons());
-            }
             // If connectivity is defined using a bitmask, allocate memory for bitmask
             if (s.second.getMatrixType() & SynapseMatrixConnectivity::BITMASK) {
                 const size_t gpSize = (s.second.getSrcNeuronGroup()->getNumNeurons() * s.second.getTrgNeuronGroup()->getNumNeurons()) / 32 + 1;
@@ -1602,14 +1643,6 @@ void genRunner(const NNmodel &model,    //!< Model description
 
                 for(const auto &v : wu->getVars()) {
                     mem += allocate_variable(os, v.second, v.first + s.first, s.second.getWUVarMode(v.first), size);
-                }
-            }
-
-            if (s.second.getMatrixType() & SynapseMatrixWeight::INDIVIDUAL_PSM) {
-                const size_t size = s.second.getTrgNeuronGroup()->getNumNeurons();
-
-                for(const auto &v : psm->getVars()) {
-                    mem += allocate_variable(os, v.second, v.first + s.first, s.second.getPSVarMode(v.first), size);
                 }
             }
             os << std::endl;
@@ -1747,14 +1780,28 @@ void genRunner(const NNmodel &model,    //!< Model description
             }
         }
 
+        // FREE POSTSYNAPTIC VARIABLES
+        for(const auto &n : model.getLocalNeuronGroups()) {
+            // Loop through incoming synaptic populations
+            for(const auto &m : n.second.getMergedInSyn()) {
+                const auto *sg = m.first;
+
+                free_variable(os, "inSyn" + sg->getName(), sg->getInSynVarMode());
+
+                if(sg->isDendriticDelayRequired()) {
+                    free_variable(os, "denDelay" + sg->getName(), sg->getDendriticDelayVarMode());
+                }
+
+                if (sg->getMatrixType() & SynapseMatrixWeight::INDIVIDUAL_PSM) {
+                    for(const auto &v : sg->getPSModel()->getVars()) {
+                        free_variable(os, v.first + sg->getName(), sg->getPSVarMode(v.first));
+                    }
+                }
+            }
+        }
+
         // FREE SYNAPSE VARIABLES
         for(const auto &s : model.getLocalSynapseGroups()) {
-            free_variable(os, "inSyn" + s.first, s.second.getInSynVarMode());
-
-            if(s.second.isDendriticDelayRequired()) {
-                free_variable(os, "denDelay" + s.first, s.second.getDendriticDelayVarMode());
-            }
-
             if (s.second.getMatrixType() & SynapseMatrixConnectivity::YALE) {
                 os << "C" << s.first << ".connN= 0;" << std::endl;
 
@@ -1807,11 +1854,6 @@ void genRunner(const NNmodel &model,    //!< Model description
             if (s.second.getMatrixType() & SynapseMatrixWeight::INDIVIDUAL) {
                 for(const auto &v : s.second.getWUModel()->getVars()) {
                     free_variable(os, v.first + s.first, s.second.getWUVarMode(v.first));
-                }
-            }
-            if (s.second.getMatrixType() & SynapseMatrixWeight::INDIVIDUAL_PSM) {
-                for(const auto &v : s.second.getPSModel()->getVars()) {
-                    free_variable(os, v.first + s.first, s.second.getPSVarMode(v.first));
                 }
             }
         }
@@ -2208,6 +2250,7 @@ void genRunnerGPU(const NNmodel &model, //!< Model description
             }
 
             // If synapse input variables can be pushed and pulled add copy code
+            // **TODO** sensible merging behaviour
             if(canPushPullVar(s.second.getInSynVarMode())) {
                 // If variable is initialised on device, only copy if hostInitialisedOnly isn't set
                 if(s.second.getInSynVarMode() & VarInit::DEVICE) {
@@ -2223,6 +2266,7 @@ void genRunnerGPU(const NNmodel &model, //!< Model description
             }
 
             // If dendritic delay variables can be pushed and pulled add copy code
+            // **TODO** sensible merging behaviour
             if(s.second.isDendriticDelayRequired() && canPushPullVar(s.second.getDendriticDelayVarMode())) {
                 // If variable is initialised on device, only copy if hostInitialisedOnly isn't set
                 if(s.second.getDendriticDelayVarMode() & VarInit::DEVICE) {
@@ -2374,12 +2418,14 @@ void genRunnerGPU(const NNmodel &model, //!< Model description
                 os << ", " << size << " * sizeof(uint32_t), cudaMemcpyDeviceToHost));" << std::endl;
             }
 
+            // **TODO** sensible merging behaviour
             if(canPushPullVar(s.second.getInSynVarMode())) {
                 os << "CHECK_CUDA_ERRORS(cudaMemcpy(inSyn" << s.first;
                 os << ", d_inSyn" << s.first;
                 os << ", " << numTrgNeurons << " * sizeof(" << model.getPrecision() << "), cudaMemcpyDeviceToHost));" << std::endl;
             }
 
+            // **TODO** sensible merging behaviour
             if(s.second.isDendriticDelayRequired() && canPushPullVar(s.second.getDendriticDelayVarMode())) {
                 os << "CHECK_CUDA_ERRORS(cudaMemcpy(denDelay" << s.first;
                 os << ", d_denDelay" << s.first;

--- a/lib/src/generateRunner.cc
+++ b/lib/src/generateRunner.cc
@@ -203,9 +203,11 @@ void genHostSpikeQueueAdvance(CodeStream &os, const NNmodel &model, int localHos
 
 void genHostDenDelayAdvance(CodeStream &os, const NNmodel &model)
 {
-	for(const auto &s : model.getLocalSynapseGroups()) {
-        if(s.second.isDendriticDelayRequired()) {
-            os << "denDelayPtr" << s.first << " = (denDelayPtr" << s.first << " + 1) % " << s.second.getMaxDendriticDelaySlots() << ";" << std::endl;
+    for(const auto &n : model.getLocalNeuronGroups()) {
+        // Loop through incoming synaptic populations
+        for(const auto &m : n.second.getMergedInSyn()) {
+            const auto *sg = m.first;
+            os << "denDelayPtr" << sg->getName() << " = (denDelayPtr" << sg->getName() << " + 1) % " << sg->getMaxDendriticDelaySlots() << ";" << std::endl;
         }
     }
 }

--- a/lib/src/generateRunner.cc
+++ b/lib/src/generateRunner.cc
@@ -207,7 +207,9 @@ void genHostDenDelayAdvance(CodeStream &os, const NNmodel &model)
         // Loop through incoming synaptic populations
         for(const auto &m : n.second.getMergedInSyn()) {
             const auto *sg = m.first;
-            os << "denDelayPtr" << sg->getName() << " = (denDelayPtr" << sg->getName() << " + 1) % " << sg->getMaxDendriticDelaySlots() << ";" << std::endl;
+            if(sg->isDendriticDelayRequired()) {
+                os << "denDelayPtr" << sg->getName() << " = (denDelayPtr" << sg->getName() << " + 1) % " << sg->getMaxDendriticDelaySlots() << ";" << std::endl;
+            }
         }
     }
 }

--- a/lib/src/global.cc
+++ b/lib/src/global.cc
@@ -39,6 +39,7 @@ namespace GENN_PREFERENCES {
     bool showPtxInfo = false; //!< Request that PTX assembler information be displayed for each CUDA kernel during compilation
     bool buildSharedLibrary = false;   //!< Should generated code and Makefile build into a shared library e.g. for use in SpineML simulator
     bool autoInitSparseVars = false; //!< Previously, variables associated with sparse synapse populations were not automatically initialised. If this flag is set this now occurs in the initMODEL_NAME function and copyStateToDevice is deferred until here
+    bool mergePostsynapticModels = false; //!< Should compatible postsynaptic models and dendritic delay buffers be merged? This can significantly reduce the cost of updating neuron population but means that per-synapse group inSyn arrays can not be retrieved
     VarMode defaultVarMode = VarMode::LOC_HOST_DEVICE_INIT_HOST;  //!< What is the default behaviour for model state variables? Historically, everything was allocated on both host AND device and initialised on HOST.
     double asGoodAsZero = 1e-19; //!< Global variable that is used when detecting close to zero values, for example when setting sparse connectivity from a dense matrix
     int defaultDevice= 0; //! default GPU device; used to determine which GPU to use if chooseDevice is 0 (off)

--- a/lib/src/modelSpec.cc
+++ b/lib/src/modelSpec.cc
@@ -1031,7 +1031,9 @@ void NNmodel::finalize()
 
     // Merge incoming postsynaptic models
     for(auto &n : m_LocalNeuronGroups) {
-        n.second.mergeIncomingPSM();
+        if(!n.second.getInSyn().empty()) {
+            n.second.mergeIncomingPSM();
+        }
     }
     //assert(false);
 

--- a/lib/src/modelSpec.cc
+++ b/lib/src/modelSpec.cc
@@ -19,6 +19,7 @@
 // Standard C++ includes
 #include <algorithm>
 #include <numeric>
+#include <typeinfo>
 
 // Standard C includes
 #include <cstdio>
@@ -1027,6 +1028,12 @@ void NNmodel::finalize()
         s.second.addExtraGlobalPostLearnParams(simLearnPostKernelParameters);
         s.second.addExtraGlobalSynapseDynamicsParams(synapseDynamicsKernelParameters);
     }
+
+    // Merge incoming postsynaptic models
+    for(auto &n : m_LocalNeuronGroups) {
+        n.second.mergeIncomingPSM();
+    }
+    //assert(false);
 
     setPopulationSums();
 

--- a/lib/src/neuronGroup.cc
+++ b/lib/src/neuronGroup.cc
@@ -125,6 +125,7 @@ void NeuronGroup::mergeIncomingPSM()
             // If synapse population b has the same model type as a and; their varmodes, parameters and derived parameters match
             if(typeid((*b)->getPSModel()).hash_code() == aModelTypeHash
                 && a->getInSynVarMode() == (*b)->getInSynVarMode()
+                && a->getMaxDendriticDelaySlots() == (*b)->getMaxDendriticDelaySlots()
                 && std::equal(aParamsBegin, aParamsEnd, (*b)->getPSParams().cbegin())
                 && std::equal(aDerivedParamsBegin, aDerivedParamsEnd, (*b)->getPSDerivedParams().cbegin()))
             {

--- a/lib/src/standardGeneratedSections.cc
+++ b/lib/src/standardGeneratedSections.cc
@@ -77,7 +77,7 @@ void StandardGeneratedSections::neuronSpikeEventTest(
     const VarNameIterCtx &nmVars,
     const ExtraGlobalParamNameIterCtx &nmExtraGlobalParams,
     const std::string &,
-    const std::vector<FunctionTemplate> functions,
+    const std::vector<FunctionTemplate> &functions,
     const std::string &ftype,
     const std::string &rng)
 {

--- a/lib/src/standardSubstitutions.cc
+++ b/lib/src/standardSubstitutions.cc
@@ -14,7 +14,7 @@ void StandardSubstitutions::postSynapseApplyInput(
     const VarNameIterCtx &nmVars,
     const DerivedParamNameIterCtx &nmDerivedParams,
     const ExtraGlobalParamNameIterCtx &nmExtraGlobalParams,
-    const std::vector<FunctionTemplate> functions,
+    const std::vector<FunctionTemplate> &functions,
     const std::string &ftype,
     const std::string &rng)
 {
@@ -55,7 +55,7 @@ void StandardSubstitutions::postSynapseDecay(
     const VarNameIterCtx &nmVars,
     const DerivedParamNameIterCtx &nmDerivedParams,
     const ExtraGlobalParamNameIterCtx &,
-    const std::vector<FunctionTemplate> functions,
+    const std::vector<FunctionTemplate> &functions,
     const std::string &ftype,
     const std::string &rng)
 {
@@ -85,7 +85,7 @@ void StandardSubstitutions::neuronThresholdCondition(
     const VarNameIterCtx &nmVars,
     const DerivedParamNameIterCtx &nmDerivedParams,
     const ExtraGlobalParamNameIterCtx &nmExtraGlobalParams,
-    const std::vector<FunctionTemplate> functions,
+    const std::vector<FunctionTemplate> &functions,
     const std::string &ftype,
     const std::string &rng)
 {
@@ -109,7 +109,7 @@ void StandardSubstitutions::neuronSim(
     const VarNameIterCtx &nmVars,
     const DerivedParamNameIterCtx &nmDerivedParams,
     const ExtraGlobalParamNameIterCtx &nmExtraGlobalParams,
-    const std::vector<FunctionTemplate> functions,
+    const std::vector<FunctionTemplate> &functions,
     const std::string &ftype,
     const std::string &rng)
 {
@@ -132,7 +132,7 @@ void StandardSubstitutions::neuronSpikeEventCondition(
     const NeuronGroup &ng,
     const VarNameIterCtx &nmVars,
     const ExtraGlobalParamNameIterCtx &nmExtraGlobalParams,
-    const std::vector<FunctionTemplate> functions,
+    const std::vector<FunctionTemplate> &functions,
     const std::string &ftype,
     const std::string &rng)
 {
@@ -153,7 +153,7 @@ void StandardSubstitutions::neuronReset(
     const VarNameIterCtx &nmVars,
     const DerivedParamNameIterCtx &nmDerivedParams,
     const ExtraGlobalParamNameIterCtx &nmExtraGlobalParams,
-    const std::vector<FunctionTemplate> functions,
+    const std::vector<FunctionTemplate> &functions,
     const std::string &ftype,
     const std::string &rng)
 {
@@ -179,7 +179,7 @@ void StandardSubstitutions::weightUpdateThresholdCondition(
     const string &preIdx, //!< index of the pre-synaptic neuron to be accessed for _pre variables; differs for different Span)
     const string &postIdx, //!< index of the post-synaptic neuron to be accessed for _post variables; differs for different Span)
     const string &devPrefix,
-    const std::vector<FunctionTemplate> functions,
+    const std::vector<FunctionTemplate> &functions,
     const std::string &ftype){
     value_substitutions(eCode, sg.getWUModel()->getParamNames(), sg.getWUParams());
     value_substitutions(eCode, wuDerivedParams.nameBegin, wuDerivedParams.nameEnd, sg.getWUDerivedParams());
@@ -200,7 +200,7 @@ void StandardSubstitutions::weightUpdateSim(
     const string &preIdx, //!< index of the pre-synaptic neuron to be accessed for _pre variables; differs for different Span)
     const string &postIdx, //!< index of the post-synaptic neuron to be accessed for _post variables; differs for different Span)
     const string &devPrefix,
-    const std::vector<FunctionTemplate> functions,
+    const std::vector<FunctionTemplate> &functions,
     const std::string &ftype)
 {
      if (sg.getMatrixType() & SynapseMatrixWeight::GLOBAL) {
@@ -227,7 +227,7 @@ void StandardSubstitutions::weightUpdateDynamics(
     const string &preIdx, //!< index of the pre-synaptic neuron to be accessed for _pre variables; differs for different Span)
     const string &postIdx, //!< index of the post-synaptic neuron to be accessed for _post variables; differs for different Span)
     const string &devPrefix,
-    const std::vector<FunctionTemplate> functions,
+    const std::vector<FunctionTemplate> &functions,
     const std::string &ftype)
 {
      if (sg->getMatrixType() & SynapseMatrixWeight::GLOBAL) {
@@ -256,7 +256,7 @@ void StandardSubstitutions::weightUpdatePostLearn(
     const string &preIdx, //!< index of the pre-synaptic neuron to be accessed for _pre variables; differs for different Span)
     const string &postIdx, //!< index of the post-synaptic neuron to be accessed for _post variables; differs for different Span)
     const string &devPrefix,
-    const std::vector<FunctionTemplate> functions,
+    const std::vector<FunctionTemplate> &functions,
     const std::string &ftype)
 {
     value_substitutions(code, sg->getWUModel()->getParamNames(), sg->getWUParams());
@@ -274,7 +274,7 @@ void StandardSubstitutions::weightUpdatePostLearn(
 std::string StandardSubstitutions::initVariable(
     const NewModels::VarInit &varInit,
     const std::string &varName,
-    const std::vector<FunctionTemplate> functions,
+    const std::vector<FunctionTemplate> &functions,
     const std::string &ftype,
     const std::string &rng)
 {

--- a/lib/src/synapseGroup.cc
+++ b/lib/src/synapseGroup.cc
@@ -307,10 +307,10 @@ std::string SynapseGroup::getDendriticDelayOffset(const std::string &devPrefix, 
     assert(isDendriticDelayRequired());
 
     if(offset.empty()) {
-        return "(" + devPrefix + "denDelayPtr" + getName() + " * " + to_string(getTrgNeuronGroup()->getNumNeurons()) + ") + ";
+        return "(" + devPrefix + "denDelayPtr" + getTargetMergedPSMName() + " * " + to_string(getTrgNeuronGroup()->getNumNeurons()) + ") + ";
     }
     else {
-        return "(((" + devPrefix + "denDelayPtr" + getName() + " + " + offset + ") % " + to_string(getMaxDendriticDelaySlots()) + ") * " + to_string(getTrgNeuronGroup()->getNumNeurons()) + ") + ";
+        return "(((" + devPrefix + "denDelayPtr" + getTargetMergedPSMName() + " + " + offset + ") % " + to_string(getMaxDendriticDelaySlots()) + ") * " + to_string(getTrgNeuronGroup()->getNumNeurons()) + ") + ";
     }
 }
 

--- a/lib/src/synapseGroup.cc
+++ b/lib/src/synapseGroup.cc
@@ -52,7 +52,7 @@ SynapseGroup::SynapseGroup(const std::string name, SynapseMatrixType matrixType,
         m_InSynVarMode(GENN_PREFERENCES::defaultVarMode), m_DendriticDelayVarMode(GENN_PREFERENCES::defaultVarMode),
         m_WUModel(wu), m_WUParams(wuParams), m_WUVarInitialisers(wuVarInitialisers), m_PSModel(ps), m_PSParams(psParams), m_PSVarInitialisers(psVarInitialisers),
         m_WUVarMode(wuVarInitialisers.size(), GENN_PREFERENCES::defaultVarMode), m_PSVarMode(psVarInitialisers.size(), GENN_PREFERENCES::defaultVarMode),
-        m_PSModelTargetName(name), m_PSModelMerged(false)
+        m_PSModelTargetName(name)
 {
     // Check that the source neuron group supports the desired number of delay steps
     srcNeuronGroup->checkNumDelaySlots(delaySteps);

--- a/lib/src/synapseGroup.cc
+++ b/lib/src/synapseGroup.cc
@@ -51,7 +51,8 @@ SynapseGroup::SynapseGroup(const std::string name, SynapseMatrixType matrixType,
         m_TrueSpikeRequired(false), m_SpikeEventRequired(false), m_EventThresholdReTestRequired(false),
         m_InSynVarMode(GENN_PREFERENCES::defaultVarMode), m_DendriticDelayVarMode(GENN_PREFERENCES::defaultVarMode),
         m_WUModel(wu), m_WUParams(wuParams), m_WUVarInitialisers(wuVarInitialisers), m_PSModel(ps), m_PSParams(psParams), m_PSVarInitialisers(psVarInitialisers),
-        m_WUVarMode(wuVarInitialisers.size(), GENN_PREFERENCES::defaultVarMode), m_PSVarMode(psVarInitialisers.size(), GENN_PREFERENCES::defaultVarMode)
+        m_WUVarMode(wuVarInitialisers.size(), GENN_PREFERENCES::defaultVarMode), m_PSVarMode(psVarInitialisers.size(), GENN_PREFERENCES::defaultVarMode),
+        m_PSModelTargetName(name), m_PSModelMerged(false)
 {
     // Check that the source neuron group supports the desired number of delay steps
     srcNeuronGroup->checkNumDelaySlots(delaySteps);
@@ -307,10 +308,10 @@ std::string SynapseGroup::getDendriticDelayOffset(const std::string &devPrefix, 
     assert(isDendriticDelayRequired());
 
     if(offset.empty()) {
-        return "(" + devPrefix + "denDelayPtr" + getTargetMergedPSMName() + " * " + to_string(getTrgNeuronGroup()->getNumNeurons()) + ") + ";
+        return "(" + devPrefix + "denDelayPtr" + getPSModelTargetName() + " * " + to_string(getTrgNeuronGroup()->getNumNeurons()) + ") + ";
     }
     else {
-        return "(((" + devPrefix + "denDelayPtr" + getTargetMergedPSMName() + " + " + offset + ") % " + to_string(getMaxDendriticDelayTimesteps()) + ") * " + to_string(getTrgNeuronGroup()->getNumNeurons()) + ") + ";
+        return "(((" + devPrefix + "denDelayPtr" + getPSModelTargetName() + " + " + offset + ") % " + to_string(getMaxDendriticDelayTimesteps()) + ") * " + to_string(getTrgNeuronGroup()->getNumNeurons()) + ") + ";
     }
 }
 


### PR DESCRIPTION
I think I've talked to you about this before but what this change does is, if the GENN_PREFERENCE is set, merge together the postsynaptic models of a neuron population's incoming synapse populations if
1. They use the same model class
2. They have the same maximum number of dendritic delay slots
3. They have no state variables (it's ambiguous as to how these should be initialised)
4. Their parameter and derived-parameter values match

When postsynaptic models are merged:

1. Memory is saved as only one dendritic delay buffer and inSyn is allocated
2. Hopefully the L2 cache is thrashed slightly less
3. The postsynaptic model updating/applying phase of the neuron kernel is much reduced

Overall, on a K40, this change more than halves the time spent by the neuron kernel on the Potjans microcircuit model. It's a little messy but I feel worth it!