### PR TITLE
Smarter row build state

### DIFF
--- a/include/genn/genn/code_generator/codeGenUtils.h
+++ b/include/genn/genn/code_generator/codeGenUtils.h
@@ -1,17 +1,12 @@
 #pragma once
 
 // Standard includes
-#include <iomanip>
-#include <limits>
 #include <string>
-#include <sstream>
 #include <unordered_map>
 #include <vector>
 
 // GeNN includes
 #include "gennExport.h"
-#include "models.h"
-#include "snippet.h"
 #include "variableMode.h"
 
 // GeNN code generator includes
@@ -105,44 +100,6 @@ bool regexFuncSubstitute(std::string &s, const std::string &trg, const std::stri
 //--------------------------------------------------------------------------
 void functionSubstitute(std::string &code, const std::string &funcName,
                         unsigned int numParams, const std::string &replaceFuncTemplate);
-
-//--------------------------------------------------------------------------
-//! \brief This function writes a floating point value to a stream -setting the precision so no digits are lost
-//--------------------------------------------------------------------------
-template<class T, typename std::enable_if<std::is_floating_point<T>::value>::type* = nullptr>
-void writePreciseString(std::ostream &os, T value)
-{
-    // Cache previous precision
-    const std::streamsize previousPrecision = os.precision();
-
-    // Set scientific formatting
-    os << std::scientific;
-
-    // Set precision to what is required to fully represent T
-    os << std::setprecision(std::numeric_limits<T>::max_digits10);
-
-    // Write value to stream
-    os << value;
-
-    // Reset to default formatting
-    // **YUCK** GCC 4.8.X doesn't seem to include std::defaultfloat
-    os.unsetf(std::ios_base::floatfield);
-    //os << std::defaultfloat;
-
-    // Restore previous precision
-    os << std::setprecision(previousPrecision);
-}
-
-//--------------------------------------------------------------------------
-//! \brief This function writes a floating point value to a string - setting the precision so no digits are lost
-//--------------------------------------------------------------------------
-template<class T, typename std::enable_if<std::is_floating_point<T>::value>::type* = nullptr>
-std::string writePreciseString(T value)
-{
-    std::stringstream s;
-    writePreciseString(s, value);
-    return s.str();
-}
 
 //! Divide two integers, rounding up i.e. effectively taking ceil
 inline size_t ceilDivide(size_t numerator, size_t denominator)

--- a/include/genn/genn/code_generator/substitutions.h
+++ b/include/genn/genn/code_generator/substitutions.h
@@ -11,8 +11,8 @@
 // Standard C includes
 #include <cassert>
 
-// GeNN code generator includes
-#include "codeGenUtils.h"
+// GeNN includes
+#include "gennUtils.h"
 
 //--------------------------------------------------------------------------
 // Substitutions
@@ -69,10 +69,8 @@ public:
         auto var = variables.cbegin();
         auto val = values.cbegin();
         for (;var != variables.cend() && val != values.cend(); var++, val++) {
-            std::stringstream stream;
-            writePreciseString(stream, *val);
             addVarSubstitution(var->name + sourceSuffix,
-                               "(" + stream.str() + ")");
+                               "(" + Utils::writePreciseString(*val) + ")");
         }
     }
 
@@ -86,10 +84,8 @@ public:
         auto param = paramNames.cbegin();
         auto val = values.cbegin();
         for (;param != paramNames.cend() && val != values.cend(); param++, val++) {
-            std::stringstream stream;
-            writePreciseString(stream, *val);
             addVarSubstitution(*param + sourceSuffix,
-                               "(" + stream.str() + ")");
+                               "(" + Utils::writePreciseString(*val) + ")");
         }
 
     }

--- a/include/genn/genn/code_generator/substitutions.h
+++ b/include/genn/genn/code_generator/substitutions.h
@@ -11,6 +11,9 @@
 // Standard C includes
 #include <cassert>
 
+// GeNN code generator includes
+#include "codeGenUtils.h"
+
 // GeNN includes
 #include "gennUtils.h"
 

--- a/include/genn/genn/gennUtils.h
+++ b/include/genn/genn/gennUtils.h
@@ -1,12 +1,20 @@
 #pragma once
 
 // Standard C++ includes
+#include <iomanip>
+#include <limits>
+#include <sstream>
 #include <string>
 #include <vector>
 
 // GeNN includes
 #include "gennExport.h"
-#include "models.h"
+
+// Forward declarations
+namespace Models
+{
+class VarInit;
+}
 
 //--------------------------------------------------------------------------
 // Utils
