### PR TITLE
Read only vars

### DIFF
--- a/bin/genn-buildmodel.bat
+++ b/bin/genn-buildmodel.bat
@@ -82,7 +82,7 @@ if defined -d (
 
 
 rem :: build backend
-msbuild "%GENN_PATH%..\genn.sln" /t:%BACKEND_PROJECT% %BACKEND_MACROS% /p:BuildProjectReferences=true && (
+msbuild "%GENN_PATH%..\genn.sln" /m /verbosity:minimal /t:%BACKEND_PROJECT% %BACKEND_MACROS% /p:BuildProjectReferences=true && (
 	echo Successfully built GeNN
 ) || (
 	echo Unable to build GeNN
@@ -91,7 +91,7 @@ msbuild "%GENN_PATH%..\genn.sln" /t:%BACKEND_PROJECT% %BACKEND_MACROS% /p:BuildP
 
 
 rem :: build generator
-msbuild "%GENN_PATH%..\src\genn\generator\generator.vcxproj" %MACROS%&& (
+msbuild "%GENN_PATH%..\src\genn\generator\generator.vcxproj" /m /verbosity:minimal %MACROS%&& (
 	echo Successfully built code generator
 ) || (
 	echo Unable to build code generator

--- a/include/genn/genn/code_generator/codeGenUtils.h
+++ b/include/genn/genn/code_generator/codeGenUtils.h
@@ -8,6 +8,7 @@
 #include <vector>
 
 // GeNN includes
+#include "models.h"
 #include "snippet.h"
 #include "variableMode.h"
 
@@ -92,7 +93,8 @@ struct NameIterCtx
 //----------------------------------------------------------------------------
 // Typedefines
 //----------------------------------------------------------------------------
-typedef NameIterCtx<Snippet::Base::VarVec> VarNameIterCtx;
+typedef NameIterCtx<Models::Base::VarVec> VarNameIterCtx;
+typedef NameIterCtx<Snippet::Base::EGPVec> EGPNameIterCtx;
 typedef NameIterCtx<Snippet::Base::DerivedParamVec> DerivedParamNameIterCtx;
 typedef NameIterCtx<Snippet::Base::ParamValVec> ParamValIterCtx;
 

--- a/include/genn/genn/initSparseConnectivitySnippet.h
+++ b/include/genn/genn/initSparseConnectivitySnippet.h
@@ -24,7 +24,7 @@
 #define SET_MAX_ROW_LENGTH(MAX_ROW_LENGTH) virtual CalcMaxLengthFunc getCalcMaxRowLengthFunc() const override{ return [](unsigned int, unsigned int, const std::vector<double> &){ return MAX_ROW_LENGTH; }; }
 #define SET_MAX_COL_LENGTH(MAX_COL_LENGTH) virtual CalcMaxLengthFunc getCalcMaxColLengthFunc() const override{ return [](unsigned int, unsigned int, const std::vector<double> &){ return MAX_COL_LENGTH; }; }
 
-#define SET_EXTRA_GLOBAL_PARAMS(...) virtual VarVec getExtraGlobalParams() const override{ return __VA_ARGS__; }
+#define SET_EXTRA_GLOBAL_PARAMS(...) virtual EGPVec getExtraGlobalParams() const override{ return __VA_ARGS__; }
 
 //----------------------------------------------------------------------------
 // InitSparseConnectivitySnippet::Base
@@ -54,7 +54,7 @@ public:
 
     //! Gets names and types (as strings) of additional
     //! per-population parameters for the connection initialisation snippet
-    virtual VarVec getExtraGlobalParams() const{ return {}; }
+    virtual EGPVec getExtraGlobalParams() const{ return {}; }
 
     //------------------------------------------------------------------------
     // Public methods
@@ -62,7 +62,7 @@ public:
     //! Find the index of a named extra global parameter
     size_t getExtraGlobalParamIndex(const std::string &paramName) const
     {
-        return getVarVecIndex(paramName, getExtraGlobalParams());
+        return getNamedVecIndex(paramName, getExtraGlobalParams());
     }
 };
 
@@ -100,7 +100,7 @@ public:
     SET_ROW_BUILD_CODE(
         "$(addSynapse, $(id_pre));\n"
         "$(endRow);\n");
-    
+
     SET_MAX_ROW_LENGTH(1);
     SET_MAX_COL_LENGTH(1);
 };

--- a/include/genn/genn/models.h
+++ b/include/genn/genn/models.h
@@ -142,11 +142,17 @@ public:
     //----------------------------------------------------------------------------
     // Structs
     //----------------------------------------------------------------------------
-    //! A variable has a name, a type and a readonly flag
-    /*! Through the wonders of C++ aggregate initialization, if readonly
-    // is not initialized in the {}, it will be VALUE-initialised to false*/
+    //! A variable has a name, a type and an access type
+    /*! Explicit constructors required as although, through the wonders of C++
+        aggregate initialization, access would default to VarAccess::READ_WRITE
+        if not specified, this results in a -Wmissing-field-initializers warning on GCC and Clang*/
     struct Var
     {
+        Var(const std::string &n, const std::string &t, VarAccess a) : name(n), type(t), access(a)
+        {}
+        Var(const std::string &n, const std::string &t) : Var(n, t, VarAccess::READ_WRITE)
+        {}
+
         std::string name;
         std::string type;
         VarAccess access;

--- a/include/genn/genn/models.h
+++ b/include/genn/genn/models.h
@@ -148,6 +148,8 @@ public:
         if not specified, this results in a -Wmissing-field-initializers warning on GCC and Clang*/
     struct Var
     {
+        Var()
+        {}
         Var(const std::string &n, const std::string &t, VarAccess a) : name(n), type(t), access(a)
         {}
         Var(const std::string &n, const std::string &t) : Var(n, t, VarAccess::READ_WRITE)

--- a/include/genn/genn/neuronModels.h
+++ b/include/genn/genn/neuronModels.h
@@ -190,8 +190,8 @@ public:
     DECLARE_MODEL(NeuronModels::IzhikevichVariable, 0, 6);
 
     SET_PARAM_NAMES({});
-    SET_VARS({{"V","scalar"}, {"U", "scalar"}, {"a", "scalar"},
-             {"b", "scalar"}, {"c", "scalar"}, {"d", "scalar"}});
+    SET_VARS({{"V","scalar"}, {"U", "scalar"}, {"a", "scalar", true},
+             {"b", "scalar", true}, {"c", "scalar", true}, {"d", "scalar", true}});
 };
 
 //----------------------------------------------------------------------------
@@ -275,7 +275,7 @@ public:
         "$(startSpike) != $(endSpike) && "
         "$(t) >= $(spikeTimes)[$(startSpike)]" );
     SET_RESET_CODE( "$(startSpike)++;\n" );
-    SET_VARS( {{"startSpike", "unsigned int"}, {"endSpike", "unsigned int"}} );
+    SET_VARS( {{"startSpike", "unsigned int"}, {"endSpike", "unsigned int", true}} );
     SET_EXTRA_GLOBAL_PARAMS( {{"spikeTimes", "scalar*"}} );
     SET_NEEDS_AUTO_REFRACTORY(false);
 };

--- a/include/genn/genn/neuronModels.h
+++ b/include/genn/genn/neuronModels.h
@@ -190,8 +190,9 @@ public:
     DECLARE_MODEL(NeuronModels::IzhikevichVariable, 0, 6);
 
     SET_PARAM_NAMES({});
-    SET_VARS({{"V","scalar"}, {"U", "scalar"}, {"a", "scalar", true},
-             {"b", "scalar", true}, {"c", "scalar", true}, {"d", "scalar", true}});
+    SET_VARS({{"V","scalar"}, {"U", "scalar"},
+              {"a", "scalar", VarAccess::READ_ONLY}, {"b", "scalar", VarAccess::READ_ONLY},
+              {"c", "scalar", VarAccess::READ_ONLY}, {"d", "scalar", VarAccess::READ_ONLY}});
 };
 
 //----------------------------------------------------------------------------
@@ -275,7 +276,7 @@ public:
         "$(startSpike) != $(endSpike) && "
         "$(t) >= $(spikeTimes)[$(startSpike)]" );
     SET_RESET_CODE( "$(startSpike)++;\n" );
