### PR TITLE
Another nasty Python corner case

### DIFF
--- a/pygenn/genn_groups.py
+++ b/pygenn/genn_groups.py
@@ -7,6 +7,7 @@ try:
 except NameError:  # Python 3
     xrange = range
 
+from weakref import proxy
 from deprecated import deprecated
 from six import iteritems
 import numpy as np
@@ -32,7 +33,7 @@ class Group(object):
         name    --  string name of the Group
         """
         self.name = name
-        self._model = model
+        self._model = proxy(model)
         self.vars = {}
         self.extra_global_params = {}
 
@@ -392,7 +393,7 @@ class SynapseGroup(Group):
         self.connectivity_extra_global_params = {}
         self.connectivity_initialiser = None
         self.weight_sharing_master = weight_sharing_master
-    
+
     @property
     def num_synapses(self):
         """Number of synapses in group"""
@@ -957,7 +958,7 @@ class CurrentSource(Group):
 
         # Load current source extra global parameters
         self._load_egp()
-    
+
     def load_init_egps(self):
         # Load any egps used for variable initialisation
         self._load_var_init_egps()

--- a/pygenn/genn_model.py
+++ b/pygenn/genn_model.py
@@ -486,7 +486,7 @@ class GeNNModel(object):
         if self._loaded:
             raise Exception("GeNN model already loaded")
         self._path_to_model = path_to_model
-        
+
         self._slm.open(self._path_to_model, self.model_name)
 
         self._slm.allocate_mem()
@@ -495,7 +495,7 @@ class GeNNModel(object):
         # extra global parameters required for initialization
         for pop_data in itervalues(self.neuron_populations):
             pop_data.load_init_egps()
-            
+
         # Loop through synapse populations and load any 
         # extra global parameters required for initialization
         for pop_data in itervalues(self.synapse_populations):
@@ -504,7 +504,7 @@ class GeNNModel(object):
         # Loop through current sources
         for src_data in itervalues(self.current_sources):
             src_data.load_init_egps()
-    
+
         # Initialize model
         self._slm.initialize()
 
@@ -651,7 +651,7 @@ class GeNNModel(object):
                     if egp_dat.needsAllocation:
                         self._slm.free_extra_global_param(g_name, egp_name)
         # "normal" variables are freed when SharedLibraryModel is destoyed
-    
+
     def _validate_neuron_group(self, group, context):
         # If group is a string
         if isinstance(group, string_types):
@@ -668,7 +668,7 @@ class GeNNModel(object):
         # Otherwise, raise error
         else:
             raise ValueError("'%s' must be a NeuronGroup or string" % context)
-    
+
     def _validate_synapse_group(self, group, context):
         # If group is a string
         if isinstance(group, string_types):

--- a/pygenn/model_preprocessor.py
+++ b/pygenn/model_preprocessor.py
@@ -4,6 +4,7 @@ and defines class Variable
 """
 from collections import namedtuple
 from numbers import Number
+from weakref import proxy
 import numpy as np
 from six import iterkeys, itervalues
 from . import genn_wrapper
@@ -244,7 +245,7 @@ class Variable(object):
         """
         self.name = variable_name
         self.type = variable_type
-        self.group = group
+        self.group = proxy(group)
         self.extra_global_params = {}
         self.view = None
         self.needs_allocation = False


### PR DESCRIPTION
Another omission in my Python knowedge came to light when trying to figure out why PyNN GeNN tests were failing. Basically, my recent addition of cross-references to some classes resulted in a structure resembling:

```python
class A(object):
    def __init__(self, parent):
        print("Creating A")
        self.parent = parent

    def __del__(self):
        print("Destroying A")

class B(object):
    def __init__(self):
        self.children = []
        print("Creating B")

    def __del__(self):
        print("Destroying B")

b = B()
b.children.append(A(b))
b.children.append(A(b))
b = None
```
Which, suprisingly (at least to me as a C++ programmer), does not result in any objects being destroyed. This is because, unlike e.g. Java, Python doesn't automatically run a 'proper' garbage collector and relies with simple refernce counting which can't deal with such loops. The solution is to redefine A as:

```python
from weakref import proxy

class A(object):
    def __init__(self, parent):
        print("Creating A")
        self.parent = proxy(parent)

    def __del__(self):
        print("Destroying A")
```

Which I have done where required in PyGeNN.