### PR TITLE
Expose memory estimate to Python

### DIFF
--- a/generate_swig_interfaces.py
+++ b/generate_swig_interfaces.py
@@ -406,8 +406,9 @@ def generateBackend(swigPath, folder, namespace):
         # Add plog severity header so logging severities can be passed to backend
         mg.addSwigInclude('<plog/Severity.h>')
         
-        # Parse backend base, ignore BackendBase itself to get PreferencesBase definition
+        # Parse backend base, ignore BackendBase itself and MemAlloc to get PreferencesBase definition
         mg.addSwigIgnore("BackendBase")
+        mg.addSwigIgnore("MemAlloc")
         mg.addSwigInclude('"code_generator/backendBase.h"')
 
         # Parse backend, ignore Backend itself to get PreferencesBase definition
@@ -500,17 +501,26 @@ def generateConfigs(gennPath, backends):
             for header in (NEURONMODELS, POSTSYNMODELS,
                            WUPDATEMODELS, CURRSOURCEMODELS, INITVARSNIPPET, SPARSEINITSNIPPET):
                 pygennSmg.addCppInclude( '"' + header + 'Custom.h"' )
+            pygennSmg.addCppInclude( '"code_generator/backendBase.h"' )
             pygennSmg.addCppInclude( '"code_generator/generateAll.h"' )
             pygennSmg.addCppInclude( '"code_generator/generateMakefile.h"' )
             pygennSmg.addCppInclude( '"code_generator/generateMSBuild.h"' )
             pygennSmg.addCppInclude( '"path.h"' )
         pygennSmg.addSwigImport( '"StlContainers.i"' )
         
+        # Enable C++ camelCase to python underscore_case conversion
+        pygennSmg.addSwigEnableUnderCaseConvert()
+        
         # Include genn export header so GENN_EXPORT macros can be correctly parsed
         pygennSmg.addSwigInclude( '"gennExport.h"' )
 
         # Add plog severity header so logging severities can be passed to backend
         pygennSmg.addSwigInclude('<plog/Severity.h>')
+        
+        # Add backend base header but ignore everything apart from MemAlloc
+        pygennSmg.addSwigIgnore("BackendBase")
+        pygennSmg.addSwigIgnore("PreferencesBase")
+        pygennSmg.addSwigInclude('"code_generator/backendBase.h"')
         
         # define and wrap three functions which replace main in generateALL.cc
         with SwigInlineScope( pygennSmg ):
@@ -521,22 +531,23 @@ def generateConfigs(gennPath, backends):
                 Logging::init(gennLevel, codeGeneratorLevel, consoleAppender, consoleAppender);
             }
 
-            void generate_code(ModelSpecInternal &model, CodeGenerator::BackendBase &backend, const std::string &path, int localHostID)
+            CodeGenerator::MemAlloc generate_code(ModelSpecInternal &model, CodeGenerator::BackendBase &backend, const std::string &path, int localHostID)
             {
                 const filesystem::path outputPath(path);
 
                 // Generate code, returning list of module names that must be build
-                const auto moduleNames = CodeGenerator::generateAll(model, backend, outputPath);
+                const auto output = CodeGenerator::generateAll(model, backend, outputPath);
 
             #ifdef _WIN32
                 // Create MSBuild project to compile and link all generated modules
                 std::ofstream makefile((outputPath / "runner.vcxproj").str());
-                CodeGenerator::generateMSBuild(makefile, backend, "", moduleNames);
+                CodeGenerator::generateMSBuild(makefile, backend, "", output.first);
             #else
                 // Create makefile to compile and link all generated modules
                 std::ofstream makefile((outputPath / "Makefile").str());
-                CodeGenerator::generateMakefile(makefile, backend, moduleNames);
+                CodeGenerator::generateMakefile(makefile, backend, output.first);
             #endif
+                return output.second;
             }
             ''' )
 
@@ -621,8 +632,6 @@ def generateConfigs(gennPath, backends):
             %}''')
 
         # wrap NeuronGroup, SynapseGroup and CurrentSource
-        pygennSmg.addSwigEnableUnderCaseConvert()
-        
         pygennSmg.addSwigInclude( '"neuronGroup.h"' )
         pygennSmg.addSwigInclude( '"synapseGroup.h"' )
         pygennSmg.addSwigInclude( '"currentSource.h"' )

--- a/include/genn/genn/code_generator/generateAll.h
+++ b/include/genn/genn/code_generator/generateAll.h
@@ -7,13 +7,11 @@
 // GeNN includes
 #include "gennExport.h"
 
+// GeNN code generator includes
+#include "backendBase.h"
+
 // Forward declarations
 class ModelSpecInternal;
