### PR TITLE
Exposing CPU_ONLYness to PyGeNN

### DIFF
--- a/generate_swig_interfaces.py
+++ b/generate_swig_interfaces.py
@@ -501,11 +501,21 @@ def generateConfigs( gennPath ):
             #endif
                 return localHostID;
             }
+
+            bool is_cpu_only()
+            {
+            #ifdef CPU_ONLY
+                return true;
+            #else
+                return false;
+            #endif
+            }
+
             void generate_model_runner_pygenn( NNmodel & model, const std::string &path, int localHostID ) {
 
                 if (!model.isFinalized()) {
                 gennError("Model was not finalized in modelDefinition(). Please call model.finalize().");
-                    }
+                }
 
                 #ifndef CPU_ONLY
                     chooseDevice(model, path, localHostID);


### PR DESCRIPTION
This means tests etc won't need whether to use CPU or not hardcoded.

- Add a function to the python wrapper which basically returns whether ``CPU_ONLY`` is defined.
-  ``GeNNModel`` now has a ``use_cpu`` property which when set to ``None`` defaults to whether module was built CPU_ONLY or not, otherwise checks validity