### PR TITLE
Small fix for Visual Studio 2013

### DIFF
--- a/src/genn/genn/code_generator/backendBase.cc
+++ b/src/genn/genn/code_generator/backendBase.cc
@@ -13,7 +13,7 @@
 // CodeGenerator::BackendBase
 //--------------------------------------------------------------------------
 CodeGenerator::BackendBase::BackendBase(int localHostID, const std::string &scalarType)
-:   m_LocalHostID(localHostID), m_TypeBytes{TYPE(char), TYPE(wchar_t), TYPE(signed char), TYPE(short),
+:   m_LocalHostID(localHostID), m_TypeBytes{{TYPE(char), TYPE(wchar_t), TYPE(signed char), TYPE(short),
     TYPE(signed short), TYPE(short int), TYPE(signed short int), TYPE(int), TYPE(signed int), TYPE(long),
     TYPE(signed long), TYPE(long int), TYPE(signed long int), TYPE(long long), TYPE(signed long long), TYPE(long long int),
     TYPE(signed long long int), TYPE(unsigned char), TYPE(unsigned short), TYPE(unsigned short int), TYPE(unsigned),
@@ -23,7 +23,7 @@ CodeGenerator::BackendBase::BackendBase(int localHostID, const std::string &scal
     TYPE(int64_t), TYPE(uint64_t), TYPE(int_least8_t), TYPE(uint_least8_t), TYPE(int_least16_t), TYPE(uint_least16_t),
     TYPE(int_least32_t), TYPE(uint_least32_t), TYPE(int_least64_t), TYPE(uint_least64_t), TYPE(int_fast8_t),
     TYPE(uint_fast8_t), TYPE(int_fast16_t), TYPE(uint_fast16_t), TYPE(int_fast32_t), TYPE(uint_fast32_t),
-    TYPE(int_fast64_t), TYPE(uint_fast64_t)}
+    TYPE(int_fast64_t), TYPE(uint_fast64_t)}}
 {
     // Add scalar type
     addType("scalar", (scalarType == "float") ? sizeof(float) : sizeof(double));


### PR DESCRIPTION
Clearly I hadn't worked from home using this machine for a while as GeNN 4.0.0 doesn't build on Visual Studio 2013 (our lowest support Visual Studi) as it has slightly broken support for {} initialisation - basically it requires an extra set of curly brackets i.e. {{}}.