### PR TITLE
Connection gen tweaks

### DIFF
--- a/lib/include/initSparseConnectivitySnippet.h
+++ b/lib/include/initSparseConnectivitySnippet.h
@@ -151,7 +151,7 @@ public:
     SET_ROW_BUILD_CODE(
         "const scalar u = $(gennrand_uniform);\n"
         "prevJ += (1 + (int)(log(u) * $(probLogRecip)));\n"
-        "if($(isPostNeuronValid, prevJ)) {\n"
+        "if(prevJ < $(num_post)) {\n"
         "   $(addSynapse, prevJ);\n"
         "}\n"
         "else {\n"
@@ -187,7 +187,7 @@ public:
         "   nextJ = prevJ + (1 + (int)(log(u) * $(probLogRecip)));\n"
         "} while(nextJ == $(id_pre));\n"
         "prevJ = nextJ;\n"
-        "if($(isPostNeuronValid, prevJ)) {\n"
+        "if(prevJ < $(num_post)) {\n"
         "   $(addSynapse, prevJ);\n"
         "}\n"
         "else {\n"

--- a/lib/src/initSparseConnectivitySnippet.cc
+++ b/lib/src/initSparseConnectivitySnippet.cc
@@ -4,3 +4,4 @@
 IMPLEMENT_SNIPPET(InitSparseConnectivitySnippet::Uninitialised);
 IMPLEMENT_SNIPPET(InitSparseConnectivitySnippet::OneToOne);
 IMPLEMENT_SNIPPET(InitSparseConnectivitySnippet::FixedProbability);
+IMPLEMENT_SNIPPET(InitSparseConnectivitySnippet::FixedProbabilityNoAutapse);

--- a/lib/src/standardSubstitutions.cc
+++ b/lib/src/standardSubstitutions.cc
@@ -367,17 +367,15 @@ std::string StandardSubstitutions::initSparseConnectivity(
     // Get user code string
     std::string code = connectInit.getSnippet()->getRowBuildCode();
 
-    // Substitute presynaptic index
+    // Substitute presynaptic index and number of postsynaptic neurons
     substitute(code, "$(id_pre)", preIdx);
+    substitute(code, "$(num_post)", std::to_string(numTrgNeurons));
 
     // Replace endRow() with break to stop loop
     functionSubstitute(code, "endRow", 0, "break");
 
     // Replace addSynapse(j) with template to increment count var
     functionSubstitute(code, "addSynapse", 1, addSynapseFunctionTemplate);
-
-    // Replace isPostNeuronValid(j) for test against size of target neuron group
-    functionSubstitute(code, "isPostNeuronValid", 1, "($(0) < " + std::to_string(numTrgNeurons) + ")");
 
     // Substitue derived and standard parameters into init code
     DerivedParamNameIterCtx viDerivedParams(connectInit.getSnippet()->getDerivedParams());

--- a/tests/features/decode_matrix_conn_gen_cont_globalg_ragged/model_new.cc
+++ b/tests/features/decode_matrix_conn_gen_cont_globalg_ragged/model_new.cc
@@ -9,7 +9,7 @@ public:
     DECLARE_SNIPPET(Decoder, 0);
 
     SET_ROW_BUILD_CODE(
-        "if($(isPostNeuronValid, j)) {\n"
+        "if(j < $(num_post)) {\n"
         "   const unsigned int jValue = (1 << j);\n"
         "   if((($(id_pre) + 1) & jValue) != 0)\n"
         "   {\n"

--- a/tests/features/decode_matrix_conn_gen_cont_individualg_ragged/model_new.cc
+++ b/tests/features/decode_matrix_conn_gen_cont_individualg_ragged/model_new.cc
@@ -9,7 +9,7 @@ public:
     DECLARE_SNIPPET(Decoder, 0);
 
     SET_ROW_BUILD_CODE(
-        "if($(isPostNeuronValid, j)) {\n"
+        "if(j < $(num_post)) {\n"
         "   const unsigned int jValue = (1 << j);\n"
         "   if((($(id_pre) + 1) & jValue) != 0)\n"
         "   {\n"

--- a/tests/features/decode_matrix_conn_gen_globalg_bitmask/model_new.cc
+++ b/tests/features/decode_matrix_conn_gen_globalg_bitmask/model_new.cc
@@ -9,7 +9,7 @@ public:
     DECLARE_SNIPPET(Decoder, 0);
 
     SET_ROW_BUILD_CODE(
-        "if($(isPostNeuronValid, j)) {\n"
+        "if(j < $(num_post)) {\n"
         "   const unsigned int jValue = (1 << j);\n"
         "   if((($(id_pre) + 1) & jValue) != 0)\n"
         "   {\n"

--- a/tests/features/decode_matrix_conn_gen_globalg_ragged/model_new.cc
+++ b/tests/features/decode_matrix_conn_gen_globalg_ragged/model_new.cc
@@ -9,7 +9,7 @@ public:
     DECLARE_SNIPPET(Decoder, 0);
 
     SET_ROW_BUILD_CODE(
-        "if($(isPostNeuronValid, j)) {\n"
+        "if(j < $(num_post)) {\n"
         "   const unsigned int jValue = (1 << j);\n"
         "   if((($(id_pre) + 1) & jValue) != 0)\n"
         "   {\n"

--- a/tests/features/decode_matrix_conn_gen_individualg_ragged/model_new.cc
+++ b/tests/features/decode_matrix_conn_gen_individualg_ragged/model_new.cc
@@ -9,7 +9,7 @@ public:
     DECLARE_SNIPPET(Decoder, 0);
 
     SET_ROW_BUILD_CODE(
-        "if($(isPostNeuronValid, j)) {\n"
+        "if(j < $(num_post)) {\n"
         "   const unsigned int jValue = (1 << j);\n"
         "   if((($(id_pre) + 1) & jValue) != 0)\n"
         "   {\n"


### PR DESCRIPTION
This is just a couple of very minor changes to the connection generation - the first of which was the result of the _final battle_ with the STDP model.
1. Alternative version of ``InitSparseConnectivitySnippet::FixedProbability`` to resample if it tries to create an autapse/self-connection 
2. More obvious syntax for accessing the number of postsynaptic neurons from connectivity initialisation snippet