### PR TITLE
Correctly simulate models with very small timesteps

### DIFF
--- a/src/genn/genn/code_generator/generateRunner.cc
+++ b/src/genn/genn/code_generator/generateRunner.cc
@@ -443,9 +443,9 @@ MemAlloc CodeGenerator::generateRunner(CodeStream &definitions, CodeStream &defi
     // write DT macro
     const ModelSpecInternal &model = modelMerged.getModel();
     if (model.getTimePrecision() == "float") {
-        definitions << "#define DT " << std::to_string(model.getDT()) << "f" << std::endl;
+        definitions << "#define DT " << Utils::writePreciseString(model.getDT()) << "f" << std::endl;
     } else {
-        definitions << "#define DT " << std::to_string(model.getDT()) << std::endl;
+        definitions << "#define DT " << Utils::writePreciseString(model.getDT()) << std::endl;
     }
 
     // Typedefine scalar type


### PR DESCRIPTION
The ``DT`` macro was previously being written out using standard iostreams formatting which typically only writes out a small number of decimal places. If you used a very small timestep e.g. ``1.0000000000000001e-11`` (!) this was written out as zero.