### PR TITLE
Fix for bug in logic for merging synapse groups with procedural variables

### DIFF
--- a/src/genn/genn/synapseGroup.cc
+++ b/src/genn/genn/synapseGroup.cc
@@ -564,6 +564,15 @@ bool SynapseGroup::canWUBeMerged(const SynapseGroup &other) const
        && (getTrgNeuronGroup()->getNumDelaySlots() == other.getTrgNeuronGroup()->getNumDelaySlots())
        && (getMatrixType() == other.getMatrixType()))
     {
+        // If weights are procedural and any of the variable's initialisers can't be merged, return false
+        if(getMatrixType() & SynapseMatrixWeight::PROCEDURAL) {
+            for(size_t i = 0; i < getWUVarInitialisers().size(); i++) {
+                if(!getWUVarInitialisers()[i].canBeMerged(other.getWUVarInitialisers()[i])) {
+                    return false;
+                }
+            }
+        }
+
         // If connectivity is either non-procedural or connectivity initialisers can be merged
         if(!(getMatrixType() & SynapseMatrixConnectivity::PROCEDURAL)
            || getConnectivityInitialiser().canBeMerged(other.getConnectivityInitialiser()))


### PR DESCRIPTION
@jamesturner246 found this when building a model with ``DENSE_PROCEDURALG`` synapse groups with different variable initialisation snippets on each one.

The symptom was that a ``std::out_of_range`` exception was thrown [here](https://github.com/genn-team/genn/blob/procedural_weight_merge_bug/src/genn/genn/code_generator/generateRunner.cc#L266) because the data structures required to hook up extra global parameters for one of the groups was missing. This turned out to be because I had never checked whether two synapse group's procedural variable initialisation code could be merged in ``SynapseGroup::canWUBeMerged``.

This code had mostly been used with models like the microcircuit where all variables are drawn from normal distributions (albeit with different parameters) so it was totally fine to merge them all together hence the fact this hadn't been found until now. In a bad case of selection bias, the unit tests also only tested this scenario - in this PR I have added these checks and a new unit test.