### PR TITLE
Hybrid parallelism

### DIFF
--- a/include/genn/genn/synapseGroup.h
+++ b/include/genn/genn/synapseGroup.h
@@ -95,6 +95,10 @@ public:
     /*! with a thread per target neuron (default) or a thread per source spike */
     void setSpanType(SpanType spanType);
 
+    //! Set how many threads CUDA implementation uses to process each spike when span type is PRESYNAPTIC
+    // **TODO** this shouldn't be in SynapseGroup - it's backend-specific
+    void setNumThreadsPerSpike(unsigned int numThreadsPerSpike);
+
     //! Sets the number of delay steps used to delay postsynaptic spikes travelling back along dendrites to synapses
     void setBackPropDelaySteps(unsigned int timesteps);
 
@@ -104,6 +108,7 @@ public:
     const std::string &getName() const{ return m_Name; }
 
     SpanType getSpanType() const{ return m_SpanType; }
+    unsigned int getNumThreadsPerSpike() const{ return m_NumThreadsPerSpike; }
     unsigned int getDelaySteps() const{ return m_DelaySteps; }
     unsigned int getBackPropDelaySteps() const{ return m_BackPropDelaySteps; }
     unsigned int getMaxConnections() const{ return m_MaxConnections; }
@@ -267,6 +272,9 @@ private:
 
     //! Execution order of synapses in the kernel. It determines whether synapses are executed in parallel for every postsynaptic neuron, or for every presynaptic neuron.
     SpanType m_SpanType;
+
+    //! How many threads CUDA implementation uses to process each spike when span type is PRESYNAPTIC
+    unsigned int m_NumThreadsPerSpike;
 
     //! Global synaptic conductance delay for the group (in time steps)
     unsigned int m_DelaySteps;

--- a/src/genn/genn/synapseGroup.cc
+++ b/src/genn/genn/synapseGroup.cc
@@ -131,6 +131,16 @@ void SynapseGroup::setSpanType(SpanType spanType)
     }
 }
 //----------------------------------------------------------------------------
