### PR TITLE
Fixes related to weight update model pre and postsynaptic variables

### DIFF
--- a/include/genn/genn/code_generator/groupMerged.h
+++ b/include/genn/genn/code_generator/groupMerged.h
@@ -435,8 +435,8 @@ private:
     //------------------------------------------------------------------------
     // Members
     //------------------------------------------------------------------------
-    std::vector<std::vector<SynapseGroupInternal *>> m_SortedInSyn;
-    std::vector<std::vector<SynapseGroupInternal *>> m_SortedOutSyn;
+    std::vector<std::vector<SynapseGroupInternal *>> m_SortedInSynWithPostVars;
+    std::vector<std::vector<SynapseGroupInternal *>> m_SortedOutSynWithPreVars;
 };
 
 //----------------------------------------------------------------------------

--- a/include/genn/genn/code_generator/groupMerged.h
+++ b/include/genn/genn/code_generator/groupMerged.h
@@ -169,45 +169,15 @@ public:
     //! Should the postsynaptic model var init derived parameter be implemented heterogeneously?
     bool isPSMVarInitDerivedParamHeterogeneous(size_t childIndex, size_t varIndex, size_t paramIndex) const;
 
-    //! Should the incoming synapse weight update model parameter be implemented heterogeneously?
-    bool isInSynWUMParamHeterogeneous(size_t childIndex, size_t paramIndex) const;
-    
-    //! Should the incoming synapse weight update model derived parameter be implemented heterogeneously?
-    bool isInSynWUMDerivedParamHeterogeneous(size_t childIndex, size_t paramIndex) const;
-
-    //! Should the incoming synapse weight update model var init parameter be implemented heterogeneously?
-    bool isInSynWUMVarInitParamHeterogeneous(size_t childIndex, size_t varIndex, size_t paramIndex) const;
-
-    //! Should the incoming synapse weight update model var init derived parameter be implemented heterogeneously?
-    bool isInSynWUMVarInitDerivedParamHeterogeneous(size_t childIndex, size_t varIndex, size_t paramIndex) const;
-
-    //! Should the outgoing synapse weight update model parameter be implemented heterogeneously?
-    bool isOutSynWUMParamHeterogeneous(size_t childIndex, size_t paramIndex) const;
-
-    //! Should the outgoing synapse weight update model derived parameter be implemented heterogeneously?
-    bool isOutSynWUMDerivedParamHeterogeneous(size_t childIndex, size_t paramIndex) const;
-
-    //! Should the outgoing synapse weight update model var init parameter be implemented heterogeneously?
-    bool isOutSynWUMVarInitParamHeterogeneous(size_t childIndex, size_t varIndex, size_t paramIndex) const;
-
-    //! Should the outgoing synapse weight update model var init derived parameter be implemented heterogeneously?
-    bool isOutSynWUMVarInitDerivedParamHeterogeneous(size_t childIndex, size_t varIndex, size_t paramIndex) const;
-
 protected:
     //------------------------------------------------------------------------
     // Protected methods
     //------------------------------------------------------------------------
     NeuronGroupMergedBase(size_t index, bool init, const std::vector<std::reference_wrapper<const NeuronGroupInternal>> &groups);
 
-    void generate(const BackendBase &backend, CodeStream &definitionsInternal,
-                  CodeStream &definitionsInternalFunc, CodeStream &definitionsInternalVar,
-                  CodeStream &runnerVarDecl, CodeStream &runnerMergedStructAlloc,
-                  MergedStructData &mergedStructData, const std::string &precision,
-                  const std::string &timePrecision, bool init) const;
-private:
-    //------------------------------------------------------------------------
-    // Private methods
-    //------------------------------------------------------------------------
+    void generate(MergedStructGenerator<NeuronGroupMergedBase> &gen, const BackendBase &backend, 
+                  const std::string &precision, const std::string &timePrecision, bool init) const;
+
     template<typename T, typename G, typename C>
     void orderNeuronGroupChildren(const std::vector<T> &archetypeChildren,
                                   std::vector<std::vector<T>> &sortedGroupChildren,
@@ -282,7 +252,7 @@ private:
         return false;
     }
 