-    SET_VARS( {{"startSpike", "unsigned int"}, {"endSpike", "unsigned int", true}} );
+    SET_VARS( {{"startSpike", "unsigned int"}, {"endSpike", "unsigned int", VarAccess::READ_ONLY}} );
     SET_EXTRA_GLOBAL_PARAMS( {{"spikeTimes", "scalar*"}} );
     SET_NEEDS_AUTO_REFRACTORY(false);
 };

--- a/include/genn/genn/snippet.h
+++ b/include/genn/genn/snippet.h
@@ -119,16 +119,14 @@ public:
     //----------------------------------------------------------------------------
     // Structs
     //----------------------------------------------------------------------------
-    //! A variable has a name, a type and a readonly flag
-    /*! Through the wonders of C++ aggregate initialization, if readonly 
-    // is not initialized in the {}, it will be VALUE-initialised to false*/
-    struct Var
+    //! An extra global parameter has a name and a type
+    struct EGP
     {
         std::string name;
         std::string type;
-        bool readonly;
     };
 
+    //! Additional input variables, row state variables and other things have a name, a type and an initial value
     struct ParamVal
     {
         std::string name;
@@ -148,7 +146,7 @@ public:
     // Typedefines
     //----------------------------------------------------------------------------
     typedef std::vector<std::string> StringVec;
-    typedef std::vector<Var> VarVec;
+    typedef std::vector<EGP> EGPVec;
     typedef std::vector<ParamVal> ParamValVec;
     typedef std::vector<DerivedParam> DerivedParamVec;
 
@@ -167,14 +165,15 @@ protected:
     //------------------------------------------------------------------------
     // Protected static helpers
     //------------------------------------------------------------------------
-    static size_t getVarVecIndex(const std::string &varName, const VarVec &vars)
+    template<typename T>
+    static size_t getNamedVecIndex(const std::string &name, const std::vector<T> &vec)
     {
-        auto varIter = std::find_if(vars.begin(), vars.end(),
-            [varName](const Var &v){ return (v.name == varName); });
-        assert(varIter != vars.end());
+        auto iter = std::find_if(vec.begin(), vec.end(),
+            [name](const T &v){ return (v.name == name); });
+        assert(iter != vec.end());
 
-        // Return flag corresponding to variable
-        return distance(vars.begin(), varIter);
+        // Return 'distance' between first entry in vector and iterator i.e. index
+        return distance(vec.begin(), iter);
     }
 };
 

