### PR TITLE
Don't #include runner in modules

### DIFF
--- a/include/genn/genn/code_generator/generateInit.h
+++ b/include/genn/genn/code_generator/generateInit.h
@@ -15,5 +15,5 @@ class ModelSpecMerged;
 namespace CodeGenerator
 {
 void generateInit(CodeStream &os, const MergedEGPMap &mergedEGPs, const ModelSpecMerged &modelMerged,
-                  const BackendBase &backend, bool standaloneModules);
+                  const BackendBase &backend);
 }

--- a/include/genn/genn/code_generator/generateNeuronUpdate.h
+++ b/include/genn/genn/code_generator/generateNeuronUpdate.h
@@ -15,5 +15,5 @@ class ModelSpecMerged;
 namespace CodeGenerator
 {
 void generateNeuronUpdate(CodeStream &os, const MergedEGPMap &mergedEGPs, const ModelSpecMerged &modelMerged,
-                          const BackendBase &backend, bool standaloneModules);
+                          const BackendBase &backend);
 }

--- a/include/genn/genn/code_generator/generateSynapseUpdate.h
+++ b/include/genn/genn/code_generator/generateSynapseUpdate.h
@@ -15,5 +15,5 @@ class ModelSpecMerged;
 namespace CodeGenerator
 {
 void generateSynapseUpdate(CodeStream &os, const MergedEGPMap &mergedEGPs, const ModelSpecMerged &modelMerged,
-                           const BackendBase &backend, bool standaloneModules);
+                           const BackendBase &backend);
 }

--- a/src/genn/backends/cuda/backend.cc
+++ b/src/genn/backends/cuda/backend.cc
@@ -1971,9 +1971,11 @@ std::string Backend::getNVCCFlags() const
     // How you hide device compiler warnings is totally non-documented but https://stackoverflow.com/a/17095910/1476754
     // holds the answer! For future reference --display_error_number option can be used to get warning ids to use in --diag-supress
     const std::string architecture = "sm_" + std::to_string(getChosenCUDADevice().major) + std::to_string(getChosenCUDADevice().minor);
-    std::string nvccFlags = "-x cu -Xcudafe '--diag_suppress=2937' -arch " + architecture;
-#ifndef _WIN32
-    nvccFlags += " -std=c++11 --compiler-options '-fPIC -Wno-return-type-c-linkage'";
+    std::string nvccFlags = "-x cu -arch " + architecture;
+#ifdef _WIN32
+    nvccFlags += " -Xcudafe \"--diag_suppress=2961\"";
+#else
+    nvccFlags += " -Xcudafe '--diag_suppress=2937' -std=c++11 --compiler-options '-fPIC -Wno-return-type-c-linkage'";
 #endif
 
     nvccFlags += " " + m_Preferences.userNvccFlags;

