### PR TITLE
Multithreaded make

### DIFF
--- a/tests/run_tests.sh
+++ b/tests/run_tests.sh
@@ -20,6 +20,13 @@ done
 TESTS_DIR=$(dirname "$0")
 GENN_PATH=$TESTS_DIR/../
 
+# Count cores using approach lifted from https://stackoverflow.com/questions/6481005/how-to-obtain-the-number-of-cpus-cores-in-linux-from-the-command-line
+if [[ $(uname) = "Darwin" ]]; then
+    CORE_COUNT=$(sysctl -n hw.physicalcpu_max)
+else
+    CORE_COUNT=$(lscpu -p | egrep -v '^#' | sort -u -t, -k 2,4 | wc -l)
+fi
+
 # Clean GeNN library
 pushd $GENN_PATH
 make clean COVERAGE=1
@@ -45,7 +52,7 @@ for f in features/*/ ; do
     # Run code generator once, generating coverage
     if genn-buildmodel.sh $BUILD_FLAGS -v model.cc; then
         # Build test
-        if make SIM_CODE=$c; then
+        if make -j $CORE_COUNT SIM_CODE=$c; then
             # Run tests
             ./test --gtest_output="xml:test_results$s.xml"
         fi
@@ -60,7 +67,7 @@ done;
 pushd unit
 
 # Clean and build
-make clean all COVERAGE=1
+make clean all -j $CORE_COUNT COVERAGE=1
 
 # Run tests
 ./test_coverage --gtest_output="xml:test_results_unit.xml"
@@ -70,7 +77,7 @@ popd    # unit
 pushd spineml/simulator
 
 # Clean and build
-make clean all
+make -j $CORE_COUNT clean all
 
 # Run SpineML simulator tests
 ./test --gtest_output="xml:test_results_spineml_simulator.xml"
@@ -80,7 +87,7 @@ popd    # spineml/simulator
 pushd spineml/generator
 
 # Clean and build
-make clean all
+make -j $CORE_COUNT clean all
 
 # Run SpineML simulator tests
 ./test --gtest_output="xml:test_results_spineml_generator.xml"


### PR DESCRIPTION
Really small change here, but a hopefully helpful one! Figures out number of (physical) cores in your machine and passes it to make -j to speed up building of GeNN when it's triggered from genn-buildmodel.sh. Also does the same for running tests (saves about 5 minutes on runtime of current test suite)