### PR TITLE
PyGeNN fix

### DIFF
--- a/pygenn/genn_model.py
+++ b/pygenn/genn_model.py
@@ -521,7 +521,7 @@ class GeNNModel(object):
         if not self._loaded:
             raise Exception("GeNN model has to be loaded before pulling")
 
-        self._slm.push_var_from_device(pop_name, var_name)
+        self._slm.push_var_to_device(pop_name, var_name)
 
     def end(self):
         """Free memory"""


### PR DESCRIPTION
Clearly a GeNN 4.0.1 is going to be required! This includes:
- Fixes a dumb typo
- Adds some more error-checking to parameter and value initialisation. Previously, while PyGeNN converted parameters and values from Python dictionaries to C++ GeNN arrays, it didn't check if your dictionary didn't also have any extra unsupported parameters which made it very easy to make mistakes
- Previously you got a auto-generated SWIG error if you tried setting parameters to e.g. arrays - this adds a friendlier error earlier