### PR TITLE
Seperate specification of precision for time

### DIFF
--- a/lib/include/modelSpec.h
+++ b/lib/include/modelSpec.h
@@ -71,12 +71,20 @@ enum SynapseGType
 #define CPU 0 //!< Macro attaching the label "CPU" to flag 0
 #define GPU 1 //!< Macro attaching the label "GPU" to flag 1
 
-// Floating point precision to use for models
+//!< Floating point precision to use for models
 enum FloatType
 {
     GENN_FLOAT,
     GENN_DOUBLE,
     GENN_LONG_DOUBLE,
+};
+
+//!< Precision to use for variables which store time
+enum class TimePrecision
+{
+    DEFAULT,    //!< Time uses default model precision
+    FLOAT,      //!< Time uses single precision - not suitable for long simulations
+    DOUBLE,     //!< Time uses double precision - may reduce performance
 };
 
 #define AUTODEVICE -1  //!< Macro attaching the label AUTODEVICE to flag -1. Used by setGPUDevice
@@ -126,6 +134,7 @@ public:
     void setName(const std::string&); //!< Method to set the neuronal network model name
 
     void setPrecision(FloatType); //!< Set numerical precision for floating point
+    void setTimePrecision(TimePrecision timePrecision); //!< Set numerical precision for time
     void setDT(double); //!< Set the integration step size of the model
     void setTiming(bool); //!< Set whether timers and timing commands are to be included
     void setSeed(unsigned int); //!< Set the random seed (disables automatic seeding if argument not 0).
@@ -166,6 +175,9 @@ public:
 
     //! Gets the floating point numerical precision
     const std::string &getPrecision() const{ return ftype; }
+
+    //! Gets the floating point numerical precision used to represent time
+    std::string getTimePrecision() const;
 
     //! Which kernel should contain the reset logic? Specified in terms of GENN_FLAGS
     unsigned int getResetKernel() const{ return resetKernel; }
@@ -591,14 +603,15 @@ private:
     map<string, string> currentSourceKernelParameters;
 
      // Model members
-    string name;                //!< Name of the neuronal newtwork model
-    string ftype;               //!< Type of floating point variables (float, double, ...; default: float)
-    string RNtype;              //!< Underlying type for random number generation (default: uint64_t)
-    double dt;                  //!< The integration time step of the model
-    bool final;                 //!< Flag for whether the model has been finalized
+    string name;                    //!< Name of the neuronal newtwork model
+    string ftype;                   //!< Type of floating point variables (float, double, ...; default: float)
+    TimePrecision m_TimePrecision;  //!< Type of floating point variables used to store time
+    string RNtype;                  //!< Underlying type for random number generation (default: uint64_t)
+    double dt;                      //!< The integration time step of the model
+    bool final;                     //!< Flag for whether the model has been finalized
     bool timing;
     unsigned int seed;
-    unsigned int resetKernel;   //!< The identity of the kernel in which the spike counters will be reset.
+    unsigned int resetKernel;       //!< The identity of the kernel in which the spike counters will be reset.
 };
 
 #endif

