### PR TITLE
Fixed issue with PyGeNN and custom var init snippets

### DIFF
--- a/pygenn/genn_model.py
+++ b/pygenn/genn_model.py
@@ -692,6 +692,13 @@ def init_var(init_var_snippet, param_space):
         prepare_snippet(init_var_snippet, param_space,
                         genn_wrapper.InitVarSnippet)
 
+    # **YUCK** VarInit (and GeNN) assume that the snippet will live forever but
+    # as far as Python is concerned, s_instance is never used again so it will be
+    # destroyed. Disowning it here hands over it's ownership to C++
+    # **NOTE** this isn't the case with models as references to neuron and synapse
+    # models are kept within NeuronGroup and SynapseGroup objects
+    s_instance.__disown__()
+
     # Use add function to create suitable VarInit
     return VarInit(s_instance, params)
 


### PR DESCRIPTION
This was the nastiest bug I've encountered in a while - good job @chanokin!

Crashes were occurring in PyNN GeNN when we created var initialisers using custom var init snippets using this code:
```python
# Prepare snippet
(s_instance, s_type, param_names, params) = \
    prepare_snippet(init_var_snippet, param_space,
                    genn_wrapper.InitVarSnippet)

# Use add function to create suitable VarInit
return VarInit(s_instance, params)
```

``s_instance`` is a wrapper around an underlying C++ object which manages it's construction and destruction using the Python garbage collector. But the garbage collector knows nothing about what goes on inside the ``VarInit`` constructor as it's another C++ object so, unless something else is holding a reference to it, it will be deleted. The solution is to add a magic SWIG call to disown the object. Hand-crafted PyGeNN code typically constructs custom models somewhere at global scope so we didn't notice this before but @chanokin 's PyNN code was creating them at runtime causing this horror to emerge. 

@jamesturner246 - you may also hit this so update GeNN!