--- a/include/genn/genn/snippet.h
+++ b/include/genn/genn/snippet.h
@@ -119,11 +119,14 @@ public:
     //----------------------------------------------------------------------------
     // Structs
     //----------------------------------------------------------------------------
-    //! A variable has a name and a type
+    //! A variable has a name, a type and a readonly flag
+    /*! Through the wonders of C++ aggregate initialization, if readonly 
+    // is not initialized in the {}, it will be VALUE-initialised to false*/
     struct Var
     {
         std::string name;
         std::string type;
+        bool readonly;
     };
 
     struct ParamVal

--- a/include/genn/genn/weightUpdateModels.h
+++ b/include/genn/genn/weightUpdateModels.h
@@ -142,7 +142,7 @@ class StaticPulse : public Base
 public:
     DECLARE_WEIGHT_UPDATE_MODEL(StaticPulse, 0, 1, 0, 0);
 
-    SET_VARS({{"g", "scalar"}});
+    SET_VARS({{"g", "scalar", true}});
 
     SET_SIM_CODE("$(addToInSyn, $(g));\n");
 };
@@ -168,7 +168,7 @@ class StaticPulseDendriticDelay : public Base
 public:
     DECLARE_MODEL(StaticPulseDendriticDelay, 0, 2);
 
-    SET_VARS({{"g", "scalar"},{"d", "uint8_t"}});
+    SET_VARS({{"g", "scalar", true},{"d", "uint8_t", true}});
 
     SET_SIM_CODE("$(addToInSynDelay, $(g), $(d));\n");
 };
@@ -205,7 +205,7 @@ public:
     DECLARE_WEIGHT_UPDATE_MODEL(StaticGraded, 2, 1, 0, 0);
 
     SET_PARAM_NAMES({"Epre", "Vslope"});
-    SET_VARS({{"g", "scalar"}});
+    SET_VARS({{"g", "scalar", true}});
 
     SET_EVENT_CODE("$(addToInSyn, max(0.0, $(g) * tanh(($(V_pre) - $(Epre)) / $(Vslope))* DT));\n");
 