+void SynapseGroup::setNumThreadsPerSpike(unsigned int numThreadsPerSpike)
+{
+    if (m_SpanType == SpanType::PRESYNAPTIC) {
+        m_NumThreadsPerSpike = numThreadsPerSpike;
+    }
+    else {
+        throw std::runtime_error("setSpanType: This function is not enabled for dense connectivity type.");
+    }
+}
+//----------------------------------------------------------------------------
 void SynapseGroup::setBackPropDelaySteps(unsigned int timesteps)
 {
     m_BackPropDelaySteps = timesteps;
@@ -288,7 +298,7 @@ SynapseGroup::SynapseGroup(const std::string name, SynapseMatrixType matrixType,
                            NeuronGroupInternal *srcNeuronGroup, NeuronGroupInternal *trgNeuronGroup,
                            const InitSparseConnectivitySnippet::Init &connectivityInitialiser,
                            VarLocation defaultVarLocation, VarLocation defaultExtraGlobalParamLocation, VarLocation defaultSparseConnectivityLocation)
-    :   m_Name(name), m_SpanType(SpanType::POSTSYNAPTIC), m_DelaySteps(delaySteps), m_BackPropDelaySteps(0),
+    :   m_Name(name), m_SpanType(SpanType::POSTSYNAPTIC), m_NumThreadsPerSpike(1), m_DelaySteps(delaySteps), m_BackPropDelaySteps(0),
         m_MaxDendriticDelayTimesteps(1), m_MatrixType(matrixType),  m_SrcNeuronGroup(srcNeuronGroup), m_TrgNeuronGroup(trgNeuronGroup),
         m_EventThresholdReTestRequired(false),
         m_InSynLocation(defaultVarLocation),  m_DendriticDelayLocation(defaultVarLocation),

--- a/tests/features/decode_matrix_globalg_ragged_hybrid/Makefile
+++ b/tests/features/decode_matrix_globalg_ragged_hybrid/Makefile
@@ -1,0 +1,1 @@
+../../utils/Makefile

--- a/tests/features/decode_matrix_globalg_ragged_hybrid/model.cc
+++ b/tests/features/decode_matrix_globalg_ragged_hybrid/model.cc
@@ -1,0 +1,48 @@
+//--------------------------------------------------------------------------
+/*! \file decode_matrix_globalg_ragged_hybrid/model.cc
+
+\brief model definition file that is part of the feature testing
+suite of minimal models with known analytic outcomes that are used for continuous integration testing.
+*/
+//--------------------------------------------------------------------------
+
+
+#include "modelSpec.h"
+
+//----------------------------------------------------------------------------
+// Neuron
+//----------------------------------------------------------------------------
+class Neuron : public NeuronModels::Base
+{
+public:
+    DECLARE_MODEL(Neuron, 0, 1);
+
+    SET_SIM_CODE("$(x)= $(Isyn);\n");
+
+    SET_VARS({{"x", "scalar"}});
+};
+
+IMPLEMENT_MODEL(Neuron);
+
+
+void modelDefinition(ModelSpec &model)
+{
+    model.setDT(0.1);
+    model.setName("decode_matrix_globalg_ragged_hybrid");
+
+    // Static synapse parameters
+    WeightUpdateModels::StaticPulse::VarValues staticSynapseInit(1.0);    // 0 - Wij (nA)
+
+    model.addNeuronPopulation<NeuronModels::SpikeSource>("Pre", 10, {}, {});
+    model.addNeuronPopulation<Neuron>("Post", 4, {}, Neuron::VarValues(0.0));
+
+
+    auto *syn = model.addSynapsePopulation<WeightUpdateModels::StaticPulse, PostsynapticModels::DeltaCurr>(
+        "Syn", SynapseMatrixType::SPARSE_GLOBALG, NO_DELAY, "Pre", "Post",
+        {}, staticSynapseInit,
+        {}, {});
+    syn->setSpanType(SynapseGroup::SpanType::PRESYNAPTIC);
+    syn->setNumThreadsPerSpike(2);
+
+    model.setPrecision(GENN_FLOAT);
+}

--- a/tests/features/decode_matrix_globalg_ragged_hybrid/test.cc
+++ b/tests/features/decode_matrix_globalg_ragged_hybrid/test.cc
@@ -1,0 +1,56 @@
+//--------------------------------------------------------------------------
+/*! \file decode_matrix_globalg_ragged_hybrid/test.cc
+
+\brief Main test code that is part of the feature testing
+suite of minimal models with known analytic outcomes that are used for continuous integration testing.
+*/
+//--------------------------------------------------------------------------
+
+
+// Google test includes
+#include "gtest/gtest.h"
+
+// Auto-generated simulation code includess
+#include "decode_matrix_globalg_ragged_hybrid_CODE/definitions.h"
+
+// **NOTE** base-class for simulation tests must be
+// included after auto-generated globals are includes
+#include "../../utils/simulation_test_decoder_matrix.h"
+
+//----------------------------------------------------------------------------
+// SimTest
+//----------------------------------------------------------------------------
+class SimTest : public SimulationTestDecoderMatrix
+{
+public:
+    //----------------------------------------------------------------------------
+    // SimulationTest virtuals
+    //----------------------------------------------------------------------------
+    virtual void Init()
+    {
+        // Loop through presynaptic neurons
+        for(unsigned int i = 0; i < 10; i++)
+        {
+            // Initially zero row length
+            rowLengthSyn[i] = 0;
+            for(unsigned int j = 0; j < 4; j++)
+            {
+                // Get value this post synaptic neuron represents
+                const unsigned int j_value = (1 << j);
+
+                // If this postsynaptic neuron should be connected, add index
+                if(((i + 1) & j_value) != 0)
+                {
+                    const unsigned int idx = (i * 4) + rowLengthSyn[i]++;
+                    indSyn[idx] = j;
+                }
+            }
+        }
+    }
+};
+
+TEST_F(SimTest, DecodeMatrixGlobalgRaggedHybrid)
+{
+    // Check total error is less than some tolerance
+    EXPECT_TRUE(Simulate());
+}

--- a/tests/features/decode_matrix_individualg_ragged_hybrid/Makefile
+++ b/tests/features/decode_matrix_individualg_ragged_hybrid/Makefile
@@ -1,0 +1,1 @@
+../../utils/Makefile

--- a/tests/features/decode_matrix_individualg_ragged_hybrid/model.cc
+++ b/tests/features/decode_matrix_individualg_ragged_hybrid/model.cc
@@ -1,0 +1,47 @@
+//--------------------------------------------------------------------------
+/*! \file decode_matrix_individualg_ragged_hybrid/model.cc
+
+\brief model definition file that is part of the feature testing
+suite of minimal models with known analytic outcomes that are used for continuous integration testing.
+*/
+//--------------------------------------------------------------------------
+
+
+#include "modelSpec.h"
+
+//----------------------------------------------------------------------------
+// Neuron
+//----------------------------------------------------------------------------
+class Neuron : public NeuronModels::Base
+{
+public:
+    DECLARE_MODEL(Neuron, 0, 1);
+
+    SET_SIM_CODE("$(x)= $(Isyn);\n");
+
+    SET_VARS({{"x", "scalar"}});
+};
+
+IMPLEMENT_MODEL(Neuron);
+
+
+void modelDefinition(ModelSpec &model)
+{
+    model.setDT(0.1);
+    model.setName("decode_matrix_individualg_ragged_hybrid");
+
+    // Static synapse parameters
+    WeightUpdateModels::StaticPulse::VarValues staticSynapseInit(1.0);    // 0 - Wij (nA)
+
+    model.addNeuronPopulation<NeuronModels::SpikeSource>("Pre", 10, {}, {});
+    model.addNeuronPopulation<Neuron>("Post", 4, {}, Neuron::VarValues(0.0));
+
+
+    auto *syn = model.addSynapsePopulation<WeightUpdateModels::StaticPulse, PostsynapticModels::DeltaCurr>(
+        "Syn", SynapseMatrixType::SPARSE_INDIVIDUALG, NO_DELAY, "Pre", "Post",
+        {}, staticSynapseInit,
+        {}, {});
+    syn->setSpanType(SynapseGroup::SpanType::PRESYNAPTIC);
+    syn->setNumThreadsPerSpike(2);
+    model.setPrecision(GENN_FLOAT);
+}

--- a/tests/features/decode_matrix_individualg_ragged_hybrid/test.cc
+++ b/tests/features/decode_matrix_individualg_ragged_hybrid/test.cc
@@ -1,0 +1,56 @@
+//--------------------------------------------------------------------------
+/*! \file decode_matrix_individualg_ragged_hybrid/test.cc
+
+\brief Main test code that is part of the feature testing
+suite of minimal models with known analytic outcomes that are used for continuous integration testing.
+*/
+//--------------------------------------------------------------------------
+
+
+// Google test includes
+#include "gtest/gtest.h"
+
+// Auto-generated simulation code includess
+#include "decode_matrix_individualg_ragged_hybrid_CODE/definitions.h"
+
+// **NOTE** base-class for simulation tests must be
+// included after auto-generated globals are includes
+#include "../../utils/simulation_test_decoder_matrix.h"
+
+//----------------------------------------------------------------------------
+// SimTest
+//----------------------------------------------------------------------------
+class SimTest : public SimulationTestDecoderMatrix
+{
+public:
+    //----------------------------------------------------------------------------
+    // SimulationTest virtuals
+    //----------------------------------------------------------------------------
+    virtual void Init()
+    {
+        // Loop through presynaptic neurons
+        for(unsigned int i = 0; i < 10; i++)
+        {
+            // Initially zero row length
+            rowLengthSyn[i] = 0;
+            for(unsigned int j = 0; j < 4; j++)
+            {
+                // Get value this post synaptic neuron represents
+                const unsigned int j_value = (1 << j);
+
+                // If this postsynaptic neuron should be connected, add index
+                if(((i + 1) & j_value) != 0)
+                {
+                    const unsigned int idx = (i * 4) + rowLengthSyn[i]++;
+                    indSyn[idx] = j;
+                }
+            }
+        }
+    }
+};
+
+TEST_F(SimTest, DecodeMatrixIndividualgRaggedHybrid)
+{
+    // Check total error is less than some tolerance
+    EXPECT_TRUE(Simulate());
+}


### PR DESCRIPTION
This is a first attempt at a hybrid between pre and postsynaptic parallelism. Basically multiple threads are spawned to process each row of connectivity. This not only increases parallelism but, because the threads process the row in an interleaved way, it **should** also improve memory coalescing when compared to purely presynaptic parallelism. 

It definitely doesn't result in across-the-board performance improvements but, benchmarking a [moderate sized model](https://github.com/neworderofjamie/genn_examples/tree/master/benchmark) (10k neurons, driven by 10k 10Hz poisson sources via 10% connectivity):
![Presynaptic update kernel time  ms](https://user-images.githubusercontent.com/6793242/62376355-5deb2b80-b538-11e9-8dd5-4e93e0daabe8.png)

illustrates that it can beat the postsynaptic parallelism which was previously the best at anything but really large-scale. This is useful because lots of stuff is tricky to efficiently implement with postsynaptic parallelism, specifically procedural connectivity and stochastic synapses (without a rng state per synapse). Other interesting findings:
- Spawning a thread per presynaptic neuron, even at this low firing rate, doesn't seem to have any adverse effect over dynamic kernel launches
- Modern dynamic parallelism i. e. launching the presynaptic update kernel from an empty 'parent' kernel performs even worse. I suspect the kernel launch latency is probably similar when launching on the host or the device and this outweighs any saving there might be.