### PR TITLE
Mention AUR packages in readme file

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,19 @@ restarted to initialise the variables set using the `SETX` command.
 
 This completes the installation.
 
+### ARCH LINUX INSTALL
+For Arch Linux there are GeNN packages available [from the AUR](https://aur.archlinux.org/packages/?O=0&K=genn).
+
+Install with your AUR helper of choice, like so:
+```sh
+yay -S genn
+```
+
+If you do not want CUDA support (i.e. if you don't have an NVIDIA GPU), there is a CPU-only version of the package:
+```sh
+yay -S genn_cpu_only
+```
+
 ## USING GeNN 
 
 ### SAMPLE PROJECTS


### PR DESCRIPTION
I've made a couple of GeNN packages on the Arch User Repo, mostly for me (they're source packages which look like this: https://aur.archlinux.org/cgit/aur.git/tree/PKGBUILD?h=genn). Thought it would be worth a mention even though the intersection of Arch users and GeNN users is probably small for now (n = 1)!