### PR TITLE
Unifying system for applying substitutions

### DIFF
--- a/include/genn/genn/code_generator/codeGenUtils.h
+++ b/include/genn/genn/code_generator/codeGenUtils.h
@@ -16,6 +16,11 @@
 class ModelSpecInternal;
 class SynapseGroupInternal;
 
+namespace CodeGenerator
+{
+class Substitutions;
+}
+
 //--------------------------------------------------------------------------
 // CodeGenerator
 //--------------------------------------------------------------------------
@@ -49,56 +54,6 @@ struct FunctionTemplate
 };
 
 //--------------------------------------------------------------------------
-// StructNameConstIter
-//--------------------------------------------------------------------------
-//! Custom iterator for iterating through the containers of structs with 'name' members
-template<typename BaseIter>
-class StructNameConstIter : public BaseIter
-{
-private:
-public:
-    StructNameConstIter() {}
-    StructNameConstIter(BaseIter iter) : BaseIter(iter) {}
-
-    //--------------------------------------------------------------------------
-    // Operators
-    //--------------------------------------------------------------------------
-    const std::string *operator->() const
-    {
-        return static_cast<const std::string*>(&BaseIter::operator->()->name);
-    }
-
-    const std::string &operator*() const
-    {
-        return BaseIter::operator*().name;
-    }
-};
-
-//----------------------------------------------------------------------------
-// NameIterCtx
-//----------------------------------------------------------------------------
-template<typename Container>
-struct NameIterCtx
-{
-    typedef StructNameConstIter<typename Container::const_iterator> NameIter;
-
-    NameIterCtx(const Container &c) :
-        container(c), nameBegin(std::begin(container)), nameEnd(std::end(container)){}
-
-    const Container container;
-    const NameIter nameBegin;
-    const NameIter nameEnd;
-};
-
-//----------------------------------------------------------------------------
-// Typedefines
-//----------------------------------------------------------------------------
-typedef NameIterCtx<Models::Base::VarVec> VarNameIterCtx;
-typedef NameIterCtx<Snippet::Base::EGPVec> EGPNameIterCtx;
-typedef NameIterCtx<Snippet::Base::DerivedParamVec> DerivedParamNameIterCtx;
-typedef NameIterCtx<Snippet::Base::ParamValVec> ParamValIterCtx;
-
-//--------------------------------------------------------------------------
 //! \brief Tool for substituting strings in the neuron code strings or other templates
 //--------------------------------------------------------------------------
 void substitute(std::string &s, const std::string &trg, const std::string &rep);
@@ -126,19 +81,6 @@ bool regexFuncSubstitute(std::string &s, const std::string &trg, const std::stri
 //--------------------------------------------------------------------------
 void functionSubstitute(std::string &code, const std::string &funcName,
                         unsigned int numParams, const std::string &replaceFuncTemplate);
-
-//--------------------------------------------------------------------------
-//! \brief This function performs a list of name substitutions for variables in code snippets.
-//--------------------------------------------------------------------------
-/*template<typename NameIter>
-inline void name_substitutions(std::string &code, const std::string &prefix, NameIter namesBegin, NameIter namesEnd, const std::string &postfix= "", const std::string &ext = "")
-{
-    for (NameIter n = namesBegin; n != namesEnd; n++) {
-        substitute(code,
-                   "$(" + *n + ext + ")",
-                   prefix + *n + postfix);
-    }
-}*/
 
 //--------------------------------------------------------------------------
 //! \brief This function writes a floating point value to a stream -setting the precision so no digits are lost
@@ -179,33 +121,6 @@ std::string writePreciseString(T value)
 }
 
 //--------------------------------------------------------------------------
-//! \brief This function performs a list of value substitutions for parameters in code snippets.
-//--------------------------------------------------------------------------
-template<typename T>
-inline void value_substitutions(std::string &code, std::map<std::string, T>::const_iterator varBegin,
-                                std::map<std::string, T>::const_iterator varEnd,
-                                const std::vector<double> &values, const std::string &ext = "")
-{
-    auto n = namesBegin;
-    auto v = values.cbegin();
-    for (;n != namesEnd && v != values.cend(); n++, v++) {
-        std::stringstream stream;
-        writePreciseString(stream, *v);
-        substitute(code,
-                   "$(" + *n + ext + ")",
-                   "(" + stream.str() + ")");
-    }
-}
-
-//--------------------------------------------------------------------------
-//! \brief This function performs a list of value substitutions for parameters in code snippets.
-//--------------------------------------------------------------------------
-inline void value_substitutions(std::string &code, const std::vector<std::string> &names, const std::vector<double> &values, const std::string &ext = "")
-{
-    value_substitutions(code, names.cbegin(), names.cend(), values, ext);
-}
-
-//--------------------------------------------------------------------------
 /*! \brief This function implements a parser that converts any floating point constant in a code snippet to a floating point constant with an explicit precision (by appending "f" or removing it).
  */
 //--------------------------------------------------------------------------
