### PR TITLE
Increase maximum supported grid size

### DIFF
--- a/src/genn/backends/cuda/backend.cc
+++ b/src/genn/backends/cuda/backend.cc
@@ -2128,7 +2128,7 @@ void Backend::genKernelDimensions(CodeStream &os, Kernel kernel, size_t numThrea
     const size_t gridSize = Utils::ceilDivide(numThreads, m_KernelBlockSizes[kernel]);
     os << "const dim3 threads(" << m_KernelBlockSizes[kernel] << ", 1);" << std::endl;
 
-    if (gridSize < (size_t)getChosenCUDADevice().maxGridSize[1]) {
+    if (gridSize < (size_t)getChosenCUDADevice().maxGridSize[0]) {
         os << "const dim3 grid(" << gridSize << ", 1);" << std::endl;
     }
     else {


### PR DESCRIPTION
Due to #277, GeNN 4 only supports generating 1D grids but, as on devices with CC > 3.0, the maximum x dimensions can be 4294967295 this is unlikely to be problematic. However, for some reason, we were checking against the y-dimension instead of the x-dimension. This was the behaviour in GeNN < 4 as well but I don't know why - any memories @tnowotny? Are squarer grids better for some reason?