@@ -32,5 +40,43 @@ GENN_EXPORT bool isTypePointer(const std::string &type);
 //! \brief Assuming type is a string containing a pointer type, function to return the underlying type
 //--------------------------------------------------------------------------
 GENN_EXPORT std::string getUnderlyingType(const std::string &type);
+
+//--------------------------------------------------------------------------
+//! \brief This function writes a floating point value to a stream -setting the precision so no digits are lost
+//--------------------------------------------------------------------------
+template<class T, typename std::enable_if<std::is_floating_point<T>::value>::type * = nullptr>
+GENN_EXPORT void writePreciseString(std::ostream &os, T value)
+{
+    // Cache previous precision
+    const std::streamsize previousPrecision = os.precision();
+
+    // Set scientific formatting
+    os << std::scientific;
+
+    // Set precision to what is required to fully represent T
+    os << std::setprecision(std::numeric_limits<T>::max_digits10);
+
+    // Write value to stream
+    os << value;
+
+    // Reset to default formatting
+    // **YUCK** GCC 4.8.X doesn't seem to include std::defaultfloat
+    os.unsetf(std::ios_base::floatfield);
+    //os << std::defaultfloat;
+
+    // Restore previous precision
+    os << std::setprecision(previousPrecision);
+}
+
+//--------------------------------------------------------------------------
+//! \brief This function writes a floating point value to a string - setting the precision so no digits are lost
+//--------------------------------------------------------------------------
+template<class T, typename std::enable_if<std::is_floating_point<T>::value>::type * = nullptr>
+GENN_EXPORT std::string writePreciseString(T value)
+{
+    std::stringstream s;
+    writePreciseString(s, value);
+    return s.str();
+}
 
 }   // namespace Utils

--- a/include/genn/genn/initSparseConnectivitySnippet.h
+++ b/include/genn/genn/initSparseConnectivitySnippet.h
@@ -226,17 +226,16 @@ public:
     DECLARE_SNIPPET(InitSparseConnectivitySnippet::FixedNumberPostWithReplacement, 1);
 
     SET_ROW_BUILD_CODE(
-        "const unsigned int rowLength = $(rowLength);\n"
-        "if(c >= rowLength) {\n"
+        "if(c == 0) {\n"
         "   $(endRow);\n"
         "}\n"
         "const scalar u = $(gennrand_uniform);\n"
-        "x += (1.0 - x) * (1.0 - pow(u, 1.0 / (scalar)(rowLength - c)));\n"
+        "x += (1.0 - x) * (1.0 - pow(u, 1.0 / (scalar)c));\n"
         "unsigned int postIdx = (unsigned int)(x * $(num_post));\n"
         "postIdx = (postIdx < $(num_post)) ? postIdx : ($(num_post) - 1);\n"
         "$(addSynapse, postIdx + $(id_post_begin));\n"
-        "c++;\n");
-    SET_ROW_BUILD_STATE_VARS({{"x", "scalar", 0.0},{"c", "unsigned int", 0}});
+        "c--;\n");
+    SET_ROW_BUILD_STATE_VARS({{"x", "scalar", 0.0},{"c", "unsigned int", "$(rowLength)"}});
 
     SET_PARAM_NAMES({"rowLength"});
 
@@ -276,17 +275,16 @@ public:
     DECLARE_SNIPPET(InitSparseConnectivitySnippet::FixedNumberTotalWithReplacement, 1);
 
     SET_ROW_BUILD_CODE(
-        "const unsigned int rowLength = $(preCalcRowLength)[($(id_pre) * $(num_threads)) + $(id_thread)];\n"
-        "if(c >= rowLength) {\n"
+        "if(c == 0) {\n"
         "   $(endRow);\n"
         "}\n"
         "const scalar u = $(gennrand_uniform);\n"
-        "x += (1.0 - x) * (1.0 - pow(u, 1.0 / (scalar)(rowLength - c)));\n"
+        "x += (1.0 - x) * (1.0 - pow(u, 1.0 / (scalar)c));\n"
         "unsigned int postIdx = (unsigned int)(x * $(num_post));\n"
         "postIdx = (postIdx < $(num_post)) ? postIdx : ($(num_post) - 1);\n"
         "$(addSynapse, postIdx + $(id_post_begin));\n"
-        "c++;\n");
-    SET_ROW_BUILD_STATE_VARS({{"x", "scalar", 0.0},{"c", "unsigned int", 0}});
+        "c--;\n");
+    SET_ROW_BUILD_STATE_VARS({{"x", "scalar", 0.0},{"c", "unsigned int", "$(preCalcRowLength)[($(id_pre) * $(num_threads)) + $(id_thread)]"}});
 
     SET_PARAM_NAMES({"total"});
     SET_EXTRA_GLOBAL_PARAMS({{"preCalcRowLength", "unsigned int*"}})

