### PR TITLE
Windows fixes

### DIFF
--- a/bin/genn-buildmodel.bat
+++ b/bin/genn-buildmodel.bat
@@ -55,7 +55,7 @@ if not defined MODEL (
 )
 for /f %%I in ("%-o%") do set "-o=%%~fI"
 for /f %%I in ("%-i%") do set "-i=%%~fI"
-for /f %%I in ("%MODEL%") do set "MACROS=/p:ModelFile=%%~fI /p:GeneratePath=%-o% /p:BuildModelInclude=%-i%"
+for /f %%I in ("%MODEL%") do set "MACROS=/p:ModelFile="%%~fI" /p:GeneratePath="%-o%" /p:BuildModelInclude="%-i%""
 
 rem set SDL check flag
 if defined -s (
@@ -87,7 +87,6 @@ if defined -d (
         set GENERATOR=.\generator_Release_CUDA.exe
     )
 )
-
 
 rem :: build backend
 msbuild "%GENN_PATH%..\genn.sln" /m /verbosity:minimal /t:%BACKEND_PROJECT% %BACKEND_MACROS% /p:BuildProjectReferences=true && (

--- a/bin/genn-buildmodel.bat
+++ b/bin/genn-buildmodel.bat
@@ -10,6 +10,7 @@ echo genn-buildmodel.bat [cdho] model
 echo -c             only generate simulation code for the CPU
 echo -d             enables the debugging mode
 echo -h             shows this help message
+echo -s             build GeNN without SDL checks
 echo -o outpath     changes the output directory
 echo -i includepath add additional include directories (seperated by semicolons)
 goto :eof
@@ -19,7 +20,7 @@ rem :: define genn-buildmodel.bat options separated by spaces
 rem :: -<option>:              option
 rem :: -<option>:""            option with argument
 rem :: -<option>:"<default>"   option with argument and default value
-set "OPTIONS=-o:"%CD%" -i:"" -d: -c: -h:"
+set "OPTIONS=-o:"%CD%" -i:"" -d: -c: -h: -s:"
 for %%O in (%OPTIONS%) do for /f "tokens=1,* delims=:" %%A in ("%%O") do set "%%A=%%~B"
 
 :genn_option
@@ -56,52 +57,59 @@ for /f %%I in ("%-o%") do set "-o=%%~fI"
 for /f %%I in ("%-i%") do set "-i=%%~fI"
 for /f %%I in ("%MODEL%") do set "MACROS=/p:ModelFile=%%~fI /p:GeneratePath=%-o% /p:BuildModelInclude=%-i%"
 
-if defined -d (
-	set "BACKEND_MACROS= /p:Configuration=Debug"
-	if defined -c (
-		set "BACKEND_PROJECT=single_threaded_cpu_backend"
-		set "MACROS=%MACROS% /p:Configuration=Debug"
-		set GENERATOR=.\generator_Debug.exe
-	) else (
-		set "BACKEND_PROJECT=cuda_backend"
-		set "MACROS=%MACROS% /p:Configuration=Debug_CUDA"
-		set GENERATOR=.\generator_Debug_CUDA.exe
-	)    
+rem set SDL check flag
+if defined -s (
+    set "MACROS=%MACROS% /p:BuildModelSDLCheck=false"
 ) else (
-	set "BACKEND_MACROS= /p:Configuration=Release"
-	if defined -c (
-		set "BACKEND_PROJECT=single_threaded_cpu_backend"
-		set "MACROS=%MACROS% /p:Configuration=Release"
-		set GENERATOR=.\generator_Release.exe
-	) else (
-		set "BACKEND_PROJECT=cuda_backend"
-		set "MACROS=%MACROS% /p:Configuration=Release_CUDA"
-		set GENERATOR=.\generator_Release_CUDA.exe
-	)
+    set "MACROS=%MACROS% /p:BuildModelSDLCheck=true"
+)
+
+if defined -d (
+    set "BACKEND_MACROS= /p:Configuration=Debug"
+    if defined -c (
+        set "BACKEND_PROJECT=single_threaded_cpu_backend"
+        set "MACROS=%MACROS% /p:Configuration=Debug"
+        set GENERATOR=.\generator_Debug.exe
+    ) else (
+        set "BACKEND_PROJECT=cuda_backend"
+        set "MACROS=%MACROS% /p:Configuration=Debug_CUDA"
+        set GENERATOR=.\generator_Debug_CUDA.exe
+    )    
+    ) else (
+    set "BACKEND_MACROS= /p:Configuration=Release"
+    if defined -c (
+        set "BACKEND_PROJECT=single_threaded_cpu_backend"
+        set "MACROS=%MACROS% /p:Configuration=Release"
+        set GENERATOR=.\generator_Release.exe
+    ) else (
+        set "BACKEND_PROJECT=cuda_backend"
+        set "MACROS=%MACROS% /p:Configuration=Release_CUDA"
+        set GENERATOR=.\generator_Release_CUDA.exe
+    )
 )
 
 
 rem :: build backend
 msbuild "%GENN_PATH%..\genn.sln" /m /verbosity:minimal /t:%BACKEND_PROJECT% %BACKEND_MACROS% /p:BuildProjectReferences=true && (
-	echo Successfully built GeNN
+    echo Successfully built GeNN
 ) || (
-	echo Unable to build GeNN
-	goto :eof
+    echo Unable to build GeNN
+    goto :eof
 )
 
 
 rem :: build generator
 msbuild "%GENN_PATH%..\src\genn\generator\generator.vcxproj" /m /verbosity:minimal %MACROS%&& (
-	echo Successfully built code generator
+    echo Successfully built code generator
 ) || (
-	echo Unable to build code generator
-	goto :eof
+    echo Unable to build code generator
+    goto :eof
 )
 
 if defined -d (
-	devenv /debugexe "%GENERATOR%" "%-o%"
+    devenv /debugexe "%GENERATOR%" "%-o%"
 ) else (
-	"%GENERATOR%" "%-o%"
+    "%GENERATOR%" "%-o%"
 )
 
 echo Model build complete

--- a/src/genn/generator/generator.vcxproj
+++ b/src/genn/generator/generator.vcxproj
@@ -67,7 +67,7 @@
     <ClCompile>
       <WarningLevel>Level3</WarningLevel>
       <Optimization>Disabled</Optimization>
-      <SDLCheck>true</SDLCheck>
+      <SDLCheck>$(BuildModelSDLCheck)</SDLCheck>
       <AdditionalIncludeDirectories>..\..\..\include\genn\genn;..\..\..\include\genn\third_party;..\..\..\include\genn\backend\single_threaded_cpu;$(BuildModelInclude)</AdditionalIncludeDirectories>
       <PreprocessorDefinitions>NOMINMAX;BACKEND_NAMESPACE=SingleThreadedCPU;BACKEND_NAME=single_threaded_cpu;%(PreprocessorDefinitions);MODEL="$(ModelFile)"</PreprocessorDefinitions>
     </ClCompile>
@@ -81,7 +81,7 @@
     <ClCompile>
       <WarningLevel>Level3</WarningLevel>
       <Optimization>Disabled</Optimization>
-      <SDLCheck>true</SDLCheck>
+      <SDLCheck>$(BuildModelSDLCheck)</SDLCheck>
       <AdditionalIncludeDirectories>..\..\..\include\genn\backends\cuda;..\..\..\include\genn\genn;..\..\..\include\genn\third_party;$(CUDA_PATH)\include;$(BuildModelInclude)</AdditionalIncludeDirectories>
       <PreprocessorDefinitions>NOMINMAX;BACKEND_NAMESPACE=CUDA;BACKEND_NAME=cuda;%(PreprocessorDefinitions);MODEL="$(ModelFile)"</PreprocessorDefinitions>
     </ClCompile>
@@ -97,7 +97,7 @@
       <Optimization>MaxSpeed</Optimization>
       <FunctionLevelLinking>true</FunctionLevelLinking>
       <IntrinsicFunctions>true</IntrinsicFunctions>
-      <SDLCheck>true</SDLCheck>
+      <SDLCheck>$(BuildModelSDLCheck)</SDLCheck>
       <AdditionalIncludeDirectories>..\..\..\include\genn\genn;..\..\..\include\genn\third_party;..\..\..\include\genn\backends\single_threaded_cpu;$(BuildModelInclude)</AdditionalIncludeDirectories>
       <PreprocessorDefinitions>NOMINMAX;BACKEND_NAMESPACE=SingleThreadedCPU;BACKEND_NAME=single_threaded_cpu;%(PreprocessorDefinitions);MODEL="$(ModelFile)"</PreprocessorDefinitions>
     </ClCompile>
@@ -115,7 +115,7 @@
       <Optimization>MaxSpeed</Optimization>
       <FunctionLevelLinking>true</FunctionLevelLinking>
       <IntrinsicFunctions>true</IntrinsicFunctions>
-      <SDLCheck>true</SDLCheck>
+      <SDLCheck>$(BuildModelSDLCheck)</SDLCheck>
       <AdditionalIncludeDirectories>..\..\..\include\genn\backends\cuda;..\..\..\include\genn\genn;..\..\..\include\genn\third_party;$(CUDA_PATH)\include;$(BuildModelInclude)</AdditionalIncludeDirectories>
       <PreprocessorDefinitions>NOMINMAX;BACKEND_NAMESPACE=CUDA;BACKEND_NAME=cuda;%(PreprocessorDefinitions);MODEL="$(ModelFile)"</PreprocessorDefinitions>
     </ClCompile>


### PR DESCRIPTION
Another one for the 4.2.1 release! This solves a couple of Brian2 issues:
- There's some dubious stuff in randomlib which would normally cause warnings but, if [SDL checks](https://docs.microsoft.com/en-us/cpp/build/reference/sdl-enable-additional-security-checks) are enabled (which by default they are), these are promoted to errors
- For the semicolon-seperated list of include paths to get through to the build system, it needs to be quoted (otherwise semicolons are treated as whitespace). Also quoted all other arguments for future-safety!
