### PR TITLE
Expose GeNN preferences to PyGeNN

### DIFF
--- a/pygenn/genn_model.py
+++ b/pygenn/genn_model.py
@@ -87,8 +87,7 @@ class GeNNModel(object):
     """
 
     def __init__(self, precision=None, model_name="GeNNModel",
-                 backend=None, selected_gpu=None,
-                 genn_log_level=genn_wrapper.warning,
+                 backend=None, genn_log_level=genn_wrapper.warning,
                  code_gen_log_level=genn_wrapper.warning,
                  backend_log_level=genn_wrapper.warning,
                  **preference_kwargs):
@@ -135,8 +134,11 @@ class GeNNModel(object):
         self.current_sources = {}
         self.dT = 0.1
 
-        # For backward compatibility, if selected GPU is set, add preferences
+        # For backward compatibility, if selected GPU is set, remove it from
+        # preferences dictionary and add in underlying GeNN preferences
+        selected_gpu = self._preferences.pop("selected_gpu", None)
         if selected_gpu is not None:
+            print("MERRR")
             self._preferences["deviceSelectMethod"] = self._backend_module.DeviceSelect_MANUAL
             self._preferences["preferences.manualDeviceID"] = selected_gpu
 

--- a/pygenn/genn_model.py
+++ b/pygenn/genn_model.py
@@ -87,10 +87,11 @@ class GeNNModel(object):
     """
 
     def __init__(self, precision=None, model_name="GeNNModel",
-                 enable_debug=False, backend=None, selected_gpu=None,
+                 backend=None, selected_gpu=None,
                  genn_log_level=genn_wrapper.warning,
                  code_gen_log_level=genn_wrapper.warning,
-                 backend_log_level=genn_wrapper.warning):
+                 backend_log_level=genn_wrapper.warning,
+                 **preference_kwargs):
         """Init GeNNModel
         Keyword args:
         precision       --  string precision as string ("float", "double"
@@ -123,7 +124,7 @@ class GeNNModel(object):
         self._built = False
         self._loaded = False
         self.use_backend = backend
-        self.selected_gpu = selected_gpu
+        self._preferences = preference_kwargs
         self.backend_log_level=backend_log_level
         self._model = genn_wrapper.ModelSpecInternal()
         self._model.set_precision(getattr(genn_wrapper, genn_float_type))
@@ -135,17 +136,10 @@ class GeNNModel(object):
         self.current_sources = {}
         self.dT = 0.1
 
-    @property
-    def selected_gpu(self):
-        return self._selected_gpu
-
-    @selected_gpu.setter
-    def selected_gpu(self, v):
-        if self.use_backend == "CUDA":
-            self._selected_gpu = v
-        elif v is not None:
-            raise Exception("Selecting a GPU is only compatible with the CUDA backend "
-                            "but the {} backend was chosen.".format(self.use_backend))
+        # For backward compatibility, if selected GPU is set, add preferences
+        if selected_gpu is not None:
+            self._preferences["deviceSelectMethod"] = self._backend_module.DeviceSelect_MANUAL
+            self._preferences["preferences.manualDeviceID"] = selected_gpu
 
     @property
     def use_backend(self):
@@ -384,10 +378,10 @@ class GeNNModel(object):
         # Create suitable preferences object for backend
         preferences = self._backend_module.Preferences()
 
-        if self.selected_gpu is not None:
-            preferences.deviceSelectMethod = self._backend_module.DeviceSelect_MANUAL
-
-            preferences.manualDeviceID = self.selected_gpu
+        # Set attributes on preferences object
+        for k, v in iteritems(self._preferences):
+            if hasattr(preferences, k):
+                setattr(preferences, k, v)
 
         # Create backend
         backend = self._backend_module.create_backend(self._model, output_path, self.backend_log_level, preferences);

--- a/pygenn/genn_model.py
+++ b/pygenn/genn_model.py
@@ -97,7 +97,6 @@ class GeNNModel(object):
         precision       --  string precision as string ("float", "double"
                             or "long double"). defaults to float.
         model_name      --  string name of the model. Defaults to "GeNNModel".
-        enable_debug    --  boolean enable debug mode. Disabled by default.
         backend         --  string specifying name of backend module to use
                             Defaults to None to pick 'best' backend for your system
         selected_gpu    --  integer specifying the id of the gpu in which the

--- a/pygenn/genn_model.py
+++ b/pygenn/genn_model.py
@@ -138,7 +138,6 @@ class GeNNModel(object):
         # preferences dictionary and add in underlying GeNN preferences
         selected_gpu = self._preferences.pop("selected_gpu", None)
         if selected_gpu is not None:
-            print("MERRR")
             self._preferences["deviceSelectMethod"] = self._backend_module.DeviceSelect_MANUAL
             self._preferences["preferences.manualDeviceID"] = selected_gpu
 


### PR DESCRIPTION
This lets you access any GeNN preferences from PyGeNN in a future-proof way e.g.

```python
genn_model.GeNNModel("float", "va_benchmark", enableBitmaskOptimisations=True)
```