### PR TITLE
Fix compilation with gcc 4.9

### DIFF
--- a/userproject/include/spikeRecorder.h
+++ b/userproject/include/spikeRecorder.h
@@ -27,7 +27,7 @@ public:
     }
 
 // GCC 4.x does not provide a move constructor for ofstream
-#if defined(__GNUC__) && (__GNUC__ > 4)
+#if !defined(__GNUC__) || __clang__ || __GNUC__ > 4
     SpikeWriterText(SpikeWriterText&& other)
     :   m_Stream(std::move(other.m_Stream)),
         m_Delimiter(std::move(other.m_Delimiter))
@@ -73,7 +73,7 @@ public:
     }
 
 // GCC 4.x does not provide a move constructor for ofstream
-#if defined(__GNUC__) && (__GNUC__ > 4)
+#if !defined(__GNUC__) || __clang__ || __GNUC__ > 4
     SpikeWriterTextCached(SpikeWriterTextCached&& other)
     :   m_Stream(std::move(other.m_Stream)),
         m_Delimiter(std::move(other.m_Delimiter)),

--- a/userproject/include/spikeRecorder.h
+++ b/userproject/include/spikeRecorder.h
@@ -26,11 +26,14 @@ public:
         }
     }
 
+// GCC 4.x does not provide a move constructor for ofstream
+#if defined(__GNUC__) && (__GNUC__ > 4)
     SpikeWriterText(SpikeWriterText&& other)
     :   m_Stream(std::move(other.m_Stream)),
         m_Delimiter(std::move(other.m_Delimiter))
     {
     }
+#endif
 
 protected:
     //----------------------------------------------------------------------------
@@ -69,12 +72,15 @@ public:
         }
     }
 
+// GCC 4.x does not provide a move constructor for ofstream
+#if defined(__GNUC__) && (__GNUC__ > 4)
     SpikeWriterTextCached(SpikeWriterTextCached&& other)
     :   m_Stream(std::move(other.m_Stream)),
         m_Delimiter(std::move(other.m_Delimiter)),
         m_Cache(std::move(other.m_Cache))
     {
     }
+#endif
 
     ~SpikeWriterTextCached()
     {


### PR DESCRIPTION
Hi,

recent changes in userproject's SpikeRecorder will fail to compile with gcc 4.9. Although gcc4.9 is fairly old, I think its worth to keep it compatible as long as possible.

Cheers,
Christoph