### PR TITLE
Host-initialised variable not copied to device in Izh_sparse

### DIFF
--- a/userproject/Izh_sparse_project/model/Izh_sparse.cc
+++ b/userproject/Izh_sparse_project/model/Izh_sparse.cc
@@ -134,6 +134,7 @@ void modelDefinition(NNmodel &model)
 
     // Override the variable mode of V and b so they can be used to calculate U on host
     inh->setVarMode("V", VarMode::LOC_HOST_DEVICE_INIT_HOST);
+    inh->setVarMode("U", VarMode::LOC_HOST_DEVICE_INIT_HOST);
     inh->setVarMode("b", VarMode::LOC_HOST_DEVICE_INIT_HOST);
 
     model.addSynapsePopulation<WeightUpdateModels::StaticPulse, PostsynapticModels::DeltaCurr>("Exc_Exc", SynapseMatrixType::SPARSE_INDIVIDUALG, NO_DELAY,


### PR DESCRIPTION
A very minor edit to Izh_sparse. The inhibitory U variable is an `uninitialisedVar()`, initialised on host, but is not copied to device since it is not set to `varMode::LOC_HOST_DEVICE_INIT_HOST`. This is causing undefined behaviour.

Is this a more general problem with uninitialised vars, where a user may be unaware that their host-initialised vars are not copied over when copy-to-device is called? It certainly tripped me up for a while.