-
-namespace CodeGenerator
-{
-class BackendBase;
-}
 
 namespace filesystem
 {
@@ -25,5 +23,6 @@ namespace filesystem
 //--------------------------------------------------------------------------
 namespace CodeGenerator
 {
-    GENN_EXPORT std::vector<std::string> generateAll(const ModelSpecInternal &model, const BackendBase &backend, const filesystem::path &outputPath, bool standaloneModules=false);
+GENN_EXPORT std::pair<std::vector<std::string>, MemAlloc> generateAll(const ModelSpecInternal &model, const BackendBase &backend, 
+                                                                      const filesystem::path &outputPath, bool standaloneModules=false);
 }

--- a/pygenn/genn_model.py
+++ b/pygenn/genn_model.py
@@ -422,7 +422,7 @@ class GeNNModel(object):
         backend = self._backend_module.create_backend(self._model, output_path, self.backend_log_level, preferences);
 
         # Generate code
-        genn_wrapper.generate_code(self._model, backend, output_path, 0)
+        mem_alloc = genn_wrapper.generate_code(self._model, backend, output_path, 0)
 
         # **YUCK** SWIG doesn't handle return objects returned by value very well so delete manually
         backend = None
@@ -435,6 +435,7 @@ class GeNNModel(object):
             check_call(["make", "-j", str(cpu_count(logical=False)), "-C", output_path])
 
         self._built = True
+        return mem_alloc
 
     def load(self, path_to_model="./"):
         """import the model as shared library and initialize it"""

--- a/src/genn/backends/cuda/optimiser.cc
+++ b/src/genn/backends/cuda/optimiser.cc
@@ -191,7 +191,7 @@ KernelOptimisationOutput optimizeBlockSize(int deviceID, const cudaDeviceProp &d
         Backend backend(blockSize, preferences, model.getPrecision(), deviceID);
 
         // Generate code
-        const auto moduleNames = generateAll(model, backend, outputPath, true);
+        const auto moduleNames = generateAll(model, backend, outputPath, true).first;
 
         // Set context
         // **NOTE** CUDA calls in code generation seem to lose driver context

--- a/src/genn/generator/generator.cc
+++ b/src/genn/generator/generator.cc
@@ -66,7 +66,7 @@ int main(int argc,     //!< number of arguments; expected to be 2
                                                 GENN_PREFERENCES);
 
         // Generate code
-        const auto moduleNames = CodeGenerator::generateAll(model, backend, outputPath);
+        const auto moduleNames = CodeGenerator::generateAll(model, backend, outputPath).first;
 
 #ifdef _WIN32
         // If runner GUID file doesn't exist

--- a/src/genn/genn/code_generator/generateAll.cc
+++ b/src/genn/genn/code_generator/generateAll.cc
@@ -26,8 +26,8 @@
 //--------------------------------------------------------------------------
 // CodeGenerator
 //--------------------------------------------------------------------------
-std::vector<std::string> CodeGenerator::generateAll(const ModelSpecInternal &model, const BackendBase &backend,
-                                                    const filesystem::path &outputPath, bool standaloneModules)
+std::pair<std::vector<std::string>, CodeGenerator::MemAlloc> CodeGenerator::generateAll(const ModelSpecInternal &model, const BackendBase &backend,
+                                                                                        const filesystem::path &outputPath, bool standaloneModules)
 {
     // Create directory for generated code
     filesystem::create_directory(outputPath);
@@ -99,5 +99,5 @@ std::vector<std::string> CodeGenerator::generateAll(const ModelSpecInternal &mod
     }
 
     // Return list of modules
-    return modules;
+    return std::make_pair(modules, mem);
 }

--- a/src/spineml/generator/main.cc
+++ b/src/spineml/generator/main.cc
@@ -582,7 +582,7 @@ int main(int argc, char *argv[])
             model, codePath, (plog::Severity)gennLogLevel, &consoleAppender, preferences);
 
         // Generate code
-        const auto moduleNames = CodeGenerator::generateAll(model, backend, codePath);
+        const auto moduleNames = CodeGenerator::generateAll(model, backend, codePath).first;
 
 #ifdef _WIN32
         // Create MSBuild project to compile and link all generated modules


### PR DESCRIPTION
``GeNNModel.build`` now returns a ``MemAlloc`` object which lets you query GeNN's memory usage estimate:

```python
mem_alloc = model.build()
print("Device mem: %uMB" % mem_alloc.get_device_mbytes())
```

The following methods are also available:
```python
get_host_bytes()
get_device_bytes()
get_zero_copy_bytes()
get_host_mbytes()
get_device_mbytes()
get_zero_copy_mbytes()
```

In #324 I also talked about exposing the kernel merging stats but getting that out ended up being a bit of a mess and I think that's ok only being outputted to the log. As such fixes #324 