--- a/lib/src/generateCPU.cc
+++ b/lib/src/generateCPU.cc
@@ -219,7 +219,7 @@ void genNeuronFunction(const NNmodel &model, //!< Model description
     os << "#include \"support_code.h\"" << std::endl << std::endl;
 
     // function header
-    os << "void calcNeuronsCPU(" << model.getPrecision() << " t)";
+    os << "void calcNeuronsCPU(" << model.getTimePrecision() << " t)";
     {
         CodeStream::Scope b(os);
 
@@ -257,7 +257,7 @@ void genNeuronFunction(const NNmodel &model, //!< Model description
                     if ((nm->getSimCode().find("$(sT)") != string::npos)
                         || (nm->getThresholdConditionCode().find("$(sT)") != string::npos)
                         || (nm->getResetCode().find("$(sT)") != string::npos)) { // load sT into local variable
-                        os << model.getPrecision() << " lsT= sT" <<  n.first << "[";
+                        os << model.getTimePrecision() << " lsT= sT" <<  n.first << "[";
                         if (n.second.isDelayRequired()) {
                             os << "(delaySlot * " << n.second.getNumNeurons() << ") + ";
                         }
@@ -476,7 +476,7 @@ void genSynapseFunction(const NNmodel &model, //!< Model description
 
     if (!model.getSynapseDynamicsGroups().empty()) {
         // synapse dynamics function
-        os << "void calcSynapseDynamicsCPU(" << model.getPrecision() << " t)";
+        os << "void calcSynapseDynamicsCPU(" << model.getTimePrecision() << " t)";
         {
             CodeStream::Scope b(os);
             os << model.getPrecision() << " addtoinSyn;" << std::endl;
@@ -613,7 +613,7 @@ void genSynapseFunction(const NNmodel &model, //!< Model description
     }
 
     // synapse function header
-    os << "void calcSynapsesCPU(" << model.getPrecision() << " t)";
+    os << "void calcSynapsesCPU(" << model.getTimePrecision() << " t)";
     {
         CodeStream::Scope b(os);
         os << std::endl;
@@ -649,7 +649,7 @@ void genSynapseFunction(const NNmodel &model, //!< Model description
 
     if (!model.getSynapsePostLearnGroups().empty()) {
 
-        os << "void learnSynapsesPostHost(" << model.getPrecision() << " t)";
+        os << "void learnSynapsesPostHost(" << model.getTimePrecision() << " t)";
         {
             CodeStream::Scope b(os);
 

--- a/lib/src/generateInit.cc
+++ b/lib/src/generateInit.cc
@@ -306,10 +306,10 @@ unsigned int genInitializeDeviceKernel(CodeStream &os, const NNmodel &model, int
                         // Reset spike times
                         if(shouldInitSpikeTimeVar) {
                             if(n.second.isDelayRequired()) {
-                                os << "dd_sT" << n.first << "[" << delayedIndex << "] = -SCALAR_MAX;" << std::endl;
+                                os << "dd_sT" << n.first << "[" << delayedIndex << "] = -TIME_MAX;" << std::endl;
                             }
                             else {
-                                os << "dd_sT" << n.first << "[lid] = -SCALAR_MAX;" << std::endl;
+                                os << "dd_sT" << n.first << "[lid] = -TIME_MAX;" << std::endl;
                             }
                         }
 
@@ -900,7 +900,7 @@ void genInit(const NNmodel &model,      //!< Model description
                 os << "for (int i = 0; i < " << n.second.getNumNeurons() * n.second.getNumDelaySlots() << "; i++)";
                 {
                     CodeStream::Scope b(os);
-                    os << "sT" <<  n.first << "[i] = -SCALAR_MAX;" << std::endl;
+                    os << "sT" <<  n.first << "[i] = -TIME_MAX;" << std::endl;
                 }
             }
 

--- a/lib/src/generateKernels.cc
+++ b/lib/src/generateKernels.cc
@@ -445,7 +445,7 @@ void genNeuronKernel(const NNmodel &model, //!< Model description
     for(const auto &p : model.getCurrentSourceKernelParameters()) {
         os << p.second << " " << p.first << ", ";
     }
-    os << model.getPrecision() << " t)" << std::endl;
+    os << model.getTimePrecision() << " t)" << std::endl;
     {
         // kernel code
         CodeStream::Scope b(os);
@@ -870,7 +870,7 @@ void genSynapseKernel(const NNmodel &model, //!< Model description
         for(const auto &p : model.getSynapseDynamicsKernelParameters()) {
             os << p.second << " " << p.first << ", ";
         }
-        os << model.getPrecision() << " t)" << std::endl; // end of synapse kernel header
+        os << model.getTimePrecision() << " t)" << std::endl; // end of synapse kernel header
 
         // synapse dynamics kernel code
         {
@@ -1021,7 +1021,7 @@ void genSynapseKernel(const NNmodel &model, //!< Model description
     for (const auto &p : model.getSynapseKernelParameters()) {
         os << p.second << " " << p.first << ", ";
     }
-    os << model.getPrecision() << " t)" << std::endl; // end of synapse kernel header
+    os << model.getTimePrecision() << " t)" << std::endl; // end of synapse kernel header
 
     // synapse kernel code
     {
@@ -1211,7 +1211,7 @@ void genSynapseKernel(const NNmodel &model, //!< Model description
         for(const auto &p : model.getSimLearnPostKernelParameters()) {
             os << p.second << " " << p.first << ", ";
         }
-        os << model.getPrecision() << " t)";
+        os << model.getTimePrecision() << " t)";
         os << std::endl;
 
         // kernel code

--- a/lib/src/modelSpec.cc
+++ b/lib/src/modelSpec.cc
@@ -66,13 +66,11 @@ void createVarInitialiserFromLegacyVars(const std::vector<double> &ini, std::vec
 // ------------------------------------------------------------------------
 // class NNmodel for specifying a neuronal network model
 
-NNmodel::NNmodel()
+NNmodel::NNmodel() : m_TimePrecision(TimePrecision::DEFAULT), RNtype{"uint64_t"}, final(false)
 {
-    final= false;
     setDT(0.5);
     setPrecision(GENN_FLOAT);
     setTiming(false);
-    RNtype= "uint64_t";
 #ifndef CPU_ONLY
     setGPUDevice(AUTODEVICE);
 #endif
@@ -195,6 +193,21 @@ bool NNmodel::canRunOnCPU() const
     }
 #endif
     return true;
+}
+
+std::string NNmodel::getTimePrecision() const
+{
+    // If time precision is set to match model precision
+    if(m_TimePrecision == TimePrecision::DEFAULT) {
+        return getPrecision();
+    }
+    // Otherwise return appropriate type
+    else if(m_TimePrecision == TimePrecision::FLOAT) {
+        return "float";
+    }
+    else {
+        return "double";
+    }
 }
 
 std::string NNmodel::getGeneratedCodePath(const std::string &path, const std::string &filename) const{
@@ -858,6 +871,14 @@ void NNmodel::setPrecision(FloatType floattype /**<  */)
     }
 }
 
+void NNmodel::setTimePrecision(TimePrecision timePrecision)
+{
+    if (final) {
+        gennError("Trying to set time precision of a finalized model.");
+    }
+
+    m_TimePrecision = timePrecision;
+}
 
 //--------------------------------------------------------------------------
 /*! \brief This function sets a flag to determine whether timers and timing commands are to be included in generated code.


### PR DESCRIPTION
This ended up being pretty simple - basically just adding a different method to ``NNmodel`` to query  the _time_ precision separately. Because of the ``ensureFType`` logic you probably need to be a little careful what you do with your double precision time or it could easily get down-cast but , in STDP rules, I tend to do this:
```c++
const scalar dt = $(t) - $(sT_post);
```
which I think will work nicely - difference in time is calculated from double precision variables and **then** cast back to single precision (which should easily be able to represent this).  Then subsequent operations on ``dt`` will be done with single-precision, faster maths functions/intrinsics.