### PR TITLE
Current Sources: fix copyStateToDevice()

### DIFF
--- a/lib/src/generateRunner.cc
+++ b/lib/src/generateRunner.cc
@@ -2463,6 +2463,14 @@ void genRunnerGPU(const NNmodel &model, //!< Model description
             os << "push" << n.first << "SpikesToDevice(hostInitialisedOnly);" << std::endl;
         }
 
+        for(const auto &cs : model.getRemoteCurrentSources()) {
+            os << "push" << cs.first << "StateToDevice(hostInitialisedOnly);" << std::endl;
+        }
+
+        for(const auto &cs : model.getLocalCurrentSources()) {
+            os << "push" << cs.first << "StateToDevice(hostInitialisedOnly);" << std::endl;
+        }
+
         for(const auto &s : model.getLocalSynapseGroups()) {
             os << "push" << s.first << "StateToDevice(hostInitialisedOnly);" << std::endl;
         }

--- a/lib/src/generateRunner.cc
+++ b/lib/src/generateRunner.cc
@@ -2463,10 +2463,6 @@ void genRunnerGPU(const NNmodel &model, //!< Model description
             os << "push" << n.first << "SpikesToDevice(hostInitialisedOnly);" << std::endl;
         }
 
-        for(const auto &cs : model.getRemoteCurrentSources()) {
-            os << "push" << cs.first << "StateToDevice(hostInitialisedOnly);" << std::endl;
-        }
-
         for(const auto &cs : model.getLocalCurrentSources()) {
             os << "push" << cs.first << "StateToDevice(hostInitialisedOnly);" << std::endl;
         }


### PR DESCRIPTION
Functions to push states of the current sources in `copyStateToDevice()` were not generated.