### PR TITLE
Use correct max function in models

### DIFF
--- a/include/genn/genn/weightUpdateModels.h
+++ b/include/genn/genn/weightUpdateModels.h
@@ -210,7 +210,7 @@ public:
     SET_PARAM_NAMES({"Epre", "Vslope"});
     SET_VARS({{"g", "scalar", VarAccess::READ_ONLY}});
 
-    SET_EVENT_CODE("$(addToInSyn, max(0.0, $(g) * tanh(($(V_pre) - $(Epre)) / $(Vslope))* DT));\n");
+    SET_EVENT_CODE("$(addToInSyn, fmax(0.0, $(g) * tanh(($(V_pre) - $(Epre)) / $(Vslope))* DT));\n");
 
     SET_EVENT_THRESHOLD_CONDITION_CODE("$(V_pre) > $(Epre)");
 };

--- a/userproject/MBody1_project/model/MBody1.cc
+++ b/userproject/MBody1_project/model/MBody1.cc
@@ -61,7 +61,7 @@ class GaussianMin : public InitVarSnippet::Base
 public:
     DECLARE_SNIPPET(GaussianMin, 3);
 
-    SET_CODE("$(value) = max($(min), $(mean) + ($(gennrand_normal) * $(sd)));");
+    SET_CODE("$(value) = fmax($(min), $(mean) + ($(gennrand_normal) * $(sd)));");
 
     SET_PARAM_NAMES({"mean", "sd", "min"});
 };


### PR DESCRIPTION
@AdityaKapoor74 found this issue when building MBody1 on CPU -  ``max`` doesn't resolve to anything useful in <cmath> so we should use ``fmax``