--- a/src/genn/backends/cuda/backend.cc
+++ b/src/genn/backends/cuda/backend.cc
@@ -1967,8 +1967,11 @@ bool Backend::isGlobalRNGRequired(const ModelSpecMerged &modelMerged) const
 //--------------------------------------------------------------------------
 std::string Backend::getNVCCFlags() const
 {
+    // **NOTE** now we don't include runner.cc when building standalone modules we get loads of warnings about
+    // How you hide device compiler warnings is totally non-documented but https://stackoverflow.com/a/17095910/1476754
+    // holds the answer! For future reference --display_error_number option can be used to get warning ids to use in --diag-supress
     const std::string architecture = "sm_" + std::to_string(getChosenCUDADevice().major) + std::to_string(getChosenCUDADevice().minor);
-    std::string nvccFlags = "-x cu -arch " + architecture;
+    std::string nvccFlags = "-x cu -Xcudafe '--diag_suppress=2937' -arch " + architecture;
 #ifndef _WIN32
     nvccFlags += " -std=c++11 --compiler-options '-fPIC -Wno-return-type-c-linkage'";
 #endif

--- a/src/genn/backends/cuda/backend.cc
+++ b/src/genn/backends/cuda/backend.cc
@@ -1975,7 +1975,7 @@ std::string Backend::getNVCCFlags() const
 #ifdef _WIN32
     nvccFlags += " -Xcudafe \"--diag_suppress=2961\"";
 #else
-    nvccFlags += " -Xcudafe '--diag_suppress=2937' -std=c++11 --compiler-options '-fPIC -Wno-return-type-c-linkage'";
+    nvccFlags += " -Xcudafe \"--diag_suppress=2937\" -std=c++11 --compiler-options \"-fPIC -Wno-return-type-c-linkage\"";
 #endif
 
     nvccFlags += " " + m_Preferences.userNvccFlags;

--- a/src/genn/genn/code_generator/generateAll.cc
+++ b/src/genn/genn/code_generator/generateAll.cc
@@ -56,9 +56,9 @@ std::vector<std::string> CodeGenerator::generateAll(const ModelSpecInternal &mod
     // Generate modules
     MergedEGPMap mergedEGPs;
     auto mem = generateRunner(definitions, definitionsInternal, runner, mergedEGPs, modelMerged, backend);
-    generateNeuronUpdate(neuronUpdate, mergedEGPs, modelMerged, backend, standaloneModules);
-    generateSynapseUpdate(synapseUpdate, mergedEGPs, modelMerged, backend, standaloneModules);
-    generateInit(init, mergedEGPs, modelMerged, backend, standaloneModules);
+    generateNeuronUpdate(neuronUpdate, mergedEGPs, modelMerged, backend);
+    generateSynapseUpdate(synapseUpdate, mergedEGPs, modelMerged, backend);
+    generateInit(init, mergedEGPs, modelMerged, backend);
 
     generateSupportCode(supportCode, modelMerged);
 

--- a/src/genn/genn/code_generator/generateInit.cc
+++ b/src/genn/genn/code_generator/generateInit.cc
@@ -190,14 +190,9 @@ void genInitWUVarCode(CodeGenerator::CodeStream &os, const CodeGenerator::Backen
 // CodeGenerator
 //--------------------------------------------------------------------------
 void CodeGenerator::generateInit(CodeStream &os, const MergedEGPMap &mergedEGPs, const ModelSpecMerged &modelMerged,
-                                 const BackendBase &backend, bool standaloneModules)
+                                 const BackendBase &backend)
 {
-    if(standaloneModules) {
-        os << "#include \"runner.cc\"" << std::endl;
-    }
-    else {
-        os << "#include \"definitionsInternal.h\"" << std::endl;
-    }
+    os << "#include \"definitionsInternal.h\"" << std::endl;
 
     // Generate functions to push merged synapse group structures
     const ModelSpecInternal &model = modelMerged.getModel();

--- a/src/genn/genn/code_generator/generateNeuronUpdate.cc
+++ b/src/genn/genn/code_generator/generateNeuronUpdate.cc
@@ -38,14 +38,9 @@ void addNeuronModelSubstitutions(CodeGenerator::Substitutions &substitution, con
 // CodeGenerator
 //--------------------------------------------------------------------------
 void CodeGenerator::generateNeuronUpdate(CodeStream &os, const MergedEGPMap &mergedEGPs, const ModelSpecMerged &modelMerged,
-                                         const BackendBase &backend, bool standaloneModules)
+                                         const BackendBase &backend)
 {
-    if(standaloneModules) {
-        os << "#include \"runner.cc\"" << std::endl;
-    }
-    else {
-        os << "#include \"definitionsInternal.h\"" << std::endl;
-    }
+    os << "#include \"definitionsInternal.h\"" << std::endl;
     os << "#include \"supportCode.h\"" << std::endl;
     os << std::endl;
 

--- a/src/genn/genn/code_generator/generateSynapseUpdate.cc
+++ b/src/genn/genn/code_generator/generateSynapseUpdate.cc
@@ -92,15 +92,9 @@ void applySynapseSubstitutions(CodeGenerator::CodeStream &os, std::string code, 
 //--------------------------------------------------------------------------
 // CodeGenerator
 //--------------------------------------------------------------------------
-void CodeGenerator::generateSynapseUpdate(CodeStream &os, const MergedEGPMap &mergedEGPs, const ModelSpecMerged &modelMerged, const BackendBase &backend,
-                                          bool standaloneModules)
+void CodeGenerator::generateSynapseUpdate(CodeStream &os, const MergedEGPMap &mergedEGPs, const ModelSpecMerged &modelMerged, const BackendBase &backend)
 {
-    if(standaloneModules) {
-        os << "#include \"runner.cc\"" << std::endl;
-    }
-    else {
-        os << "#include \"definitionsInternal.h\"" << std::endl;
-    }
+    os << "#include \"definitionsInternal.h\"" << std::endl;
     os << "#include \"supportCode.h\"" << std::endl;
     os << std::endl;
 


### PR DESCRIPTION
One of the hacky bits of getting GeNN 4's multiple module CUDA build to work was that, when we were compiling each module independently to cubin while optimizing block sizes, there were persistent warnings about extern variables being treated as static. These didn't matter as the code was never run, but I couldn't find any way of suppressing them as they came from the (undocumented) **device** compiler rather than gcc or whatever so I ended up #included the runner in each module when optimizing block sizes.

However, with large models, the runner becomes very large and compiling it an extra 6 times or whatever is the last thing one wants to do. I finally found the (undocumented) nvcc command line arguments on a dark corner of stack overflow and incorporated them.

**Note** on Windows nvcc is not normally invoked directly, but in the special case of optimizing block sizes, it is so the same approach (irritatingly the warning numbers are different) works on Windows as well.