### PR TITLE
Fix for issues with sm_21 devices on windows

### DIFF
--- a/lib/src/generateRunner.cc
+++ b/lib/src/generateRunner.cc
@@ -2918,11 +2918,15 @@ void genMSBuild(const NNmodel &model,   //!< Model description
 #else
     os << "  <Import Project=\"$(GENN_PATH)\\userproject\\include\\genn.props\"/>" << endl;
     os << endl;
-    const string computeCapability = to_string(deviceProp[theDevice].major) + to_string(deviceProp[theDevice].minor);
-	os << "  <!-- Set CUDA code generation options based on selected device -->" << endl;
+    // **YUCK** the CUDA Visual Studio plugin build system demands that you specify both a virtual an actual architecture 
+    // (which NVCC itself doesn't require). While, in general, actual architectures are usable as virtual architectures, 
+    // there is no compute_21 so we need to replace that with compute_20
+    const string architecture = to_string(deviceProp[theDevice].major) + to_string(deviceProp[theDevice].minor);
+    const string virtualArchitecture = (architecture == "21") ? "20" : architecture;
+    os << "  <!-- Set CUDA code generation options based on selected device -->" << endl;
     os << "  <ItemDefinitionGroup>" << endl;
     os << "    <CudaCompile>" << endl;
-    os << "      <CodeGeneration>compute_" << computeCapability <<",sm_" << computeCapability << "</CodeGeneration>" << endl;
+    os << "      <CodeGeneration>compute_" << virtualArchitecture <<",sm_" << architecture << "</CodeGeneration>" << endl;
     os << "    </CudaCompile>" << endl;
     os << "  </ItemDefinitionGroup>" << endl;
     os << "  <!-- Compile runner using CUDA compiler -->" << endl;


### PR DESCRIPTION
The Windows build system requires target architecture to be specified as ``compute_XX,sm_YY``. We were using the value from the device properties for both **but** there is no ``compute_21`` 'virtual architecture' corresponding to SM_21.

Based on the NVCC help this is unique so I have just added a simple hack.
- compute_20, sm_20
- ?, sm_21
- compute_30,sm_30
- compute_32, sm_32
- compute_35, sm_35
- compute_37, sm_37
- compute_50, sm_50
- compute_52, sm_52
- compute_53, sm_53'.

