### PR TITLE
Issues with seeding of device RNG

### DIFF
--- a/lib/src/generateInit.cc
+++ b/lib/src/generateInit.cc
@@ -229,7 +229,7 @@ void genHostInitSpikeCode(CodeStream &os, const NeuronGroup &ng, bool spikeEvent
 }
 // ------------------------------------------------------------------------
 #ifndef CPU_ONLY
-void genInitializeDeviceRNGKernel(CodeStream &os, const NNmodel &model)
+void genInitializeDeviceRNGKernel(CodeStream &os)
 {
     // If global device RNG is required
     os << "extern \"C\" __global__ void initializeDeviceRNG(unsigned long long deviceRNGSeed)";
@@ -816,7 +816,7 @@ void genInit(const NNmodel &model,      //!< Model description
 #ifndef CPU_ONLY
     // If device RNG is required, generate kernel to initialise it
     if(model.isDeviceRNGRequired()) {
-        genInitializeDeviceRNGKernel(os, model);
+        genInitializeDeviceRNGKernel(os);
         os << std::endl;
     }
 

--- a/lib/src/generateInit.cc
+++ b/lib/src/generateInit.cc
@@ -898,7 +898,7 @@ void genInit(const NNmodel &model,      //!< Model description
             }
             // Otherwise, use model seed
             else {
-                os << "deviceRNGSeed = model.getSeed();" << std::endl;
+                os << "deviceRNGSeed = " << model.getSeed() << ";" << std::endl;
             }
         }
 #endif

--- a/lib/src/modelSpec.cc
+++ b/lib/src/modelSpec.cc
@@ -146,7 +146,7 @@ bool NNmodel::isHostRNGRequired() const
 
 bool NNmodel::isDeviceRNGRequired() const
 {
-    // If any neuron groupsrequire device RNG for initialisation, return true
+    // If any neuron groups require device RNG for initialisation, return true
     if(any_of(begin(m_LocalNeuronGroups), end(m_LocalNeuronGroups),
         [](const NeuronGroupValueType &n)
         {

--- a/lib/src/modelSpec.cc
+++ b/lib/src/modelSpec.cc
@@ -222,11 +222,6 @@ std::string NNmodel::getGeneratedCodePath(const std::string &path, const std::st
 
 bool NNmodel::isDeviceInitRequired(int localHostID) const
 {
-    // If device RNG is required, device init is required to initialise it
-    if(isDeviceRNGRequired()) {
-        return true;
-    }
-
     // If any local neuron groups require device initialisation, return true
     if(std::any_of(std::begin(m_LocalNeuronGroups), std::end(m_LocalNeuronGroups),
         [](const NNmodel::NeuronGroupValueType &n){ return n.second.isDeviceInitRequired(); }))


### PR DESCRIPTION
If the ``NNmodel`` seed was manually set, this was correctly used to initialize the CUDA RNGs. However, if it was set to zero, the seed of the CUDA RNGs weren't randomly initialised. In this change I generate ``sizeof(unsigned long long)`` worth of system randomness to seed it in this case.

Also I spotted what I think is a potential bug in the ``initializeDevice`` kernel - it was entirely possible that, while ``dd_rng`` was initialized at the top of the kernel, the updated state didn't make it to all the states. Am I right in this interpretation of CUDA  @tnowotny? I don't think even a ``__threadfence`` would help here so I just added a pre-initialisation kernel to initialise the RNG.