@@ -219,7 +134,7 @@ std::string ensureFtype(const std::string &oldcode, const std::string &type);
 void checkUnreplacedVariables(const std::string &code, const std::string &codeName);
 
 void preNeuronSubstitutionsInSynapticCode(
-    std::string &wCode, //!< the code string to work on
+    Substitutions &substitutions,
     const SynapseGroupInternal &sg,
     const std::string &offset,
     const std::string &axonalDelayOffset,
@@ -229,7 +144,7 @@ void preNeuronSubstitutionsInSynapticCode(
     const std::string &preVarSuffix = "");   //!< suffix to be used for presynaptic variable accesses - typically combined with prefix to wrap in function call such as __ldg(&XXX)
 
 void postNeuronSubstitutionsInSynapticCode(
-    std::string &wCode, //!< the code string to work on
+    Substitutions &substitutions,
     const SynapseGroupInternal &sg,
     const std::string &offset,
     const std::string &backPropDelayOffset,
@@ -244,7 +159,7 @@ void postNeuronSubstitutionsInSynapticCode(
 */
 //-------------------------------------------------------------------------
 void neuronSubstitutionsInSynapticCode(
-    std::string &wCode,                      //!< the code string to work on
+    Substitutions &substitutions,
     const SynapseGroupInternal &sg,             //!< the synapse group connecting the pre and postsynaptic neuron populations whose parameters might need to be substituted
     const std::string &preIdx,               //!< index of the pre-synaptic neuron to be accessed for _pre variables; differs for different Span)
     const std::string &postIdx,              //!< index of the post-synaptic neuron to be accessed for _post variables; differs for different Span)

--- a/include/genn/genn/code_generator/codeGenUtils.h
+++ b/include/genn/genn/code_generator/codeGenUtils.h
@@ -130,7 +130,7 @@ void functionSubstitute(std::string &code, const std::string &funcName,
 //--------------------------------------------------------------------------
 //! \brief This function performs a list of name substitutions for variables in code snippets.
 //--------------------------------------------------------------------------
-template<typename NameIter>
+/*template<typename NameIter>
 inline void name_substitutions(std::string &code, const std::string &prefix, NameIter namesBegin, NameIter namesEnd, const std::string &postfix= "", const std::string &ext = "")
 {
     for (NameIter n = namesBegin; n != namesEnd; n++) {
@@ -138,15 +138,7 @@ inline void name_substitutions(std::string &code, const std::string &prefix, Nam
                    "$(" + *n + ext + ")",
                    prefix + *n + postfix);
     }
-}
-
-//--------------------------------------------------------------------------
-//! \brief This function performs a list of name substitutions for variables in code snippets.
-//--------------------------------------------------------------------------
-inline void name_substitutions(std::string &code, const std::string &prefix, const std::vector<std::string> &names, const std::string &postfix= "", const std::string &ext = "")
-{
-    name_substitutions(code, prefix, names.cbegin(), names.cend(), postfix, ext);
-}
+}*/
 
 //--------------------------------------------------------------------------
 //! \brief This function writes a floating point value to a stream -setting the precision so no digits are lost
@@ -189,10 +181,12 @@ std::string writePreciseString(T value)
 //--------------------------------------------------------------------------
 //! \brief This function performs a list of value substitutions for parameters in code snippets.
 //--------------------------------------------------------------------------
-template<typename NameIter>
-inline void value_substitutions(std::string &code, NameIter namesBegin, NameIter namesEnd, const std::vector<double> &values, const std::string &ext = "")
+template<typename T>
+inline void value_substitutions(std::string &code, std::map<std::string, T>::const_iterator varBegin,
+                                std::map<std::string, T>::const_iterator varEnd,
+                                const std::vector<double> &values, const std::string &ext = "")
 {
-    NameIter n = namesBegin;
+    auto n = namesBegin;
     auto v = values.cbegin();
     for (;n != namesEnd && v != values.cend(); n++, v++) {
         std::stringstream stream;

--- a/include/genn/genn/code_generator/substitutions.h
+++ b/include/genn/genn/code_generator/substitutions.h
@@ -5,6 +5,9 @@
 #include <stdexcept>
 #include <string>
 
+// PLOG includes
+#include <plog/Log.h>
+
 // Standard C includes
 #include <cassert>
 
@@ -165,6 +168,7 @@ private:
     {
         // Apply variable substitutions
         for(const auto &v : m_VarSubstitutions) {
+            LOGD << "Substituting '$(" << v.first << ")' for '" << v.second << "'";
             substitute(code, "$(" + v.first + ")", v.second);
         }
 

--- a/include/genn/genn/code_generator/substitutions.h
+++ b/include/genn/genn/code_generator/substitutions.h
@@ -37,12 +37,12 @@ public:
     // Public API
     //--------------------------------------------------------------------------
     template<typename T>
-    void addVarNameSubstitution(const std::map<std::string, T> &sourceVars, const std::string &sourceSuffix = "",
+    void addVarNameSubstitution(const std::vector<T> &variables, const std::string &sourceSuffix = "",
                                 const std::string &destPrefix = "", const std::string &destSuffix = "")
     {
         for(const auto &v : variables) {
-            addVarSubstitution(v.first + sourceSuffix,
-                               destPrefix + v.first + destSuffix);
+            addVarSubstitution(v.name + sourceSuffix,
+                               destPrefix + v.name + destSuffix);
         }
     }
 
@@ -56,24 +56,24 @@ public:
     }
 
     template<typename T>
-    void addVarValueSubstitution(const std::map<std::string, T> &sourceVars, const std::vector<double> &varVals,
+    void addVarValueSubstitution(const std::vector<T> &variables, const std::vector<double> &values,
                                  const std::string &sourceSuffix = "")
     {
-        if(sourceVars.size() != varVals.size()) {
+        if(variables.size() != values.size()) {
             throw std::runtime_error("Number of variables does not match number of values");
         }
 
-        auto var = sourceVars.cbegin();
+        auto var = variables.cbegin();
         auto val = values.cbegin();
-        for (;var != sourceVars.cend() && val != varVals.cend(); var++, val++) {
+        for (;var != variables.cend() && val != values.cend(); var++, val++) {
             std::stringstream stream;
             writePreciseString(stream, *val);
-            addVarSubstitution(v.first + sourceSuffix,
+            addVarSubstitution(var->name + sourceSuffix,
                                stream.str());
         }
     }
 
-    void addParamValueSubstitution(const std::vector<std::string> &paramNames, const std::vector<double> &paramVals,
+    void addParamValueSubstitution(const std::vector<std::string> &paramNames, const std::vector<double> &values,
                                    const std::string &sourceSuffix = "")
     {
         if(paramNames.size() != values.size()) {
@@ -82,7 +82,7 @@ public:
 
         auto param = paramNames.cbegin();
         auto val = values.cbegin();
-        for (;param != paramNames.cend() && val != varVals.cend(); param++, val++) {
+        for (;param != paramNames.cend() && val != values.cend(); param++, val++) {
             std::stringstream stream;
             writePreciseString(stream, *val);
             addVarSubstitution(*param + sourceSuffix,

--- a/include/genn/genn/code_generator/substitutions.h
+++ b/include/genn/genn/code_generator/substitutions.h
@@ -139,6 +139,12 @@ public:
         applyVars(code);
     }
 
+    void applyCheckUnreplaced(std::string &code, const std::string &context) const
+    {
+        apply(code);
+        checkUnreplacedVariables(code, context);
+    }
+
     //--------------------------------------------------------------------------
     // Public API
     //--------------------------------------------------------------------------

--- a/include/genn/genn/code_generator/substitutions.h
+++ b/include/genn/genn/code_generator/substitutions.h
@@ -36,6 +36,61 @@ public:
     //--------------------------------------------------------------------------
     // Public API
     //--------------------------------------------------------------------------
+    template<typename T>
+    void addVarNameSubstitution(const std::map<std::string, T> &sourceVars, const std::string &sourceSuffix = "",
+                                const std::string &destPrefix = "", const std::string &destSuffix = "")
+    {
+        for(const auto &v : variables) {
+            addVarSubstitution(v.first + sourceSuffix,
+                               destPrefix + v.first + destSuffix);
+        }
+    }
+
+    void addParamNameSubstitution(const std::vector<std::string> &paramNames, const std::string &sourceSuffix = "",
+                                  const std::string &destPrefix = "", const std::string &destSuffix = "")
+    {
+        for(const auto &p : paramNames) {
+            addVarSubstitution(p + sourceSuffix,
+                               destPrefix + p + destSuffix);
+        }
+    }
+
+    template<typename T>
+    void addVarValueSubstitution(const std::map<std::string, T> &sourceVars, const std::vector<double> &varVals,
+                                 const std::string &sourceSuffix = "")
+    {
+        if(sourceVars.size() != varVals.size()) {
+            throw std::runtime_error("Number of variables does not match number of values");
+        }
+
+        auto var = sourceVars.cbegin();
+        auto val = values.cbegin();
+        for (;var != sourceVars.cend() && val != varVals.cend(); var++, val++) {
+            std::stringstream stream;
+            writePreciseString(stream, *val);
+            addVarSubstitution(v.first + sourceSuffix,
+                               stream.str());
+        }
+    }
+
+    void addParamValueSubstitution(const std::vector<std::string> &paramNames, const std::vector<double> &paramVals,
+                                   const std::string &sourceSuffix = "")
+    {
+        if(paramNames.size() != values.size()) {
+            throw std::runtime_error("Number of parameters does not match number of values");
+        }
+
+        auto param = paramNames.cbegin();
+        auto val = values.cbegin();
+        for (;param != paramNames.cend() && val != varVals.cend(); param++, val++) {
+            std::stringstream stream;
+            writePreciseString(stream, *val);
+            addVarSubstitution(*param + sourceSuffix,
+                               stream.str());
+        }
+
+    }
+
     void addVarSubstitution(const std::string &source, const std::string &destionation, bool allowOverride = false)
     {
         auto res = m_VarSubstitutions.emplace(source, destionation);

--- a/src/genn/genn/code_generator/codeGenUtils.cc
+++ b/src/genn/genn/code_generator/codeGenUtils.cc
@@ -24,6 +24,9 @@
 // GeNN includes
 #include "modelSpec.h"
 
+// GeNN code generator includes
+#include "code_generator/substitutions.h"
+
 //--------------------------------------------------------------------------
 // Anonymous namespace
 //--------------------------------------------------------------------------
@@ -147,7 +150,7 @@ void doFinal(std::string &code, unsigned int i, const std::string &type, unsigne
 }
 
 void neuronSubstitutionsInSynapticCode(
-    std::string &wCode, //!< the code string to work on
+    CodeGenerator::Substitutions &substitutions,
     const NeuronGroupInternal *ng,
     const std::string &offset,
     const std::string &delayOffset,
@@ -161,21 +164,17 @@ void neuronSubstitutionsInSynapticCode(
 
     // presynaptic neuron variables, parameters, and global parameters
     const auto *neuronModel = ng->getNeuronModel();
-    substitute(wCode, "$(sT" + sourceSuffix + ")",
-               "(" + delayOffset + varPrefix + devPrefix+ "sT" + ng->getName() + "[" + offset + idx + "]" + varSuffix + ")");
+    substitutions.addVarSubstitution("$(sT" + sourceSuffix + ")",
+                                     "(" + delayOffset + varPrefix + devPrefix+ "sT" + ng->getName() + "[" + offset + idx + "]" + varSuffix + ")");
     for(const auto &v : neuronModel->getVars()) {
         const std::string varIdx = ng->isVarQueueRequired(v.name) ? offset + idx : idx;
 
-        substitute(wCode, "$(" + v.name + sourceSuffix + ")",
-                   varPrefix + devPrefix + v.name + ng->getName() + "[" + varIdx + "]" + varSuffix);
+        substitutions.addVarSubstitution("$(" + v.name + sourceSuffix + ")",
+                                         varPrefix + devPrefix + v.name + ng->getName() + "[" + varIdx + "]" + varSuffix);
     }
-    value_substitutions(wCode, neuronModel->getParamNames(), ng->getParams(), sourceSuffix);
-
-    DerivedParamNameIterCtx preDerivedParams(neuronModel->getDerivedParams());
-    value_substitutions(wCode, preDerivedParams.nameBegin, preDerivedParams.nameEnd, ng->getDerivedParams(), sourceSuffix);
-
-    EGPNameIterCtx preExtraGlobalParams(neuronModel->getExtraGlobalParams());
-    name_substitutions(wCode, "", preExtraGlobalParams.nameBegin, preExtraGlobalParams.nameEnd, ng->getName(), sourceSuffix);
+    substitutions.addParamValueSubstitution(neuronModel->getParamNames(), ng->getParams(), sourceSuffix);
+    substitutions.addVarValueSubstitution(neuronModel->getDerivedParams(), ng->getDerivedParams(), sourceSuffix);
+    substitutions.addVarNameSubstitution(neuronModel->getExtraGlobalParams(), sourceSuffix, "", ng->getName());
 }
 
 bool regexSubstitute(std::string &s, const std::regex &regex, const std::string &format)
@@ -503,7 +502,7 @@ void checkUnreplacedVariables(const std::string &code, const std::string &codeNa
 */
 //-------------------------------------------------------------------------
 void preNeuronSubstitutionsInSynapticCode(
-    std::string &wCode, //!< the code string to work on
+    Substitutions &substitutions, //!< the code string to work on
     const SynapseGroupInternal &sg,
     const std::string &offset,
     const std::string &axonalDelayOffset,
@@ -513,11 +512,11 @@ void preNeuronSubstitutionsInSynapticCode(
     const std::string &preVarSuffix)     //!< suffix to be used for presynaptic variable accesses - typically combined with prefix to wrap in function call such as __ldg(&XXX)
 {
     // presynaptic neuron variables, parameters, and global parameters
-    ::neuronSubstitutionsInSynapticCode(wCode, sg.getSrcNeuronGroup(), offset, axonalDelayOffset, preIdx, "_pre", devPrefix, preVarPrefix, preVarSuffix);
+    ::neuronSubstitutionsInSynapticCode(substitutions, sg.getSrcNeuronGroup(), offset, axonalDelayOffset, preIdx, "_pre", devPrefix, preVarPrefix, preVarSuffix);
 }
 
 void postNeuronSubstitutionsInSynapticCode(
-    std::string &wCode, //!< the code string to work on
+    Substitutions &substitutions, //!< the code string to work on
     const SynapseGroupInternal &sg,
     const std::string &offset,
     const std::string &backPropDelayOffset,
@@ -527,11 +526,11 @@ void postNeuronSubstitutionsInSynapticCode(
     const std::string &postVarSuffix)    //!< suffix to be used for postsynaptic variable accesses - typically combined with prefix to wrap in function call such as __ldg(&XXX)
 {
     // postsynaptic neuron variables, parameters, and global parameters
-    ::neuronSubstitutionsInSynapticCode(wCode, sg.getTrgNeuronGroup(), offset, backPropDelayOffset, postIdx, "_post", devPrefix, postVarPrefix, postVarSuffix);
+    ::neuronSubstitutionsInSynapticCode(substitutions, sg.getTrgNeuronGroup(), offset, backPropDelayOffset, postIdx, "_post", devPrefix, postVarPrefix, postVarSuffix);
 }
 
 void neuronSubstitutionsInSynapticCode(
-    std::string &wCode,                  //!< the code string to work on
+    Substitutions &substitutions,                  //!< the code string to work on
     const SynapseGroupInternal &sg,         //!< the synapse group connecting the pre and postsynaptic neuron populations whose parameters might need to be substituted
     const std::string &preIdx,           //!< index of the pre-synaptic neuron to be accessed for _pre variables; differs for different Span)
     const std::string &postIdx,          //!< index of the post-synaptic neuron to be accessed for _post variables; differs for different Span)
@@ -544,10 +543,10 @@ void neuronSubstitutionsInSynapticCode(
 {
     const std::string axonalDelayOffset = writePreciseString(dt * (double)(sg.getDelaySteps() + 1)) + " + ";
     const std::string preOffset = sg.getSrcNeuronGroup()->isDelayRequired() ? "preReadDelayOffset + " : "";
-    preNeuronSubstitutionsInSynapticCode(wCode, sg, preOffset, axonalDelayOffset, preIdx, devPrefix, preVarPrefix, preVarSuffix);
+    preNeuronSubstitutionsInSynapticCode(substitutions, sg, preOffset, axonalDelayOffset, preIdx, devPrefix, preVarPrefix, preVarSuffix);
     
     const std::string backPropDelayMs = writePreciseString(dt * (double)(sg.getBackPropDelaySteps() + 1)) + " + ";
     const std::string postOffset = sg.getTrgNeuronGroup()->isDelayRequired() ? "postReadDelayOffset + " : "";
-    postNeuronSubstitutionsInSynapticCode(wCode, sg, postOffset, backPropDelayMs, postIdx, devPrefix, postVarPrefix, postVarSuffix);
+    postNeuronSubstitutionsInSynapticCode(substitutions, sg, postOffset, backPropDelayMs, postIdx, devPrefix, postVarPrefix, postVarSuffix);
 }
 }   // namespace CodeGenerator

--- a/src/genn/genn/code_generator/codeGenUtils.cc
+++ b/src/genn/genn/code_generator/codeGenUtils.cc
@@ -164,12 +164,12 @@ void neuronSubstitutionsInSynapticCode(
 
     // presynaptic neuron variables, parameters, and global parameters
     const auto *neuronModel = ng->getNeuronModel();
-    substitutions.addVarSubstitution("$(sT" + sourceSuffix + ")",
+    substitutions.addVarSubstitution("sT" + sourceSuffix,
                                      "(" + delayOffset + varPrefix + devPrefix+ "sT" + ng->getName() + "[" + offset + idx + "]" + varSuffix + ")");
     for(const auto &v : neuronModel->getVars()) {
         const std::string varIdx = ng->isVarQueueRequired(v.name) ? offset + idx : idx;
 
-        substitutions.addVarSubstitution("$(" + v.name + sourceSuffix + ")",
+        substitutions.addVarSubstitution(v.name + sourceSuffix,
                                          varPrefix + devPrefix + v.name + ng->getName() + "[" + varIdx + "]" + varSuffix);
     }
     substitutions.addParamValueSubstitution(neuronModel->getParamNames(), ng->getParams(), sourceSuffix);

--- a/src/genn/genn/code_generator/generateInit.cc
+++ b/src/genn/genn/code_generator/generateInit.cc
@@ -18,12 +18,6 @@
 //--------------------------------------------------------------------------
 namespace
 {
-void addVarInitSnippetSubstitutions(CodeGenerator::Substitutions &subs, const Models::VarInit &varInit)
-{
-    subs.addParamValueSubstitution(varInit.getSnippet()->getParamNames(), varInit.getParams());
-    subs.addVarValueSubstitution(varInit.getSnippet()->getDerivedParams(), varInit.getDerivedParams());
-}
-//--------------------------------------------------------------------------
 void genInitSpikeCount(CodeGenerator::CodeStream &os, const CodeGenerator::BackendBase &backend,
                        const CodeGenerator::Substitutions &popSubs, const NeuronGroupInternal &ng, bool spikeEvent)
 {

--- a/src/genn/genn/code_generator/generateInit.cc
+++ b/src/genn/genn/code_generator/generateInit.cc
@@ -130,9 +130,8 @@ void genInitNeuronVarCode(CodeGenerator::CodeStream &os, const CodeGenerator::Ba
 
 
                         std::string code = varInit.getSnippet()->getCode();
-                        varSubs.apply(code);
+                        varSubs.applyCheckUnreplaced(code, "initVar : " + vars[k].name + popName);
                         code = ensureFtype(code, ftype);
-                        checkUnreplacedVariables(code, "initVar");
                         os << code << std::endl;
 
                         // Copy this into all delay slots
@@ -146,9 +145,8 @@ void genInitNeuronVarCode(CodeGenerator::CodeStream &os, const CodeGenerator::Ba
                         varSubs.addVarSubstitution("value", backend.getVarPrefix() + vars[k].name + popName + "[" + varSubs["id"] + "]");
 
                         std::string code = varInit.getSnippet()->getCode();
-                        varSubs.apply(code);
+                        varSubs.applyCheckUnreplaced(code, "initVar : " + vars[k].name + popName);
                         code = ensureFtype(code, ftype);
-                        checkUnreplacedVariables(code, "initVar");
                         os << code << std::endl;
                     }
                 });
@@ -190,10 +188,8 @@ void genInitWUVarCode(CodeGenerator::CodeStream &os, const CodeGenerator::Backen
                     varSubs.addVarValueSubstitution(varInit.getSnippet()->getDerivedParams(), varInit.getDerivedParams());
 
                     std::string code = varInit.getSnippet()->getCode();
-                    varSubs.apply(code);
-
+                    varSubs.applyCheckUnreplaced(code, "initVar : " + vars[k].name + sg.getName());
                     code = ensureFtype(code, ftype);
-                    checkUnreplacedVariables(code, "initVar");
                     os << code << std::endl;
                 });
         }
@@ -353,9 +349,8 @@ void CodeGenerator::generateInit(CodeStream &os, const ModelSpecInternal &model,
                 popSubs.addVarNameSubstitution(connectInit.getSnippet()->getExtraGlobalParams(), "", "", sg.getName());
 
                 std::string code = connectInit.getSnippet()->getRowBuildCode();
-                popSubs.apply(code);
+                popSubs.applyCheckUnreplaced(code, "initSparseConnectivity : " + sg.getName());
                 code = ensureFtype(code, model.getPrecision());
-                checkUnreplacedVariables(code, "initSparseConnectivity");
 
                 // Write out code
                 os << code << std::endl;

--- a/src/genn/genn/code_generator/generateNeuronUpdate.cc
+++ b/src/genn/genn/code_generator/generateNeuronUpdate.cc
@@ -142,9 +142,8 @@ void CodeGenerator::generateNeuronUpdate(CodeStream &os, const ModelSpecInternal
 
                 // Apply substitutions to current converter code
                 std::string psCode = psm->getApplyInputCode();
-                inSynSubs.apply(psCode);
+                inSynSubs.applyCheckUnreplaced(psCode, "postSyntoCurrent : " + sg->getPSModelTargetName());
                 psCode = ensureFtype(psCode, model.getPrecision());
-                checkUnreplacedVariables(psCode, sg->getPSModelTargetName() + " : postSyntoCurrent");
 
                 if (!psm->getSupportCode().empty()) {
                     os << CodeStream::OB(29) << " using namespace " << sg->getPSModelTargetName() << "_postsyn;" << std::endl;
@@ -176,9 +175,8 @@ void CodeGenerator::generateNeuronUpdate(CodeStream &os, const ModelSpecInternal
                 currSourceSubs.addVarNameSubstitution(csm->getExtraGlobalParams(), "", "", cs->getName());
 
                 std::string iCode = csm->getInjectionCode();
-                currSourceSubs.apply(iCode);
+                currSourceSubs.applyCheckUnreplaced(iCode, "injectionCode : " + cs->getName());
                 iCode = ensureFtype(iCode, model.getPrecision());
-                checkUnreplacedVariables(iCode, cs->getName() + " : current source injectionCode");
                 os << iCode << std::endl;
 
                 // Write read/write variables back to global memory
@@ -200,9 +198,8 @@ void CodeGenerator::generateNeuronUpdate(CodeStream &os, const ModelSpecInternal
             else {
                 os << "// test whether spike condition was fulfilled previously" << std::endl;
 
-                neuronSubs.apply(thCode);
+                neuronSubs.applyCheckUnreplaced(thCode, "thresholdConditionCode : " + ng.getName());
                 thCode= ensureFtype(thCode, model.getPrecision());
-                checkUnreplacedVariables(thCode, ng.getName() + " : thresholdConditionCode");
 
                 if (nm->isAutoRefractoryRequired()) {
                     os << "const bool oldSpike= (" << thCode << ");" << std::endl;
@@ -211,9 +208,8 @@ void CodeGenerator::generateNeuronUpdate(CodeStream &os, const ModelSpecInternal
 
             os << "// calculate membrane potential" << std::endl;
             std::string sCode = nm->getSimCode();
-            neuronSubs.apply(sCode);
+            neuronSubs.applyCheckUnreplaced(sCode, "simCode : " + ng.getName());
             sCode = ensureFtype(sCode, model.getPrecision());
-            checkUnreplacedVariables(sCode, ng.getName() + " : neuron simCode");
 
             os << sCode << std::endl;
 
@@ -230,9 +226,8 @@ void CodeGenerator::generateNeuronUpdate(CodeStream &os, const ModelSpecInternal
                     addNeuronModelSubstitutions(spkEventCondSubs, ng, "_pre");
 
                     std::string eCode = spkEventCond.first;
-                    spkEventCondSubs.apply(eCode);
+                    spkEventCondSubs.applyCheckUnreplaced(eCode, "neuronSpkEvntCondition : " + ng.getName());
                     eCode = ensureFtype(eCode, model.getPrecision());
-                    checkUnreplacedVariables(eCode, ng.getName() + " : neuronSpkEvntCondition");
 
                     // Open scope for spike-like event test
                     os << CodeStream::OB(31);
@@ -273,9 +268,8 @@ void CodeGenerator::generateNeuronUpdate(CodeStream &os, const ModelSpecInternal
                     // add after-spike reset if provided
                     if (!nm->getResetCode().empty()) {
                         std::string rCode = nm->getResetCode();
-                        neuronSubs.apply(rCode);
+                        neuronSubs.applyCheckUnreplaced(rCode, "resetCode : " + ng.getName());
                         rCode = ensureFtype(rCode, model.getPrecision());
-                        checkUnreplacedVariables(rCode, ng.getName() + " : resetCode");
 
                         os << "// spike reset code" << std::endl;
                         os << rCode << std::endl;
@@ -358,9 +352,8 @@ void CodeGenerator::generateNeuronUpdate(CodeStream &os, const ModelSpecInternal
                 addPostsynapticModelSubstitutions(inSynSubs, sg);
 
                 std::string pdCode = psm->getDecayCode();
-                inSynSubs.apply(pdCode);
+                inSynSubs.applyCheckUnreplaced(pdCode, "decayCode : " + sg->getPSModelTargetName());
                 pdCode = ensureFtype(pdCode, model.getPrecision());
-                checkUnreplacedVariables(pdCode, sg->getPSModelTargetName() + " : postSynDecay");
 
                 os << "// the post-synaptic dynamics" << std::endl;
                 if (!psm->getSupportCode().empty()) {
@@ -413,9 +406,8 @@ void CodeGenerator::generateNeuronUpdate(CodeStream &os, const ModelSpecInternal
 
                     // Perform standard substitutions
                     std::string code = sg->getWUModel()->getPreSpikeCode();
-                    preSubs.apply(code);
+                    preSubs.applyCheckUnreplaced(code, "preSpikeCode : " + sg->getName());
                     code = ensureFtype(code, model.getPrecision());
-                    checkUnreplacedVariables(code, sg->getName() + " : simCodePreSpike");
                     os << code;
 
                     // Loop through presynaptic variables into global memory
@@ -464,9 +456,8 @@ void CodeGenerator::generateNeuronUpdate(CodeStream &os, const ModelSpecInternal
 
                     // Perform standard substitutions
                     std::string code = sg->getWUModel()->getPostSpikeCode();
-                    postSubs.apply(code);
+                    postSubs.applyCheckUnreplaced(code, "postSpikeCode : " + sg->getName());
                     code = ensureFtype(code, model.getPrecision());
-                    checkUnreplacedVariables(code, sg->getName() + " : simLearnPostSpike");
                     os << code;
 
                     // Write back presynaptic variables into global memory

--- a/src/genn/genn/code_generator/generateSynapseUpdate.cc
+++ b/src/genn/genn/code_generator/generateSynapseUpdate.cc
@@ -19,41 +19,38 @@ namespace
 void applySynapseSubstitutions(CodeGenerator::CodeStream &os, std::string code, const std::string &errorSuffix, const SynapseGroupInternal &sg,
                                const CodeGenerator::Substitutions &baseSubs, const ModelSpecInternal &model, const CodeGenerator::BackendBase &backend)
 {
-    using namespace CodeGenerator;
     const auto *wu = sg.getWUModel();
 
-    // Create iteration context to iterate over the variables; derived and extra global parameters
-    DerivedParamNameIterCtx wuDerivedParams(wu->getDerivedParams());
-    EGPNameIterCtx wuExtraGlobalParams(wu->getExtraGlobalParams());
-    VarNameIterCtx wuVars(wu->getVars());
-    VarNameIterCtx wuPreVars(wu->getPreVars());
-    VarNameIterCtx wuPostVars(wu->getPostVars());
+    CodeGenerator::Substitutions synapseSubs(&baseSubs);
 
-    value_substitutions(code, sg.getWUModel()->getParamNames(), sg.getWUParams());
-    value_substitutions(code, wuDerivedParams.nameBegin, wuDerivedParams.nameEnd, sg.getWUDerivedParams());
-    name_substitutions(code, "", wuExtraGlobalParams.nameBegin, wuExtraGlobalParams.nameEnd, sg.getName());
+    // Substitute parameter and derived parameter names
+    synapseSubs.addParamValueSubstitution(sg.getWUModel()->getParamNames(), sg.getWUParams());
+    synapseSubs.addVarValueSubstitution(wu->getDerivedParams(), sg.getWUDerivedParams());
+    synapseSubs.addVarNameSubstitution(wu->getExtraGlobalParams(), "", "", sg.getName());
 
     // Substitute names of pre and postsynaptic weight update variables
-    const std::string delayedPreIdx = (sg.getDelaySteps() == NO_DELAY) ? baseSubs["id_pre"] : "preReadDelayOffset + " + baseSubs["id_pre"];
-    name_substitutions(code, backend.getVarPrefix(), wuPreVars.nameBegin, wuPreVars.nameEnd, sg.getName() + "[" + delayedPreIdx + "]");
+    const std::string delayedPreIdx = (sg.getDelaySteps() == NO_DELAY) ? synapseSubs["id_pre"] : "preReadDelayOffset + " + baseSubs["id_pre"];
+    synapseSubs.addVarNameSubstitution(wu->getPreVars(), "", backend.getVarPrefix(),
+                                       sg.getName() + "[" + delayedPreIdx + "]");
 
-    const std::string delayedPostIdx = (sg.getBackPropDelaySteps() == NO_DELAY) ? baseSubs["id_post"] : "postReadDelayOffset + " + baseSubs["id_post"];
-    name_substitutions(code, backend.getVarPrefix(), wuPostVars.nameBegin, wuPostVars.nameEnd, sg.getName() + "[" + delayedPostIdx + "]");
+    const std::string delayedPostIdx = (sg.getBackPropDelaySteps() == NO_DELAY) ? synapseSubs["id_post"] : "postReadDelayOffset + " + baseSubs["id_post"];
+    synapseSubs.addVarNameSubstitution(wu->getPostVars(), "", backend.getVarPrefix(),
+                                       sg.getName() + "[" + delayedPostIdx + "]");
 
     if (sg.getMatrixType() & SynapseMatrixWeight::INDIVIDUAL) {
-        name_substitutions(code, backend.getVarPrefix(), wuVars.nameBegin, wuVars.nameEnd,
-                           sg.getName() + "[" + baseSubs["id_syn"] + "]", "");
+        synapseSubs.addVarNameSubstitution(wu->getVars(), "", backend.getVarPrefix(),
+                                           sg.getName() + "[" + synapseSubs["id_syn"] + "]");
     }
     else {
-        value_substitutions(code, wuVars.nameBegin, wuVars.nameEnd, sg.getWUConstInitVals());
+        synapseSubs.addVarValueSubstitution(wu->getVars(), sg.getWUConstInitVals());
     }
 
-    neuronSubstitutionsInSynapticCode(code, sg, baseSubs["id_pre"],
-                                      baseSubs["id_post"], backend.getVarPrefix(),
+    neuronSubstitutionsInSynapticCode(synapseSubs, sg, synapseSubs["id_pre"],
+                                      synapseSubs["id_post"], backend.getVarPrefix(),
                                       model.getDT());
-    baseSubs.apply(code);
-    code= ensureFtype(code, model.getPrecision());
-    checkUnreplacedVariables(code, sg.getName() + errorSuffix);
+    synapseSubs.apply(code);
+    code= CodeGenerator::ensureFtype(code, model.getPrecision());
+    CodeGenerator::checkUnreplacedVariables(code, sg.getName() + errorSuffix);
     os << code;
 }
 }   // Anonymous namespace
@@ -78,20 +75,19 @@ void CodeGenerator::generateSynapseUpdate(CodeStream &os, const ModelSpecInterna
         // Presynaptic weight update threshold
         [&backend, &model](CodeStream &os, const SynapseGroupInternal &sg, const Substitutions &baseSubs)
         {
-            // Get event threshold condition code
-            std::string code = sg.getWUModel()->getEventThresholdConditionCode();
+            Substitutions synapseSubs(&baseSubs);
 
             // Make weight update model substitutions
-            DerivedParamNameIterCtx wuDerivedParams(sg.getWUModel()->getDerivedParams());
-            EGPNameIterCtx wuExtraGlobalParams(sg.getWUModel()->getExtraGlobalParams());
-            value_substitutions(code, sg.getWUModel()->getParamNames(), sg.getWUParams());
-            value_substitutions(code, wuDerivedParams.nameBegin, wuDerivedParams.nameEnd, sg.getWUDerivedParams());
-            name_substitutions(code, "", wuExtraGlobalParams.nameBegin, wuExtraGlobalParams.nameEnd, sg.getName());
+            synapseSubs.addParamValueSubstitution(sg.getWUModel()->getParamNames(), sg.getWUParams());
+            synapseSubs.addVarValueSubstitution(sg.getWUModel()->getDerivedParams(), sg.getWUDerivedParams());
+            synapseSubs.addVarNameSubstitution(sg.getWUModel()->getExtraGlobalParams(), "", sg.getName());
 
             // Get read offset if required
             const std::string offset = sg.getSrcNeuronGroup()->isDelayRequired() ? "preReadDelayOffset + " : "";
-            preNeuronSubstitutionsInSynapticCode(code, sg, offset, "", baseSubs["id_pre"], backend.getVarPrefix());
+            preNeuronSubstitutionsInSynapticCode(synapseSubs, sg, offset, "", baseSubs["id_pre"], backend.getVarPrefix());
 
+            // Get event threshold condition code
+            std::string code = sg.getWUModel()->getEventThresholdConditionCode();
             baseSubs.apply(code);
             code = ensureFtype(code, model.getPrecision());
             checkUnreplacedVariables(code, sg.getName() + " : evntThreshold");

--- a/src/genn/genn/code_generator/generateSynapseUpdate.cc
+++ b/src/genn/genn/code_generator/generateSynapseUpdate.cc
@@ -79,7 +79,7 @@ void CodeGenerator::generateSynapseUpdate(CodeStream &os, const ModelSpecInterna
             // Make weight update model substitutions
             synapseSubs.addParamValueSubstitution(sg.getWUModel()->getParamNames(), sg.getWUParams());
             synapseSubs.addVarValueSubstitution(sg.getWUModel()->getDerivedParams(), sg.getWUDerivedParams());
-            synapseSubs.addVarNameSubstitution(sg.getWUModel()->getExtraGlobalParams(), "", sg.getName());
+            synapseSubs.addVarNameSubstitution(sg.getWUModel()->getExtraGlobalParams(), "", "", sg.getName());
 
             // Get read offset if required
             const std::string offset = sg.getSrcNeuronGroup()->isDelayRequired() ? "preReadDelayOffset + " : "";

--- a/src/genn/genn/code_generator/generateSynapseUpdate.cc
+++ b/src/genn/genn/code_generator/generateSynapseUpdate.cc
@@ -87,7 +87,7 @@ void CodeGenerator::generateSynapseUpdate(CodeStream &os, const ModelSpecInterna
 
             // Get event threshold condition code
             std::string code = sg.getWUModel()->getEventThresholdConditionCode();
-            baseSubs.applyCheckUnreplaced(code, "eventThresholdConditionCode");
+            synapseSubs.applyCheckUnreplaced(code, "eventThresholdConditionCode");
             code = ensureFtype(code, model.getPrecision());
             os << code;
         },

--- a/src/genn/genn/modelSpec.cc
+++ b/src/genn/genn/modelSpec.cc
@@ -157,7 +157,7 @@ void ModelSpec::finalize()
                 using namespace CodeGenerator;
                 assert(!wu->getEventThresholdConditionCode().empty());
 
-                // do an early replacement of parameters, derived parameters and extraglobalsynapse parameters
+                // do an early replacement of parameters, derived parameters and extra global parameters
                 // **NOTE** this is really gross but I can't really see an alternative - backend logic changes based on whether event threshold retesting is required
                 Substitutions thresholdSubs;
                 thresholdSubs.addParamValueSubstitution(wu->getParamNames(), sg->getWUParams());

--- a/tests/unit/codeGenUtils.cc
+++ b/tests/unit/codeGenUtils.cc
@@ -10,6 +10,7 @@
 
 // GeNN code generator includes
 #include "code_generator/codeGenUtils.h"
+#include "code_generator/substitutions.h"
 
 using namespace CodeGenerator;
 
@@ -63,12 +64,11 @@ protected:
     {
         // Substitute variable for value
         m_Code = "$(test)";
-        std::vector<std::string> names = {"test"};
-        std::vector<double> values = { GetParam() };
-        value_substitutions(m_Code, names, values);
 
-        // For safety, value_substitutions adds brackets around substituted values - trim these out
-        m_Code = m_Code.substr(1, m_Code.size() - 2);
+        // Substitute test parameter for value
+        Substitutions subs;
+        subs.addParamValueSubstitution({"test"}, { GetParam() });
+        subs.apply(m_Code);
     }
 
     //--------------------------------------------------------------------------


### PR DESCRIPTION
I'm afraid this is another building block type feature upon which more exciting things can be built. Basically, in GeNN 4 I added the ``Substitutions`` class which managed 'individual' substitutions of stuff like "$(id)". However there was still ``name_substitution`` and ``value_substitution`` calls going on all over the place for model parameters, variables etc and these were implemented with some particularly gnarly C++ I added early in my GeNN career!

Having a single unified system for substituting stuff not only tidies stuff up but, in future, could allow us to do stuff like add reference counts meaning that things like #232 #47 and #55 could be addressed in a nicer way that just adding increasingly-complex if clauses around them