### PR TITLE
small fix

### DIFF
--- a/src/genn/genn/code_generator/generateNeuronUpdate.cc
+++ b/src/genn/genn/code_generator/generateNeuronUpdate.cc
@@ -94,13 +94,13 @@ void CodeGenerator::generateNeuronUpdate(CodeStream &os, const ModelSpecInternal
             os << std::endl;
 
             // If neuron model sim code references ISyn (could still be the case if there are no incoming synapses)
-            // OR any incoming synapse groups have post synaptic models which reference $(inSyn), declare it
+            // OR any incoming synapse groups have post synaptic models which reference $(Isyn), declare it
             if (nm->getSimCode().find("$(Isyn)") != std::string::npos ||
                 std::any_of(ng.getMergedInSyn().cbegin(), ng.getMergedInSyn().cend(),
                             [](const std::pair<SynapseGroupInternal*, std::vector<SynapseGroupInternal*>> &p)
                             {
-                                return (p.first->getPSModel()->getApplyInputCode().find("$(inSyn)") != std::string::npos
-                                        || p.first->getPSModel()->getDecayCode().find("$(inSyn)") != std::string::npos);
+                                return (p.first->getPSModel()->getApplyInputCode().find("$(Isyn)") != std::string::npos
+                                        || p.first->getPSModel()->getDecayCode().find("$(Isyn)") != std::string::npos);
                             }))
             {
                 os << model.getPrecision() << " Isyn = 0;" << std::endl;


### PR DESCRIPTION
The Brian2GeNN tests exposed a small bug I clearly introduced when attempting to fix compiler warnings in the generated code. The default neuron input current ``Isyn`` should only be included if the neuron model or any postsynaptic models on incoming connections refer to it. However, for some reason, I was instead checking whether postsynaptic models reference ``inSyn`` (which is the input rather than the output). This meant that a Brian2GeNN model with a postsynaptic model whose  apply input code was ``$(Isyn) += 0`` (no idea why they do but still) failed to compile.

Note, this is currently being merged into the 4.2.0 (pre kernel-merging) branch for a 4.2.1 release but I'll also merge it into master