### PR TITLE
Fix for nasty bug in single-threaded CPU backend

### DIFF
--- a/src/genn/backends/single_threaded_cpu/backend.cc
+++ b/src/genn/backends/single_threaded_cpu/backend.cc
@@ -127,11 +127,11 @@ void Backend::genNeuronUpdate(CodeStream &os, const ModelSpecInternal &model, Ne
                         // Emit true spikes
                         [this, wuVarUpdateHandler](CodeStream &os, const NeuronGroupInternal &ng, Substitutions &subs)
                         {
-                            // Insert code to emit true spikes
-                            genEmitSpike(os, ng, subs, true);
-
                             // Insert code to update WU vars
                             wuVarUpdateHandler(os, ng, subs);
+
+                            // Insert code to emit true spikes
+                            genEmitSpike(os, ng, subs, true);
                         },
                         // Emit spike-like events
                         [this](CodeStream &os, const NeuronGroupInternal &ng, Substitutions &subs)


### PR DESCRIPTION
The standard pattern for implementing STDP traces using pre or postsynaptic variables is to use code something like:

```c++
const scalar dt = $(t) - $(sT_post);
$(C) = ($(C) * exp(-dt / $(tauC))) + 1.0;
```

This worked fine in the CUDA backend but, in the CPU backend, ``sT`` was updated **before** this code was run meaning that dt was always 0. Note this is being merged into the 4_2_0 branch as I'm planning a 4.2.1 release - intended to be the last release before kernel merging finally gets merged - containing a few fixes.