--- a/include/genn/genn/weightUpdateModels.h
+++ b/include/genn/genn/weightUpdateModels.h
@@ -111,13 +111,13 @@ public:
     //! Find the index of a named presynaptic variable
     size_t getPreVarIndex(const std::string &varName) const
     {
-        return getVarVecIndex(varName, getPreVars());
+        return getNamedVecIndex(varName, getPreVars());
     }
 
     //! Find the index of a named postsynaptic variable
     size_t getPostVarIndex(const std::string &varName) const
     {
-        return getVarVecIndex(varName, getPostVars());
+        return getNamedVecIndex(varName, getPostVars());
     }
 
 };
@@ -142,7 +142,7 @@ class StaticPulse : public Base
 public:
     DECLARE_WEIGHT_UPDATE_MODEL(StaticPulse, 0, 1, 0, 0);
 
-    SET_VARS({{"g", "scalar", true}});
+    SET_VARS({{"g", "scalar", VarAccess::READ_ONLY}});
 
     SET_SIM_CODE("$(addToInSyn, $(g));\n");
 };
@@ -168,7 +168,7 @@ class StaticPulseDendriticDelay : public Base
 public:
     DECLARE_MODEL(StaticPulseDendriticDelay, 0, 2);
 
-    SET_VARS({{"g", "scalar", true},{"d", "uint8_t", true}});
+    SET_VARS({{"g", "scalar", VarAccess::READ_ONLY},{"d", "uint8_t", VarAccess::READ_ONLY}});
 
     SET_SIM_CODE("$(addToInSynDelay, $(g), $(d));\n");
 };
@@ -205,7 +205,7 @@ public:
     DECLARE_WEIGHT_UPDATE_MODEL(StaticGraded, 2, 1, 0, 0);
 
     SET_PARAM_NAMES({"Epre", "Vslope"});
-    SET_VARS({{"g", "scalar", true}});
+    SET_VARS({{"g", "scalar", VarAccess::READ_ONLY}});
 
     SET_EVENT_CODE("$(addToInSyn, max(0.0, $(g) * tanh(($(V_pre) - $(Epre)) / $(Vslope))* DT));\n");
 