--- a/include/genn/genn/snippet.h
+++ b/include/genn/genn/snippet.h
@@ -11,6 +11,7 @@
 
 // GeNN includes
 #include "gennExport.h"
+#include "gennUtils.h"
 
 //----------------------------------------------------------------------------
 // Macros
@@ -134,6 +135,13 @@ public:
     //! Additional input variables, row state variables and other things have a name, a type and an initial value
     struct ParamVal
     {
+        ParamVal(const std::string &n, const std::string &t, const std::string &v) : name(n), type(t), value(v)
+        {}
+        ParamVal(const std::string &n, const std::string &t, double v) : ParamVal(n, t, Utils::writePreciseString(v))
+        {}
+        ParamVal() : ParamVal("", "", "0.0")
+        {}
+
         bool operator == (const ParamVal &other) const
         {
             return ((name == other.name) && (type == other.type) && (value == other.value));
@@ -141,7 +149,7 @@ public:
 
         std::string name;
         std::string type;
-        double value;
+        std::string value;
     };
 
     //! A derived parameter has a name and a function for obtaining its value

--- a/pygenn/genn_wrapper/swig/Snippet.i
+++ b/pygenn/genn_wrapper/swig/Snippet.i
@@ -51,17 +51,6 @@
     }
 };
 
-%extend Snippet::Base::ParamVal {
-    ParamVal(const std::string &name, const std::string &type, double value) 
-    {
-        Snippet::Base::ParamVal* v = new Snippet::Base::ParamVal();
-        v->name = name;
-        v->type = type;
-        v->value = value;
-        return v;
-    }
-};
-
 %extend Snippet::Base::DerivedParam {
     DerivedParam(const std::string &name, std::function<double(const std::vector<double> &, double)> func) 
     {

--- a/src/genn/genn/code_generator/codeGenUtils.cc
+++ b/src/genn/genn/code_generator/codeGenUtils.cc
@@ -551,11 +551,11 @@ void neuronSubstitutionsInSynapticCode(
     const std::string &postVarPrefix,    //!< prefix to be used for postsynaptic variable accesses - typically combined with suffix to wrap in function call such as __ldg(&XXX)
     const std::string &postVarSuffix)    //!< suffix to be used for postsynaptic variable accesses - typically combined with prefix to wrap in function call such as __ldg(&XXX)
 {
-    const std::string axonalDelayOffset = writePreciseString(dt * (double)(sg.getDelaySteps() + 1u)) + " + ";
+    const std::string axonalDelayOffset = Utils::writePreciseString(dt * (double)(sg.getDelaySteps() + 1u)) + " + ";
     const std::string preOffset = sg.getSrcNeuronGroup()->isDelayRequired() ? "preReadDelayOffset + " : "";
     neuronSubstitutionsInSynapticCode(substitutions, sg.getSrcNeuronGroup(), preOffset, axonalDelayOffset, preIdx, "_pre", "Pre", preVarPrefix, preVarSuffix);
     
-    const std::string backPropDelayMs = writePreciseString(dt * (double)(sg.getBackPropDelaySteps() + 1u)) + " + ";
+    const std::string backPropDelayMs = Utils::writePreciseString(dt * (double)(sg.getBackPropDelaySteps() + 1u)) + " + ";
     const std::string postOffset = sg.getTrgNeuronGroup()->isDelayRequired() ? "postReadDelayOffset + " : "";
     neuronSubstitutionsInSynapticCode(substitutions, sg.getTrgNeuronGroup(), postOffset, backPropDelayMs, postIdx, "_post", "Post", postVarPrefix, postVarSuffix);
 }

--- a/src/genn/genn/code_generator/generateInit.cc
+++ b/src/genn/genn/code_generator/generateInit.cc
@@ -330,25 +330,30 @@ void CodeGenerator::generateInit(CodeStream &os, const MergedEGPMap &mergedEGPs,
         // Sparse synaptic matrix connectivity initialisation
         [&model](CodeStream &os, const SynapseGroupMerged &sg, Substitutions &popSubs)
         {
+            const auto &connectInit = sg.getArchetype().getConnectivityInitialiser();
+
+            // Add substitutions
             popSubs.addFuncSubstitution("endRow", 0, "break");
+            popSubs.addParamValueSubstitution(connectInit.getSnippet()->getParamNames(), connectInit.getParams());
+            popSubs.addVarValueSubstitution(connectInit.getSnippet()->getDerivedParams(), connectInit.getDerivedParams());
+            popSubs.addVarNameSubstitution(connectInit.getSnippet()->getExtraGlobalParams(), "", "group.");
 
             // Initialise row building state variables and loop on generated code to initialise sparse connectivity
-            const auto &connectInit = sg.getArchetype().getConnectivityInitialiser();
             os << "// Build sparse connectivity" << std::endl;
             for(const auto &a : connectInit.getSnippet()->getRowBuildStateVars()) {
-                os << a.type << " " << a.name << " = " << a.value << ";" << std::endl;
+                // Apply substitutions to value
+                std::string value = a.value;
+                popSubs.applyCheckUnreplaced(value, "initSparseConnectivity row build state var : merged" + std::to_string(sg.getIndex()));
+
+                os << a.type << " " << a.name << " = " << value << ";" << std::endl;
             }
             os << "while(true)";
             {
                 CodeStream::Scope b(os);
 
-                // Add substitutions
-                popSubs.addParamValueSubstitution(connectInit.getSnippet()->getParamNames(), connectInit.getParams());
-                popSubs.addVarValueSubstitution(connectInit.getSnippet()->getDerivedParams(), connectInit.getDerivedParams());
-                popSubs.addVarNameSubstitution(connectInit.getSnippet()->getExtraGlobalParams(), "", "group.");
-                popSubs.addVarNameSubstitution(connectInit.getSnippet()->getRowBuildStateVars());
-
+                // Apply substitutions to row build code
                 std::string code = connectInit.getSnippet()->getRowBuildCode();
+                popSubs.addVarNameSubstitution(connectInit.getSnippet()->getRowBuildStateVars());
                 popSubs.applyCheckUnreplaced(code, "initSparseConnectivity : merged" + std::to_string(sg.getIndex()));
                 code = ensureFtype(code, model.getPrecision());
 

--- a/src/genn/genn/code_generator/generateNeuronUpdate.cc
+++ b/src/genn/genn/code_generator/generateNeuronUpdate.cc
@@ -108,7 +108,11 @@ void CodeGenerator::generateNeuronUpdate(CodeStream &os, const MergedEGPMap &mer
 
             // Initialise any additional input variables supported by neuron model
             for (const auto &a : nm->getAdditionalInputVars()) {
-                os << a.type << " " << a.name<< " = " << a.value << ";" << std::endl;
+                // Apply substitutions to value
+                std::string value = a.value;
+                neuronSubs.applyCheckUnreplaced(value, "neuron additional input var : merged" + std::to_string(ng.getIndex()));
+
+                os << a.type << " " << a.name << " = " << value << ";" << std::endl;
             }
 
             // Loop through incoming synapse groups

--- a/src/genn/genn/code_generator/generateRunner.cc
+++ b/src/genn/genn/code_generator/generateRunner.cc
@@ -35,21 +35,21 @@ void genTypeRange(CodeGenerator::CodeStream &os, const std::string &precision, c
 
     os << "#define " << prefix << "_MIN ";
     if (precision == "float") {
-        writePreciseString(os, std::numeric_limits<float>::min());
+        Utils::writePreciseString(os, std::numeric_limits<float>::min());
         os << "f" << std::endl;
     }
     else {
-        writePreciseString(os, std::numeric_limits<double>::min());
+        Utils::writePreciseString(os, std::numeric_limits<double>::min());
         os << std::endl;
     }
 
     os << "#define " << prefix << "_MAX ";
     if (precision == "float") {
-        writePreciseString(os, std::numeric_limits<float>::max());
+        Utils::writePreciseString(os, std::numeric_limits<float>::max());
         os << "f" << std::endl;
     }
     else {
-        writePreciseString(os, std::numeric_limits<double>::max());
+        Utils::writePreciseString(os, std::numeric_limits<double>::max());
         os << std::endl;
     }
     os << std::endl;

--- a/src/genn/genn/gennUtils.cc
+++ b/src/genn/genn/gennUtils.cc
@@ -3,6 +3,9 @@
 // Standard C++ includes
 #include <algorithm>
 
+// GeNN includes
+#include "models.h"
+
 namespace
 {
 //--------------------------------------------------------------------------


### PR DESCRIPTION
This P.R. slightly extends the syntax for defining connectivity initialization models so you can initialize row-wide state variables with expressions (which get substitutions applied etc) as well as with constants. This lets you express the fixed total number of synapses connectivity in such a way that the row length is only read once per row. This actually makes a pretty sizable difference to the performance - 20% faster procedural synapse update on my home machine. Because it uses the same code path, this functionality also now applies to neuron additional inputs although I can't think of a use-case off hand...

**NOTE** this is currently set to merge into #293 as it updates the built in models