-    template<typename H, typename V>
+    template<typename T = NeuronGroupMergedBase, typename H, typename V>
     void addHeterogeneousChildParams(MergedStructGenerator<NeuronGroupMergedBase> &gen, 
                                      const Snippet::Base::StringVec &paramNames, size_t childIndex,
                                      const std::string &prefix, 
@@ -291,7 +261,7 @@ private:
         // Loop through parameters
         for(size_t p = 0; p < paramNames.size(); p++) {
             // If parameter is heterogeneous
-            if((this->*isChildParamHeterogeneousFn)(childIndex, p)) {
+            if((static_cast<const T *>(this)->*isChildParamHeterogeneousFn)(childIndex, p)) {
                 gen.addScalarField(paramNames[p] + prefix + std::to_string(childIndex),
                                    [childIndex, p, getValueFn](const NeuronGroupInternal &, size_t groupIndex)
                                    {
@@ -301,7 +271,7 @@ private:
         }
     }
 
-    template<typename H, typename V>
+    template<typename T = NeuronGroupMergedBase, typename H, typename V>
     void addHeterogeneousChildDerivedParams(MergedStructGenerator<NeuronGroupMergedBase> &gen,
                                             const Snippet::Base::DerivedParamVec &derivedParams, size_t childIndex,
                                             const std::string &prefix, H isChildDerivedParamHeterogeneousFn, V getValueFn) const
@@ -309,7 +279,7 @@ private:
         // Loop through derived parameters
         for(size_t p = 0; p < derivedParams.size(); p++) {
             // If parameter is heterogeneous
-            if((this->*isChildDerivedParamHeterogeneousFn)(childIndex, p)) {
+            if((static_cast<const T *>(this)->*isChildDerivedParamHeterogeneousFn)(childIndex, p)) {
                 gen.addScalarField(derivedParams[p].name + prefix + std::to_string(childIndex),
                                    [childIndex, p, getValueFn](const NeuronGroupInternal &, size_t groupIndex)
                                    {
@@ -319,7 +289,7 @@ private:
         }
     }
 
-    template<typename H, typename V>
+    template<typename T = NeuronGroupMergedBase, typename H, typename V>
     void addHeterogeneousChildVarInitParams(MergedStructGenerator<NeuronGroupMergedBase> &gen,
                                             const Snippet::Base::StringVec &paramNames, size_t childIndex,
                                             size_t varIndex, const std::string &prefix,
@@ -328,7 +298,7 @@ private:
         // Loop through parameters
         for(size_t p = 0; p < paramNames.size(); p++) {
             // If parameter is heterogeneous
-            if((this->*isChildParamHeterogeneousFn)(childIndex, varIndex, p)) {
+            if((static_cast<const T*>(this)->*isChildParamHeterogeneousFn)(childIndex, varIndex, p)) {
                 gen.addScalarField(paramNames[p] + prefix + std::to_string(childIndex),
                                    [childIndex, varIndex, p, getVarInitialiserFn](const NeuronGroupInternal &, size_t groupIndex)
                                    {
@@ -339,7 +309,7 @@ private:
         }
     }
 
-    template<typename H, typename V>
+    template<typename T = NeuronGroupMergedBase, typename H, typename V>
     void addHeterogeneousChildVarInitDerivedParams(MergedStructGenerator<NeuronGroupMergedBase> &gen,
                                                    const Snippet::Base::DerivedParamVec &derivedParams, size_t childIndex,
                                                    size_t varIndex, const std::string &prefix,
@@ -348,7 +318,7 @@ private:
         // Loop through parameters
         for(size_t p = 0; p < derivedParams.size(); p++) {
             // If parameter is heterogeneous
-            if((this->*isChildDerivedParamHeterogeneousFn)(childIndex, varIndex, p)) {
+            if((static_cast<const T *>(this)->*isChildDerivedParamHeterogeneousFn)(childIndex, varIndex, p)) {
                 gen.addScalarField(derivedParams[p].name + prefix + std::to_string(childIndex),
                                    [childIndex, varIndex, p, getVarInitialiserFn](const NeuronGroupInternal &, size_t groupIndex)
                                    {
@@ -384,13 +354,12 @@ private:
                                     const std::string &type, const std::string &name, 
                                     size_t archetypeIndex, const std::string &prefix) const;
 
+private:
     //------------------------------------------------------------------------
     // Members
     //------------------------------------------------------------------------
     std::vector<std::vector<std::pair<SynapseGroupInternal *, std::vector<SynapseGroupInternal *>>>> m_SortedMergedInSyns;
     std::vector<std::vector<CurrentSourceInternal*>> m_SortedCurrentSources;
-    std::vector<std::vector<SynapseGroupInternal *>> m_SortedInSynWithPostCode;
-    std::vector<std::vector<SynapseGroupInternal *>> m_SortedOutSynWithPreCode;
 };
 
 //----------------------------------------------------------------------------
@@ -399,9 +368,7 @@ private:
 class GENN_EXPORT NeuronUpdateGroupMerged : public NeuronGroupMergedBase
 {
 public:
-    NeuronUpdateGroupMerged(size_t index, const std::vector<std::reference_wrapper<const NeuronGroupInternal>> &groups)
-    :   NeuronGroupMergedBase(index, false, groups)
-    {}
+    NeuronUpdateGroupMerged(size_t index, const std::vector<std::reference_wrapper<const NeuronGroupInternal>> &groups);
 
     //------------------------------------------------------------------------
     // Public API
@@ -412,15 +379,30 @@ public:
     //! Get the expression to calculate the queue offset for accessing state of variables in previous timestep
     std::string getPrevQueueOffset() const;
 
+    //! Should the incoming synapse weight update model parameter be implemented heterogeneously?
+    bool isInSynWUMParamHeterogeneous(size_t childIndex, size_t paramIndex) const;
+
+    //! Should the incoming synapse weight update model derived parameter be implemented heterogeneously?
+    bool isInSynWUMDerivedParamHeterogeneous(size_t childIndex, size_t paramIndex) const;
+
+    //! Should the outgoing synapse weight update model parameter be implemented heterogeneously?
+    bool isOutSynWUMParamHeterogeneous(size_t childIndex, size_t paramIndex) const;
+
+    //! Should the outgoing synapse weight update model derived parameter be implemented heterogeneously?
+    bool isOutSynWUMDerivedParamHeterogeneous(size_t childIndex, size_t paramIndex) const;
+
     void generate(const BackendBase &backend, CodeStream &definitionsInternal,
                   CodeStream &definitionsInternalFunc, CodeStream &definitionsInternalVar,
                   CodeStream &runnerVarDecl, CodeStream &runnerMergedStructAlloc,
                   MergedStructData &mergedStructData, const std::string &precision,
-                  const std::string &timePrecision) const
-    {
-        NeuronGroupMergedBase::generate(backend, definitionsInternal, definitionsInternalFunc, definitionsInternalVar,
-                                        runnerVarDecl, runnerMergedStructAlloc, mergedStructData, precision, timePrecision, false);
-    }
+                  const std::string &timePrecision) const;
+
+private:
+    //------------------------------------------------------------------------
+    // Members
+    //------------------------------------------------------------------------
+    std::vector<std::vector<SynapseGroupInternal *>> m_SortedInSynWithPostCode;
+    std::vector<std::vector<SynapseGroupInternal *>> m_SortedOutSynWithPreCode;
 };
 
 //----------------------------------------------------------------------------
@@ -429,19 +411,32 @@ public:
 class GENN_EXPORT NeuronInitGroupMerged : public NeuronGroupMergedBase
 {
 public:
-    NeuronInitGroupMerged(size_t index, const std::vector<std::reference_wrapper<const NeuronGroupInternal>> &groups)
-    :   NeuronGroupMergedBase(index, true, groups)
-    {}
+    NeuronInitGroupMerged(size_t index, const std::vector<std::reference_wrapper<const NeuronGroupInternal>> &groups);
+
+    //! Should the incoming synapse weight update model var init parameter be implemented heterogeneously?
+    bool isInSynWUMVarInitParamHeterogeneous(size_t childIndex, size_t varIndex, size_t paramIndex) const;
+
+    //! Should the incoming synapse weight update model var init derived parameter be implemented heterogeneously?
+    bool isInSynWUMVarInitDerivedParamHeterogeneous(size_t childIndex, size_t varIndex, size_t paramIndex) const;
+
+    //! Should the outgoing synapse weight update model var init parameter be implemented heterogeneously?
+    bool isOutSynWUMVarInitParamHeterogeneous(size_t childIndex, size_t varIndex, size_t paramIndex) const;
+
+    //! Should the outgoing synapse weight update model var init derived parameter be implemented heterogeneously?
+    bool isOutSynWUMVarInitDerivedParamHeterogeneous(size_t childIndex, size_t varIndex, size_t paramIndex) const;
 
     void generate(const BackendBase &backend, CodeStream &definitionsInternal,
                   CodeStream &definitionsInternalFunc, CodeStream &definitionsInternalVar,
                   CodeStream &runnerVarDecl, CodeStream &runnerMergedStructAlloc,
                   MergedStructData &mergedStructData, const std::string &precision,
-                  const std::string &timePrecision) const
-    {
-        NeuronGroupMergedBase::generate(backend, definitionsInternal, definitionsInternalFunc, definitionsInternalVar,
-                                        runnerVarDecl, runnerMergedStructAlloc, mergedStructData, precision, timePrecision, true);
-    }
+                  const std::string &timePrecision) const;
+
+private:
+    //------------------------------------------------------------------------
+    // Members
+    //------------------------------------------------------------------------
+    std::vector<std::vector<SynapseGroupInternal *>> m_SortedInSyn;
+    std::vector<std::vector<SynapseGroupInternal *>> m_SortedOutSyn;
 };
 
 //----------------------------------------------------------------------------

--- a/include/genn/genn/code_generator/groupMerged.h
+++ b/include/genn/genn/code_generator/groupMerged.h
@@ -199,11 +199,6 @@ protected:
     //------------------------------------------------------------------------
     NeuronGroupMergedBase(size_t index, bool init, const std::vector<std::reference_wrapper<const NeuronGroupInternal>> &groups);
 
-    const std::vector<std::vector<std::pair<SynapseGroupInternal *, std::vector<SynapseGroupInternal *>>>> &getSortedMergedInSyns() const { return m_SortedMergedInSyns; }
-    const std::vector<std::vector<CurrentSourceInternal *>> &getSortedCurrentSources() const { return m_SortedCurrentSources; }
-    const std::vector<std::vector<SynapseGroupInternal *>> &getSortedInSynWithPostCode() const { return m_SortedInSynWithPostCode; }
-    const std::vector<std::vector<SynapseGroupInternal *>> &getSortedOutSynWithPreCode() const { return m_SortedOutSynWithPreCode; }
-
     void generate(const BackendBase &backend, CodeStream &definitionsInternal,
                   CodeStream &definitionsInternalFunc, CodeStream &definitionsInternalVar,
                   CodeStream &runnerVarDecl, CodeStream &runnerMergedStructAlloc,

--- a/include/genn/genn/neuronGroup.h
+++ b/include/genn/genn/neuronGroup.h
@@ -216,6 +216,12 @@ protected:
     //! Helper to get vector of outgoing synapse groups which have presynaptic update code
     std::vector<SynapseGroupInternal*> getOutSynWithPreCode() const;
 
+    //! Helper to get vector of incoming synapse groups which have postsynaptic variables
+    std::vector<SynapseGroupInternal *> getInSynWithPostVars() const;
+
+    //! Helper to get vector of outgoing synapse groups which have presynaptic variables
+    std::vector<SynapseGroupInternal *> getOutSynWithPreVars() const;
+
     bool isVarQueueRequired(const std::string &var) const;
     bool isVarQueueRequired(size_t index) const{ return m_VarQueueRequired[index]; }
 

--- a/include/genn/genn/neuronGroupInternal.h
+++ b/include/genn/genn/neuronGroupInternal.h
@@ -34,6 +34,8 @@ public:
     using NeuronGroup::getSpikeEventCondition;
     using NeuronGroup::getInSynWithPostCode;
     using NeuronGroup::getOutSynWithPreCode;
+    using NeuronGroup::getInSynWithPostVars;
+    using NeuronGroup::getOutSynWithPreVars;
     using NeuronGroup::isVarQueueRequired;
     using NeuronGroup::canBeMerged;
     using NeuronGroup::canInitBeMerged;

--- a/include/genn/genn/synapseGroup.h
+++ b/include/genn/genn/synapseGroup.h
@@ -216,6 +216,12 @@ public:
     //! Does this synapse group require an RNG for it's weight update init code?
     bool isWUInitRNGRequired() const;
 
+    //! Does this synapse group require an RNG for it's weight update presynaptic variable init code?
+    bool isWUPreInitRNGRequired() const;
+
+    //! Does this synapse group require an RNG for it's weight update postsynaptic variable init code?
+    bool isWUPostInitRNGRequired() const;
+
     //! Does this synapse group require a RNG for any sort of initialization
     bool isHostInitRNGRequired() const;
 

--- a/src/genn/genn/code_generator/generateInit.cc
+++ b/src/genn/genn/code_generator/generateInit.cc
@@ -295,9 +295,9 @@ void CodeGenerator::generateInit(CodeStream &os, const MergedStructData &mergedS
             }
 
             // Loop through incoming synaptic populations with postsynaptic update code
-            const auto inSynWithPostCode = ng.getArchetype().getInSynWithPostCode();
-            for(size_t i = 0; i < inSynWithPostCode.size(); i++) {
-                const auto *sg = inSynWithPostCode[i];
+            // **NOTE** number of delay slots is based on the target neuron (for simplicity) but whether delay is required is based on the synapse group
+            for(size_t i = 0; i < ng.getArchetype().getInSyn().size(); i++) {
+                const auto *sg = ng.getArchetype().getInSyn().at(i);
                 genInitNeuronVarCode(os, backend, popSubs, sg->getWUModel()->getPostVars(),
                                      "WUPost" + std::to_string(i), "numNeurons", sg->getTrgNeuronGroup()->getNumDelaySlots(),
                                      i, model.getPrecision(),
@@ -308,10 +308,9 @@ void CodeGenerator::generateInit(CodeStream &os, const MergedStructData &mergedS
             }
 
             // Loop through outgoing synaptic populations with presynaptic update code
-            const auto outSynWithPreCode = ng.getArchetype().getOutSynWithPreCode();
-            for(size_t i = 0; i < outSynWithPreCode.size(); i++) {
-                const auto *sg = outSynWithPreCode[i];
-                // **NOTE** number of delay slots is based on the source neuron (for simplicity) but whether delay is required is based on the synapse group
+            // **NOTE** number of delay slots is based on the source neuron (for simplicity) but whether delay is required is based on the synapse group
+            for(size_t i = 0; i < ng.getArchetype().getOutSyn().size(); i++) {
+                const auto *sg = ng.getArchetype().getOutSyn().at(i);
                 genInitNeuronVarCode(os, backend, popSubs, sg->getWUModel()->getPreVars(),
                                      "WUPre" + std::to_string(i), "numNeurons", sg->getSrcNeuronGroup()->getNumDelaySlots(),
                                      i, model.getPrecision(),

--- a/src/genn/genn/code_generator/groupMerged.cc
+++ b/src/genn/genn/code_generator/groupMerged.cc
@@ -384,7 +384,7 @@ void CodeGenerator::NeuronGroupMergedBase::generate(const BackendBase &backend, 
             gen.addField("volatile unsigned int*", "denDelayPtrInSyn" + std::to_string(i),
                          [&backend, i, this](const NeuronGroupInternal &, size_t groupIndex)
                          {
-                             const std::string &targetName = getSortedMergedInSyns().at(groupIndex).at(i).first->getPSModelTargetName();
+                             const std::string &targetName = m_SortedMergedInSyns.at(groupIndex).at(i).first->getPSModelTargetName();
                              return "getSymbolAddress(" + backend.getScalarPrefix() + "denDelayPtr" + targetName + ")";
                          });
         }
@@ -404,7 +404,7 @@ void CodeGenerator::NeuronGroupMergedBase::generate(const BackendBase &backend, 
                     const auto *varInitSnippet = sg->getPSVarInitialisers().at(v).getSnippet();
                     auto getVarInitialiserFn = [this](size_t groupIndex, size_t childIndex)
                     {
-                        return getSortedMergedInSyns().at(groupIndex).at(childIndex).first->getPSVarInitialisers();
+                        return m_SortedMergedInSyns.at(groupIndex).at(childIndex).first->getPSVarInitialisers();
                     };
                     addHeterogeneousChildVarInitParams(gen, varInitSnippet->getParamNames(), i, v, vars[v].name + "InSyn",
                                                        &NeuronGroupMergedBase::isPSMVarInitParamHeterogeneous, getVarInitialiserFn);
@@ -419,7 +419,7 @@ void CodeGenerator::NeuronGroupMergedBase::generate(const BackendBase &backend, 
                     gen.addScalarField(vars[v].name + "InSyn" + std::to_string(i),
                                        [this, i, v](const NeuronGroupInternal &, size_t groupIndex)
                                        {
-                                           const double val = getSortedMergedInSyns().at(groupIndex).at(i).first->getPSConstInitVals().at(v);
+                                           const double val = m_SortedMergedInSyns.at(groupIndex).at(i).first->getPSConstInitVals().at(v);
                                            return Utils::writePreciseString(val);
                                        });
                 }
@@ -432,7 +432,7 @@ void CodeGenerator::NeuronGroupMergedBase::generate(const BackendBase &backend, 
             addHeterogeneousChildParams(gen, paramNames, i, "InSyn", &NeuronGroupMergedBase::isPSMParamHeterogeneous,
                                         [this](size_t groupIndex, size_t childIndex, size_t paramIndex)
                                         {
-                                            return getSortedMergedInSyns().at(groupIndex).at(childIndex).first->getPSParams().at(paramIndex);
+                                            return m_SortedMergedInSyns.at(groupIndex).at(childIndex).first->getPSParams().at(paramIndex);
                                         });
 
             // Add any heterogeneous postsynaptic mode derived parameters
@@ -440,13 +440,13 @@ void CodeGenerator::NeuronGroupMergedBase::generate(const BackendBase &backend, 
             addHeterogeneousChildDerivedParams(gen, derivedParams, i, "InSyn", &NeuronGroupMergedBase::isPSMDerivedParamHeterogeneous,
                                                [this](size_t groupIndex, size_t childIndex, size_t paramIndex)
                                                {
-                                                   return getSortedMergedInSyns().at(groupIndex).at(childIndex).first->getPSDerivedParams().at(paramIndex);
+                                                   return m_SortedMergedInSyns.at(groupIndex).at(childIndex).first->getPSDerivedParams().at(paramIndex);
                                                });
             // Add EGPs
             addChildEGPs(gen, sg->getPSModel()->getExtraGlobalParams(), i, backend.getArrayPrefix(), "InSyn",
                          [this](size_t groupIndex, size_t childIndex)
                          {
-                             return getSortedMergedInSyns().at(groupIndex).at(childIndex).first->getPSModelTargetName();
+                             return m_SortedMergedInSyns.at(groupIndex).at(childIndex).first->getPSModelTargetName();
                          });
         }
     }
@@ -472,7 +472,7 @@ void CodeGenerator::NeuronGroupMergedBase::generate(const BackendBase &backend, 
                 const auto *varInitSnippet = cs->getVarInitialisers().at(v).getSnippet();
                 auto getVarInitialiserFn = [this](size_t groupIndex, size_t childIndex)
                 {
-                    return getSortedCurrentSources().at(groupIndex).at(childIndex)->getVarInitialisers();
+                    return m_SortedCurrentSources.at(groupIndex).at(childIndex)->getVarInitialisers();
                 };
                 addHeterogeneousChildVarInitParams(gen, varInitSnippet->getParamNames(), i, v, vars[v].name + "CS",
                                                    &NeuronGroupMergedBase::isCurrentSourceVarInitParamHeterogeneous, getVarInitialiserFn);
@@ -487,7 +487,7 @@ void CodeGenerator::NeuronGroupMergedBase::generate(const BackendBase &backend, 
             addHeterogeneousChildParams(gen, paramNames, i, "CS", &NeuronGroupMergedBase::isCurrentSourceParamHeterogeneous,
                                         [this](size_t groupIndex, size_t childIndex, size_t paramIndex)
                                         {
-                                            return getSortedCurrentSources().at(groupIndex).at(childIndex)->getParams().at(paramIndex);
+                                            return m_SortedCurrentSources.at(groupIndex).at(childIndex)->getParams().at(paramIndex);
                                         });
 
             // Add any heterogeneous current source derived parameters
@@ -495,14 +495,14 @@ void CodeGenerator::NeuronGroupMergedBase::generate(const BackendBase &backend, 
             addHeterogeneousChildDerivedParams(gen, derivedParams, i, "CS", &NeuronGroupMergedBase::isCurrentSourceDerivedParamHeterogeneous,
                                                [this](size_t groupIndex, size_t childIndex, size_t paramIndex)
                                                {
-                                                   return getSortedCurrentSources().at(groupIndex).at(childIndex)->getDerivedParams().at(paramIndex);
+                                                   return m_SortedCurrentSources.at(groupIndex).at(childIndex)->getDerivedParams().at(paramIndex);
                                                });
 
             // Add EGPs
             addChildEGPs(gen, cs->getCurrentSourceModel()->getExtraGlobalParams(), i, backend.getArrayPrefix(), "CS",
                          [this](size_t groupIndex, size_t childIndex) 
                          { 
-                             return getSortedCurrentSources().at(groupIndex).at(childIndex)->getName(); 
+                             return m_SortedCurrentSources.at(groupIndex).at(childIndex)->getName(); 
                          });
             
         }
@@ -522,7 +522,7 @@ void CodeGenerator::NeuronGroupMergedBase::generate(const BackendBase &backend, 
             gen.addField(var.type + "*", var.name + "WUPost" + std::to_string(i),
                          [i, var, &backend, this](const NeuronGroupInternal &, size_t groupIndex)
                          {
-                             return backend.getArrayPrefix() + var.name + getSortedInSynWithPostCode().at(groupIndex).at(i)->getName();
+                             return backend.getArrayPrefix() + var.name + m_SortedInSynWithPostCode.at(groupIndex).at(i)->getName();
                          });
 
             // If we're generating an initialization structure, also add any heterogeneous parameters and derived parameters required for initializers
@@ -530,7 +530,7 @@ void CodeGenerator::NeuronGroupMergedBase::generate(const BackendBase &backend, 
                 const auto *varInitSnippet = sg->getWUPostVarInitialisers().at(v).getSnippet();
                 auto getVarInitialiserFn = [this](size_t groupIndex, size_t childIndex)
                 {
-                    return getSortedInSynWithPostCode().at(groupIndex).at(childIndex)->getWUPostVarInitialisers();
+                    return m_SortedInSynWithPostCode.at(groupIndex).at(childIndex)->getWUPostVarInitialisers();
                 };
                 addHeterogeneousChildVarInitParams(gen, varInitSnippet->getParamNames(), i, v, vars[v].name + "WUPost",
                                                    &NeuronGroupMergedBase::isInSynWUMVarInitParamHeterogeneous, getVarInitialiserFn);
@@ -545,7 +545,7 @@ void CodeGenerator::NeuronGroupMergedBase::generate(const BackendBase &backend, 
             addHeterogeneousChildParams(gen, paramNames, i, "WUPost", &NeuronGroupMergedBase::isInSynWUMParamHeterogeneous,
                                         [this](size_t groupIndex, size_t childIndex, size_t paramIndex)
                                         {
-                                            return getSortedInSynWithPostCode().at(groupIndex).at(childIndex)->getWUParams().at(paramIndex);
+                                            return m_SortedInSynWithPostCode.at(groupIndex).at(childIndex)->getWUParams().at(paramIndex);
                                         });
 
             // Add any heterogeneous derived parameters
@@ -553,14 +553,14 @@ void CodeGenerator::NeuronGroupMergedBase::generate(const BackendBase &backend, 
             addHeterogeneousChildDerivedParams(gen, derivedParams, i, "WUPost", &NeuronGroupMergedBase::isInSynWUMDerivedParamHeterogeneous,
                                                [this](size_t groupIndex, size_t childIndex, size_t paramIndex)
                                                {
-                                                   return getSortedInSynWithPostCode().at(groupIndex).at(childIndex)->getWUDerivedParams().at(paramIndex);
+                                                   return m_SortedInSynWithPostCode.at(groupIndex).at(childIndex)->getWUDerivedParams().at(paramIndex);
                                                });
 
             // Add EGPs
             addChildEGPs(gen, sg->getWUModel()->getExtraGlobalParams(), i, backend.getArrayPrefix(), "WUPost",
                          [this](size_t groupIndex, size_t childIndex)
                          {
-                             return getSortedInSynWithPostCode().at(groupIndex).at(childIndex)->getName();
+                             return m_SortedInSynWithPostCode.at(groupIndex).at(childIndex)->getName();
                          });
         }
     }
@@ -579,7 +579,7 @@ void CodeGenerator::NeuronGroupMergedBase::generate(const BackendBase &backend, 
             gen.addField(var.type + "*", var.name + "WUPre" + std::to_string(i),
                          [i, var, &backend, this](const NeuronGroupInternal &, size_t groupIndex)
                          {
-                             return backend.getArrayPrefix() + var.name + getSortedOutSynWithPreCode().at(groupIndex).at(i)->getName();
+                             return backend.getArrayPrefix() + var.name + m_SortedOutSynWithPreCode.at(groupIndex).at(i)->getName();
                          });
 
             // If we're generating an initialization structure, also add any heterogeneous parameters and derived parameters required for initializers
@@ -587,7 +587,7 @@ void CodeGenerator::NeuronGroupMergedBase::generate(const BackendBase &backend, 
                 const auto *varInitSnippet = sg->getWUPreVarInitialisers().at(v).getSnippet();
                 auto getVarInitialiserFn = [this](size_t groupIndex, size_t childIndex)
                 {
-                    return getSortedInSynWithPostCode().at(groupIndex).at(childIndex)->getWUPreVarInitialisers();
+                    return m_SortedInSynWithPostCode.at(groupIndex).at(childIndex)->getWUPreVarInitialisers();
                 };
                 addHeterogeneousChildVarInitParams(gen, varInitSnippet->getParamNames(), i, v, vars[v].name + "WUPre",
                                                    &NeuronGroupMergedBase::isOutSynWUMVarInitParamHeterogeneous, getVarInitialiserFn);
@@ -602,7 +602,7 @@ void CodeGenerator::NeuronGroupMergedBase::generate(const BackendBase &backend, 
             addHeterogeneousChildParams(gen, paramNames, i, "WUPre", &NeuronGroupMergedBase::isOutSynWUMParamHeterogeneous,
                                         [this](size_t groupIndex, size_t childIndex, size_t paramIndex)
                                         {
-                                            return getSortedOutSynWithPreCode().at(groupIndex).at(childIndex)->getWUParams().at(paramIndex);
+                                            return m_SortedOutSynWithPreCode.at(groupIndex).at(childIndex)->getWUParams().at(paramIndex);
                                         });
 
             // Add any heterogeneous derived parameters
@@ -610,14 +610,14 @@ void CodeGenerator::NeuronGroupMergedBase::generate(const BackendBase &backend, 
             addHeterogeneousChildDerivedParams(gen, derivedParams, i, "WUPre", &NeuronGroupMergedBase::isOutSynWUMDerivedParamHeterogeneous,
                                                [this](size_t groupIndex, size_t childIndex, size_t paramIndex)
                                                {
-                                                   return getSortedOutSynWithPreCode().at(groupIndex).at(childIndex)->getWUDerivedParams().at(paramIndex);
+                                                   return m_SortedOutSynWithPreCode.at(groupIndex).at(childIndex)->getWUDerivedParams().at(paramIndex);
                                                });
 
             // Add EGPs
             addChildEGPs(gen, sg->getWUModel()->getExtraGlobalParams(), i, backend.getArrayPrefix(), "WUPre",
                          [this](size_t groupIndex, size_t childIndex)
                          {
-                             return getSortedOutSynWithPreCode().at(groupIndex).at(childIndex)->getName();
+                             return m_SortedOutSynWithPreCode.at(groupIndex).at(childIndex)->getName();
                          });
         }
     }

--- a/src/genn/genn/neuronGroup.cc
+++ b/src/genn/genn/neuronGroup.cc
@@ -406,9 +406,9 @@ bool NeuronGroup::canInitBeMerged(const NeuronGroup &other) const
             return false;
         }
 
-        // Check if, by reshuffling, all incoming synapse groups with post code are mergable
-        auto otherInSynWithPostCode = other.getInSynWithPostCode();
-        if(!checkCompatibleUnordered(getInSynWithPostCode(), otherInSynWithPostCode,
+        // Check if, by reshuffling, all incoming synapse groups with are mergable
+        auto otherInSyn = other.getInSyn();
+        if(!checkCompatibleUnordered(getInSynWithPostCode(), otherInSyn,
                                      [](const SynapseGroupInternal *a, SynapseGroupInternal *b)
                                      {
                                          return a->canWUPostInitBeMerged(*b);
@@ -418,8 +418,8 @@ bool NeuronGroup::canInitBeMerged(const NeuronGroup &other) const
         }
 
         // Check if, by reshuffling, all outgoing synapse groups with pre code are mergable
-        auto otherOutSynWithPreCode = other.getOutSynWithPreCode();
-        if(!checkCompatibleUnordered(getOutSynWithPreCode(), otherOutSynWithPreCode,
+        auto otherOutSyn = other.getOutSyn();
+        if(!checkCompatibleUnordered(getOutSynWithPreCode(), otherOutSyn,
                                      [](const SynapseGroupInternal *a, SynapseGroupInternal *b)
                                      {
                                          return a->canWUPreInitBeMerged(*b);

--- a/src/genn/genn/neuronGroup.cc
+++ b/src/genn/genn/neuronGroup.cc
@@ -311,6 +311,22 @@ std::vector<SynapseGroupInternal*> NeuronGroup::getOutSynWithPreCode() const
     return vec;
 }
 //----------------------------------------------------------------------------
+std::vector<SynapseGroupInternal*> NeuronGroup::getInSynWithPostVars() const
+{
+    std::vector<SynapseGroupInternal *> vec;
+    std::copy_if(getInSyn().cbegin(), getInSyn().cend(), std::back_inserter(vec),
+                 [](SynapseGroupInternal *sg) { return !sg->getWUModel()->getPostVars().empty(); });
+    return vec;
+}
+//----------------------------------------------------------------------------
+std::vector<SynapseGroupInternal*> NeuronGroup::getOutSynWithPreVars() const
+{
+    std::vector<SynapseGroupInternal *> vec;
+    std::copy_if(getOutSyn().cbegin(), getOutSyn().cend(), std::back_inserter(vec),
+                 [](SynapseGroupInternal *sg) { return !sg->getWUModel()->getPreVars().empty(); });
+    return vec;
+}
+//----------------------------------------------------------------------------
 void NeuronGroup::addSpkEventCondition(const std::string &code, SynapseGroupInternal *synapseGroup)
 {
     const auto *wu = synapseGroup->getWUModel();
@@ -421,8 +437,8 @@ bool NeuronGroup::canInitBeMerged(const NeuronGroup &other) const
         }
 
         // Check if, by reshuffling, all incoming synapse groups with are mergable
-        auto otherInSyn = other.getInSyn();
-        if(!checkCompatibleUnordered(getInSyn(), otherInSyn,
+        auto otherInSynWithPostVars = other.getInSynWithPostVars();
+        if(!checkCompatibleUnordered(getInSynWithPostVars(), otherInSynWithPostVars,
                                      [](const SynapseGroupInternal *a, SynapseGroupInternal *b)
                                      {
                                          return a->canWUPostInitBeMerged(*b);
@@ -432,8 +448,8 @@ bool NeuronGroup::canInitBeMerged(const NeuronGroup &other) const
         }
 
         // Check if, by reshuffling, all outgoing synapse groups with pre code are mergable
-        auto otherOutSyn = other.getOutSyn();
-        if(!checkCompatibleUnordered(getOutSyn(), otherOutSyn,
+        auto otherOutSynWithPreVars = other.getOutSynWithPreVars();
+        if(!checkCompatibleUnordered(getOutSynWithPreVars(), otherOutSynWithPreVars,
                                      [](const SynapseGroupInternal *a, SynapseGroupInternal *b)
                                      {
                                          return a->canWUPreInitBeMerged(*b);

--- a/src/genn/genn/neuronGroup.cc
+++ b/src/genn/genn/neuronGroup.cc
@@ -422,7 +422,7 @@ bool NeuronGroup::canInitBeMerged(const NeuronGroup &other) const
 
         // Check if, by reshuffling, all incoming synapse groups with are mergable
         auto otherInSyn = other.getInSyn();
-        if(!checkCompatibleUnordered(getInSynWithPostCode(), otherInSyn,
+        if(!checkCompatibleUnordered(getInSyn(), otherInSyn,
                                      [](const SynapseGroupInternal *a, SynapseGroupInternal *b)
                                      {
                                          return a->canWUPostInitBeMerged(*b);
@@ -433,7 +433,7 @@ bool NeuronGroup::canInitBeMerged(const NeuronGroup &other) const
 
         // Check if, by reshuffling, all outgoing synapse groups with pre code are mergable
         auto otherOutSyn = other.getOutSyn();
-        if(!checkCompatibleUnordered(getOutSynWithPreCode(), otherOutSyn,
+        if(!checkCompatibleUnordered(getOutSyn(), otherOutSyn,
                                      [](const SynapseGroupInternal *a, SynapseGroupInternal *b)
                                      {
                                          return a->canWUPreInitBeMerged(*b);

--- a/src/genn/genn/neuronGroup.cc
+++ b/src/genn/genn/neuronGroup.cc
@@ -176,6 +176,20 @@ bool NeuronGroup::isInitRNGRequired() const
         return true;
     }
 
+    // Return true if any incoming synapse groups require and RNG to initialize their postsynaptic variables
+    if(std::any_of(getInSyn().cbegin(), getInSyn().cend(),
+                   [](const SynapseGroupInternal *sg) { return sg->isWUPostInitRNGRequired(); }))
+    {
+        return true;
+    }
+
+    // Return true if any outgoing synapse groups require and RNG to initialize their presynaptic variables
+    if(std::any_of(getOutSyn().cbegin(), getOutSyn().cend(),
+                   [](const SynapseGroupInternal *sg) { return sg->isWUPreInitRNGRequired(); }))
+    {
+        return true;
+    }
+
     // Return true if any of the incoming synapse groups have state variables which require an RNG to initialise
     // **NOTE** these are included here as they are initialised in neuron initialisation threads
     return std::any_of(getInSyn().cbegin(), getInSyn().cend(),

--- a/src/genn/genn/synapseGroup.cc
+++ b/src/genn/genn/synapseGroup.cc
@@ -378,6 +378,16 @@ bool SynapseGroup::isWUInitRNGRequired() const
             && Utils::isRNGRequired(m_ConnectivityInitialiser.getSnippet()->getRowBuildCode()));
 }
 //----------------------------------------------------------------------------
+bool SynapseGroup::isWUPreInitRNGRequired() const
+{
+    return Utils::isRNGRequired(m_WUPreVarInitialisers);
+}
+//----------------------------------------------------------------------------
+bool SynapseGroup::isWUPostInitRNGRequired() const
+{
+    return Utils::isRNGRequired(m_WUPostVarInitialisers);
+}
+//----------------------------------------------------------------------------
 bool SynapseGroup::isHostInitRNGRequired() const
 {
     return (m_ConnectivityInitialiser.getSnippet()->getHostInitCode().find("$(rng)") != std::string::npos);

--- a/tests/features/var_init/model.cc
+++ b/tests/features/var_init/model.cc
@@ -51,9 +51,11 @@ IMPLEMENT_MODEL(PostsynapticModel);
 class WeightUpdateModel : public WeightUpdateModels::Base
 {
 public:
-    DECLARE_MODEL(WeightUpdateModel, 0, 5);
+    DECLARE_WEIGHT_UPDATE_MODEL(WeightUpdateModel, 0, 5, 5, 5);
 
     SET_VARS({{"constant", "scalar"}, {"uniform", "scalar"}, {"normal", "scalar"}, {"exponential", "scalar"}, {"gamma", "scalar"}});
+    SET_PRE_VARS({{"pre_constant", "scalar"}, {"pre_uniform", "scalar"}, {"pre_normal", "scalar"}, {"pre_exponential", "scalar"}, {"pre_gamma", "scalar"}});
+    SET_POST_VARS({{"post_constant", "scalar"}, {"post_uniform", "scalar"}, {"post_normal", "scalar"}, {"post_exponential", "scalar"}, {"post_gamma", "scalar"}});
 };
 IMPLEMENT_MODEL(WeightUpdateModel);
 
@@ -111,7 +113,19 @@ void modelDefinition(ModelSpec &model)
         initVar<InitVarSnippet::Normal>(normalParams),
         initVar<InitVarSnippet::Exponential>(exponentialParams),
         initVar<InitVarSnippet::Gamma>(gammaParams));
-
+    WeightUpdateModel::PreVarValues weightUpdatePreInit(
+        13.0,
+        initVar<InitVarSnippet::Uniform>(uniformParams),
+        initVar<InitVarSnippet::Normal>(normalParams),
+        initVar<InitVarSnippet::Exponential>(exponentialParams),
+        initVar<InitVarSnippet::Gamma>(gammaParams));
+    WeightUpdateModel::PostVarValues weightUpdatePostInit(
+        13.0,
+        initVar<InitVarSnippet::Uniform>(uniformParams),
+        initVar<InitVarSnippet::Normal>(normalParams),
+        initVar<InitVarSnippet::Exponential>(exponentialParams),
+        initVar<InitVarSnippet::Gamma>(gammaParams));
+    
     // Neuron populations
     model.addNeuronPopulation<NeuronModels::SpikeSource>("SpikeSource", 1, {}, {});
     model.addNeuronPopulation<Neuron>("Pop", 10000, {}, neuronInit);
@@ -121,14 +135,14 @@ void modelDefinition(ModelSpec &model)
     model.addSynapsePopulation<WeightUpdateModel, PostsynapticModel>(
         "Dense", SynapseMatrixType::DENSE_INDIVIDUALG, NO_DELAY,
         "SpikeSource", "Pop",
-        {}, weightUpdateInit,
+        {}, weightUpdateInit, weightUpdatePreInit, weightUpdatePostInit,
         {}, postsynapticInit);
 
     // Sparse synapse populations
     model.addSynapsePopulation<WeightUpdateModel, PostsynapticModel>(
         "Sparse", SynapseMatrixType::SPARSE_INDIVIDUALG, NO_DELAY,
         "SpikeSource", "Pop",
-        {}, weightUpdateInit,
+        {}, weightUpdateInit, weightUpdatePreInit, weightUpdatePostInit,
         {}, postsynapticInit);
 
     model.setPrecision(GENN_FLOAT);

--- a/tests/features/var_init/model.cc
+++ b/tests/features/var_init/model.cc
@@ -61,7 +61,7 @@ IMPLEMENT_MODEL(WeightUpdateModel);
 
 void modelDefinition(ModelSpec &model)
 {
-    model.setSeed(12345);
+    model.setSeed(2345678);
     model.setDT(0.1);
     model.setName("var_init");
 

--- a/tests/features/var_init/model.cc
+++ b/tests/features/var_init/model.cc
@@ -127,21 +127,22 @@ void modelDefinition(ModelSpec &model)
         initVar<InitVarSnippet::Gamma>(gammaParams));
     
     // Neuron populations
-    model.addNeuronPopulation<NeuronModels::SpikeSource>("SpikeSource", 10000, {}, {});
-    model.addNeuronPopulation<Neuron>("Pop", 10000, {}, neuronInit);
+    model.addNeuronPopulation<NeuronModels::SpikeSource>("SpikeSource1", 1, {}, {});
+    model.addNeuronPopulation<NeuronModels::SpikeSource>("SpikeSource2", 20000, {}, {});
+    model.addNeuronPopulation<Neuron>("Pop", 20000, {}, neuronInit);
     model.addCurrentSource<CurrentSrc>("CurrSource", "Pop", {}, currentSourceInit);
 
     // Dense synapse populations
     model.addSynapsePopulation<WeightUpdateModel, PostsynapticModel>(
         "Dense", SynapseMatrixType::DENSE_INDIVIDUALG, NO_DELAY,
-        "SpikeSource", "Pop",
+        "SpikeSource1", "Pop",
         {}, weightUpdateInit, weightUpdatePreInit, weightUpdatePostInit,
         {}, postsynapticInit);
 
     // Sparse synapse populations
     model.addSynapsePopulation<WeightUpdateModel, PostsynapticModel>(
         "Sparse", SynapseMatrixType::SPARSE_INDIVIDUALG, NO_DELAY,
-        "SpikeSource", "Pop",
+        "SpikeSource2", "Pop",
         {}, weightUpdateInit, weightUpdatePreInit, weightUpdatePostInit,
         {}, postsynapticInit,
         initConnectivity<InitSparseConnectivitySnippet::OneToOne>());

--- a/tests/features/var_init/model.cc
+++ b/tests/features/var_init/model.cc
@@ -127,7 +127,7 @@ void modelDefinition(ModelSpec &model)
         initVar<InitVarSnippet::Gamma>(gammaParams));
     
     // Neuron populations
-    model.addNeuronPopulation<NeuronModels::SpikeSource>("SpikeSource", 1, {}, {});
+    model.addNeuronPopulation<NeuronModels::SpikeSource>("SpikeSource", 10000, {}, {});
     model.addNeuronPopulation<Neuron>("Pop", 10000, {}, neuronInit);
     model.addCurrentSource<CurrentSrc>("CurrSource", "Pop", {}, currentSourceInit);
 
@@ -143,7 +143,8 @@ void modelDefinition(ModelSpec &model)
         "Sparse", SynapseMatrixType::SPARSE_INDIVIDUALG, NO_DELAY,
         "SpikeSource", "Pop",
         {}, weightUpdateInit, weightUpdatePreInit, weightUpdatePostInit,
-        {}, postsynapticInit);
+        {}, postsynapticInit,
+        initConnectivity<InitSparseConnectivitySnippet::OneToOne>());
 
     model.setPrecision(GENN_FLOAT);
 }

--- a/tests/features/var_init/test.cc
+++ b/tests/features/var_init/test.cc
@@ -70,13 +70,12 @@ TEST_F(SimTest, Vars)
     pullSparseStateFromDevice();
 
     // Test host-generated vars
-    PROB_TEST(, Pop, 10000)
-    PROB_TEST(, CurrSource, 10000)
-    PROB_TEST(p, Dense, 10000)
-    // **NOTE** dense actually contains 10000 * 10000 entries but that slows down test too much
-    PROB_TEST(, Dense, 10000)
-    PROB_TEST(pre_, Dense, 10000)
-    PROB_TEST(post_, Dense, 10000)
-    PROB_TEST(, Sparse, 10000)
+    PROB_TEST(, Pop, 20000)
+    PROB_TEST(, CurrSource, 20000)
+    PROB_TEST(p, Dense, 20000)
+    PROB_TEST(, Dense, 20000)
+    PROB_TEST(, Sparse, 20000)
+    PROB_TEST(pre_, Sparse, 20000)
+    PROB_TEST(post_, Sparse, 20000)
 }
 

--- a/tests/features/var_init/test.cc
+++ b/tests/features/var_init/test.cc
@@ -42,18 +42,6 @@ double gammaCDF4(double x)
 //----------------------------------------------------------------------------
 class SimTest : public SimulationTest
 {
-public:
-    //----------------------------------------------------------------------------
-    // SimulationTest virtuals
-    //----------------------------------------------------------------------------
-    virtual void Init()
-    {
-        // Build sparse connectors
-        rowLengthSparse[0] = 10000;
-        for(unsigned int i = 0; i < 10000; i++) {
-            indSparse[i] = i;
-        }
-    }
 };
 
 template<typename F>
@@ -85,6 +73,7 @@ TEST_F(SimTest, Vars)
     PROB_TEST(, Pop, 10000)
     PROB_TEST(, CurrSource, 10000)
     PROB_TEST(p, Dense, 10000)
+    // **NOTE** dense actually contains 10000 * 10000 entries but that slows down test too much
     PROB_TEST(, Dense, 10000)
     PROB_TEST(pre_, Dense, 10000)
     PROB_TEST(post_, Dense, 10000)

--- a/tests/features/var_init/test.cc
+++ b/tests/features/var_init/test.cc
@@ -86,6 +86,8 @@ TEST_F(SimTest, Vars)
     PROB_TEST(, CurrSource, 10000)
     PROB_TEST(p, Dense, 10000)
     PROB_TEST(, Dense, 10000)
+    PROB_TEST(pre_, Dense, 10000)
+    PROB_TEST(post_, Dense, 10000)
     PROB_TEST(, Sparse, 10000)
 }
 

--- a/tests/features/var_init/var_init.vcxproj
+++ b/tests/features/var_init/var_init.vcxproj
@@ -47,6 +47,7 @@
       <IntrinsicFunctions Condition="'$(Configuration)'=='Release'">true</IntrinsicFunctions>
       <SDLCheck>true</SDLCheck>
       <AdditionalIncludeDirectories>var_init_CODE;$(GTEST_DIR);$(GTEST_DIR)/include</AdditionalIncludeDirectories>
+      <PreprocessorDefinitions>_SILENCE_TR1_NAMESPACE_DEPRECATION_WARNING;_MBCS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
     </ClCompile>
     <Link>
       <GenerateDebugInformation>true</GenerateDebugInformation>


### PR DESCRIPTION
In the process of implementing extra global parameters for variable initialization, I thought I'd update the variable initialisation feature test so it tests pre and postsynaptic weight update model variable initialisation. Clearly this was a good idea as they failed! This was the result of several bugs of various ages:
- When merging and code generating the neuron _update_ kernel (where pre and postsynaptic weight update model variables are updated) we only consider synapse groups where there is some update code (which is correct). **However** we were also doing this for the neuron _initialisation_ kernel (where pre and postsynaptic weight update model variables are initialised). _This_ is not correct as it's perfectly valid to use pre and postsynaptic weight update model variables for per-neuron synapse parameters in which case there may not be any update code.
- The initialisers for pre and postsynaptic weight update model variables were not searched for references to an RNG when determining whether a neuron group requires an initialisation RNG

Fixing most of this was pretty trivial but the merging part involved splitting up and moving some code around the ``GroupMerged`` classes.