--- a/include/spineml/generator/modelCommon.h
+++ b/include/spineml/generator/modelCommon.h
@@ -78,7 +78,7 @@ public:
         // Populate this vector with either values from map or 0s
         std::transform(modelVars.begin(), modelVars.end(),
                        std::back_inserter(varValues),
-                       [this](const Snippet::Base::Var &n)
+                       [this](const Models::Base::Var &n)
                        {
                            if(n.name == "_regimeID") {
                                return Models::VarInit(InitVarSnippet::Constant::getInstance(),

--- a/pygenn/genn_model.py
+++ b/pygenn/genn_model.py
@@ -53,10 +53,10 @@ from six import iteritems, itervalues
 # pygenn imports
 from . import genn_wrapper
 from .genn_wrapper import SharedLibraryModel as slm
-from .genn_wrapper.Models import VarInit
+from .genn_wrapper.Models import (Var, VarInit, VarVector)
 from .genn_wrapper.InitSparseConnectivitySnippet import Init
-from .genn_wrapper.Snippet import (make_dpf, Var, ParamVal, DerivedParam,
-                                   VarVector, ParamValVector,
+from .genn_wrapper.Snippet import (make_dpf, EGP, ParamVal, DerivedParam,
+                                   EGPVector, ParamValVector,
                                    DerivedParamVector)
 from .genn_wrapper.InitSparseConnectivitySnippet import make_cmlf
 from .genn_wrapper.StlContainers import StringVector
@@ -639,7 +639,7 @@ def create_custom_neuron_class(class_name, param_names=None,
 
     if extra_global_params is not None:
         body["get_extra_global_params"] =\
-            lambda self: VarVector([Var(egp[0], egp[1])
+            lambda self: EGPVector([EGP(egp[0], egp[1])
                                     for egp in extra_global_params])
 
     if additional_input_vars:
@@ -819,7 +819,7 @@ def create_custom_weight_update_class(class_name, param_names=None,
 
     if extra_global_params is not None:
         body["get_extra_global_params"] =\
-            lambda self: VarVector([Var(egp[0], egp[1])
+            lambda self: EGPVector([EGP(egp[0], egp[1])
                                     for egp in extra_global_params])
 
     if pre_var_name_types is not None:
@@ -889,7 +889,7 @@ def create_custom_current_source_class(class_name, param_names=None,
 
     if extra_global_params is not None:
         body["get_extra_global_params"] =\
-            lambda self: VarVector([Var(egp[0], egp[1])
+            lambda self: EGPVector([EGP(egp[0], egp[1])
                                     for egp in extra_global_params])
 
     if custom_body is not None:
@@ -1097,7 +1097,7 @@ def create_custom_sparse_connect_init_snippet_class(class_name,
 
     if extra_global_params is not None:
         body["get_extra_global_params"] =\
-            lambda self: VarVector([Var(egp[0], egp[1])
+            lambda self: EGPVector([EGP(egp[0], egp[1])
                                     for egp in extra_global_params])
 
     if custom_body is not None:

--- a/pygenn/genn_model.py
+++ b/pygenn/genn_model.py
@@ -824,12 +824,12 @@ def create_custom_weight_update_class(class_name, param_names=None,
 
     if pre_var_name_types is not None:
         body["get_pre_vars"] =\
-            lambda self: VarVector([Var(vn[0], vn[1])
+            lambda self: VarVector([Var(*vn)
                                     for vn in pre_var_name_types])
 
     if post_var_name_types is not None:
         body["get_post_vars"] =\
-            lambda self: VarVector([Var(vn[0], vn[1])
+            lambda self: VarVector([Var(*vn)
                                     for vn in post_var_name_types])
 
     if is_pre_spike_time_required is not None:
@@ -938,7 +938,7 @@ def create_custom_model_class(class_name, base, param_names, var_name_types,
 
     if var_name_types is not None:
         body["get_vars"] =\
-            lambda self: VarVector([Var(vn[0], vn[1])
+            lambda self: VarVector([Var(*vn)
                                     for vn in var_name_types])
 
     if derived_params is not None:

--- a/pygenn/genn_wrapper/swig/Models.i
+++ b/pygenn/genn_wrapper/swig/Models.i
@@ -25,6 +25,7 @@
 #include "initVarSnippetCustom.h"
 %}
 
+%feature("flatnested", "1");
 %rename("%(undercase)s", %$isfunction, notregexmatch$name="add[a-zA-Z]*Population", notregexmatch$name="addCurrentSource", notregexmatch$name="assignExternalPointer[a-zA-Z]*") "";
 
 %ignore LegacyWrapper;
@@ -37,7 +38,15 @@
 %include "gennExport.h"
 %feature("director") Models::Base; // for inheritance in python
 %nodefaultctor Models::VarInit;
+
+// flatten nested classes
+%rename (Var) Models::Base::Var;
+
+// add vector overrides for them
+%template(VarVector) std::vector<Models::Base::Var>;
+
 %include "models.h"
+
 
 %nodefaultctor CustomValues::VarValues;
 %include "customVarValues.h"

--- a/pygenn/genn_wrapper/swig/Snippet.i
+++ b/pygenn/genn_wrapper/swig/Snippet.i
@@ -28,12 +28,12 @@
 
 
 // flatten nested classes
-%rename (Var) Snippet::Base::Var;
+%rename (EGP) Snippet::Base::EGP;
 %rename (ParamVal) Snippet::Base::ParamVal;
 %rename (DerivedParam) Snippet::Base::DerivedParam;
 
 // add vector overrides for them
-%template(VarVector) std::vector<Snippet::Base::Var>;
+%template(EGPVector) std::vector<Snippet::Base::EGP>;
 %template(ParamValVector) std::vector<Snippet::Base::ParamVal>;
 %template(DerivedParamVector) std::vector<Snippet::Base::DerivedParam>;
 
@@ -41,10 +41,10 @@
 %include "snippet.h"
 
 // Extend each of the underlying structs with constructors
-%extend Snippet::Base::Var {
-    Var(const std::string &name, const std::string &type) 
+%extend Snippet::Base::EGP {
+    EGP(const std::string &name, const std::string &type) 
     {
-        Snippet::Base::Var* v = new Snippet::Base::Var();
+        Snippet::Base::EGP* v = new Snippet::Base::EGP();
         v->name = name;
         v->type = type;
         return v;

--- a/pygenn/model_preprocessor.py
+++ b/pygenn/model_preprocessor.py
@@ -73,7 +73,7 @@ def prepare_model(model, param_space, var_space, pre_var_space=None,
 
     if model_family == genn_wrapper.WeightUpdateModels:
         pre_var_names = [vnt.name for vnt in m_instance.get_pre_vars()]
-        if set(iterkeys(pre_var_space)) != set(pre_var_names):
+        if pre_var_space is not None and set(iterkeys(pre_var_space)) != set(pre_var_names):
             raise ValueError("Invalid presynaptic variable initializers "
                              "for {0}".format(model_family.__name__))
         pre_var_dict = {
@@ -81,9 +81,9 @@ def prepare_model(model, param_space, var_space, pre_var_space=None,
             for vnt in m_instance.get_pre_vars()}
 
         post_var_names = [vnt.name for vnt in m_instance.get_post_vars()]
-        if set(iterkeys(post_var_space)) != set(post_var_names):
+        if post_var_space is not None and set(iterkeys(post_var_space)) != set(post_var_names):
             raise ValueError("Invalid postsynaptic variable initializers "
-                             "for {0}".format(model_family.__name__))
+                            "for {0}".format(model_family.__name__))
         post_var_dict = {
             vnt.name: Variable(vnt.name, vnt.type, post_var_space[vnt.name])
             for vnt in m_instance.get_post_vars()}

--- a/src/genn/backends/cuda/backend.cc
+++ b/src/genn/backends/cuda/backend.cc
@@ -90,7 +90,7 @@ bool isSparseInitRequired(const SynapseGroupInternal &sg)
             && (sg.isWUVarInitRequired() || !sg.getWUModel()->getLearnPostCode().empty() || !sg.getWUModel()->getSynapseDynamicsCode().empty()));
 }
 //-----------------------------------------------------------------------
-void updateExtraGlobalParams(const std::string &varSuffix, const std::string &codeSuffix, const Models::Base::VarVec &extraGlobalParameters,
+void updateExtraGlobalParams(const std::string &varSuffix, const std::string &codeSuffix, const Snippet::Base::EGPVec &extraGlobalParameters,
                              std::map<std::string, std::string> &kernelParameters, const std::vector<std::string> &codeStrings)
 {
     // Loop through list of global parameters

--- a/src/genn/genn/code_generator/codeGenUtils.cc
+++ b/src/genn/genn/code_generator/codeGenUtils.cc
@@ -174,7 +174,7 @@ void neuronSubstitutionsInSynapticCode(
     DerivedParamNameIterCtx preDerivedParams(neuronModel->getDerivedParams());
     value_substitutions(wCode, preDerivedParams.nameBegin, preDerivedParams.nameEnd, ng->getDerivedParams(), sourceSuffix);
 
-    VarNameIterCtx preExtraGlobalParams(neuronModel->getExtraGlobalParams());
+    EGPNameIterCtx preExtraGlobalParams(neuronModel->getExtraGlobalParams());
     name_substitutions(wCode, "", preExtraGlobalParams.nameBegin, preExtraGlobalParams.nameEnd, ng->getName(), sourceSuffix);
 }
 

--- a/src/genn/genn/code_generator/generateInit.cc
+++ b/src/genn/genn/code_generator/generateInit.cc
@@ -36,7 +36,7 @@ void applySparsConnectInitSnippetSubstitutions(std::string &code, const SynapseG
 
     // Substitue derived and standard parameters into init code
     DerivedParamNameIterCtx viDerivedParams(connectInit.getSnippet()->getDerivedParams());
-    VarNameIterCtx viExtraGlobalParams(connectInit.getSnippet()->getExtraGlobalParams());
+    EGPNameIterCtx viExtraGlobalParams(connectInit.getSnippet()->getExtraGlobalParams());
     value_substitutions(code, connectInit.getSnippet()->getParamNames(), connectInit.getParams());
     value_substitutions(code, viDerivedParams.nameBegin, viDerivedParams.nameEnd, connectInit.getDerivedParams());
     name_substitutions(code, "", viExtraGlobalParams.nameBegin, viExtraGlobalParams.nameEnd, sg.getName());

--- a/src/genn/genn/code_generator/generateSynapseUpdate.cc
+++ b/src/genn/genn/code_generator/generateSynapseUpdate.cc
@@ -24,7 +24,7 @@ void applySynapseSubstitutions(CodeGenerator::CodeStream &os, std::string code, 
 
     // Create iteration context to iterate over the variables; derived and extra global parameters
     DerivedParamNameIterCtx wuDerivedParams(wu->getDerivedParams());
-    VarNameIterCtx wuExtraGlobalParams(wu->getExtraGlobalParams());
+    EGPNameIterCtx wuExtraGlobalParams(wu->getExtraGlobalParams());
     VarNameIterCtx wuVars(wu->getVars());
     VarNameIterCtx wuPreVars(wu->getPreVars());
     VarNameIterCtx wuPostVars(wu->getPostVars());
@@ -83,7 +83,7 @@ void CodeGenerator::generateSynapseUpdate(CodeStream &os, const ModelSpecInterna
 
             // Make weight update model substitutions
             DerivedParamNameIterCtx wuDerivedParams(sg.getWUModel()->getDerivedParams());
-            VarNameIterCtx wuExtraGlobalParams(sg.getWUModel()->getExtraGlobalParams());
+            EGPNameIterCtx wuExtraGlobalParams(sg.getWUModel()->getExtraGlobalParams());
             value_substitutions(code, sg.getWUModel()->getParamNames(), sg.getWUParams());
             value_substitutions(code, wuDerivedParams.nameBegin, wuDerivedParams.nameEnd, sg.getWUDerivedParams());
             name_substitutions(code, "", wuExtraGlobalParams.nameBegin, wuExtraGlobalParams.nameEnd, sg.getName());

--- a/src/genn/genn/modelSpec.cc
+++ b/src/genn/genn/modelSpec.cc
@@ -157,7 +157,7 @@ void ModelSpec::finalize()
                 assert(!wu->getEventThresholdConditionCode().empty());
 
                  // Create iteration context to iterate over derived and extra global parameters
-                VarNameIterCtx wuExtraGlobalParams(wu->getExtraGlobalParams());
+                EGPNameIterCtx wuExtraGlobalParams(wu->getExtraGlobalParams());
                 DerivedParamNameIterCtx wuDerivedParams(wu->getDerivedParams());
 
                 // do an early replacement of parameters, derived parameters and extraglobalsynapse parameters

--- a/src/spineml/generator/modelCommon.cc
+++ b/src/spineml/generator/modelCommon.cc
@@ -335,7 +335,7 @@ std::string SpineMLGenerator::getSendPortCode(const std::map<std::string, std::s
 
     // If this send port corresponds to a state variable
     auto correspondingVar = std::find_if(vars.begin(), vars.end(),
-                                         [sendPortName](const Snippet::Base::Var &v)
+                                         [sendPortName](const Models::Base::Var &v)
                                          {
                                              return (v.name == sendPortName);
                                         });

--- a/src/spineml/generator/postsynapticModel.cc
+++ b/src/spineml/generator/postsynapticModel.cc
@@ -308,7 +308,7 @@ SpineMLGenerator::PostsynapticModel::PostsynapticModel(const ModelParams::Postsy
 
         // As this variable is being implemented using a built in GeNN state variable, remove it from variables
         auto stateVar = std::find_if(m_Vars.begin(), m_Vars.end(),
-                                     [impulseAssignStateVar](const Snippet::Base::Var &var)
+                                     [impulseAssignStateVar](const Models::Base::Var &var)
                                      {
                                          return (var.name == impulseAssignStateVar);
                                      });


### PR DESCRIPTION
This change allows you to specify whether state variables are readonly when you define a model e.g. in the ``IzhikevichVariable (using syntax similar to that suggested in  #55):
```c++
class IzhikevichVariable : public Izhikevich
{
public:
    DECLARE_MODEL(NeuronModels::IzhikevichVariable, 0, 6);

    SET_PARAM_NAMES({});
    SET_VARS({{"V","scalar"}, {"U", "scalar"}, 
              {"a", "scalar", VarAccess::READ_ONLY}, {"b", "scalar", VarAccess::READ_ONLY}, 
              {"c", "scalar", VarAccess::READ_ONLY}, {"d", "scalar", VarAccess::READ_ONLY}});
};
```
Knowing whether state variables are read-only is useful in two ways:
- Immediately: to remove unnecessary writes of neuron and postsynaptic; and pre and postsynaptic post weight update model state variable back to global memory (to some extent aiding #55) - depending on dumbness of CUDA compiler this could reduce memory bandwidth and reduce register pressure
- In future: this allows all kinds of useful 'analysis' e.g. to determine if state variables can be optimised out either in the style of ``GLOBALG`` 
 (this is something that I think is done in the PyNN, SpineML and, I suspect, Brian frontends) or by the long-dreamed-of Izhikevich style re-sampling