### PR TITLE
Fix bug in merging logic for detecting which parameters are 'heterogeneus'

### DIFF
--- a/include/genn/genn/code_generator/groupMerged.h
+++ b/include/genn/genn/code_generator/groupMerged.h
@@ -74,7 +74,7 @@ protected:
 
     //! Helper to test whether parameter values are heterogeneous within merged group
     template<typename P>
-    bool isParamValueHeterogeneous(std::initializer_list<std::string> codeStrings, const std::string &paramName,
+    bool isParamValueHeterogeneous(const std::vector<std::string> &codeStrings, const std::string &paramName,
                                    size_t index, P getParamValuesFn) const
     {
         // If none of the code strings reference the parameter, return false
@@ -226,7 +226,7 @@ protected:
 
 
     template<typename T, typename G>
-    bool isChildParamValueHeterogeneous(std::initializer_list<std::string> codeStrings,
+    bool isChildParamValueHeterogeneous(const std::vector<std::string> &codeStrings,
                                         const std::string &paramName, size_t childIndex, size_t paramIndex,
                                         const std::vector<std::vector<T>> &sortedGroupChildren, G getParamValuesFn) const
     {

--- a/src/genn/genn/code_generator/groupMerged.cc
+++ b/src/genn/genn/code_generator/groupMerged.cc
@@ -868,16 +868,30 @@ bool CodeGenerator::SynapseConnectivityHostInitGroupMerged::isConnectivityInitDe
 bool CodeGenerator::SynapseConnectivityInitGroupMerged::isConnectivityInitParamHeterogeneous(size_t paramIndex) const
 {
     const auto *connectivityInitSnippet = getArchetype().getConnectivityInitialiser().getSnippet();
+    const auto rowBuildStateVars = connectivityInitSnippet->getRowBuildStateVars();
+    
+    // Build list of code strings containing row build code and any row build state variable values
+    std::vector<std::string> codeStrings{connectivityInitSnippet->getRowBuildCode()};
+    std::transform(rowBuildStateVars.cbegin(), rowBuildStateVars.cend(), std::back_inserter(codeStrings),
+                   [](const Snippet::Base::ParamVal &p) { return p.value; });
+    
     const std::string paramName = connectivityInitSnippet->getParamNames().at(paramIndex);
-    return isParamValueHeterogeneous({connectivityInitSnippet->getRowBuildCode()}, paramName, paramIndex,
+    return isParamValueHeterogeneous(codeStrings, paramName, paramIndex,
                                      [](const SynapseGroupInternal &sg) { return sg.getConnectivityInitialiser().getParams(); });
 }
 //----------------------------------------------------------------------------
 bool CodeGenerator::SynapseConnectivityInitGroupMerged::isConnectivityInitDerivedParamHeterogeneous(size_t paramIndex) const
 {
     const auto *connectivityInitSnippet = getArchetype().getConnectivityInitialiser().getSnippet();
+    const auto rowBuildStateVars = connectivityInitSnippet->getRowBuildStateVars();
+
+    // Build list of code strings containing row build code and any row build state variable values
+    std::vector<std::string> codeStrings{connectivityInitSnippet->getRowBuildCode()};
+    std::transform(rowBuildStateVars.cbegin(), rowBuildStateVars.cend(), std::back_inserter(codeStrings),
+                   [](const Snippet::Base::ParamVal &p) { return p.value; });
+
     const std::string derivedParamName = connectivityInitSnippet->getDerivedParams().at(paramIndex).name;
-    return isParamValueHeterogeneous({connectivityInitSnippet->getRowBuildCode()}, derivedParamName, paramIndex,
+    return isParamValueHeterogeneous(codeStrings, derivedParamName, paramIndex,
                                      [](const SynapseGroupInternal &sg) { return sg.getConnectivityInitialiser().getDerivedParams(); });
 }
 //------------------------------------------------------------------------
@@ -1025,16 +1039,30 @@ bool CodeGenerator::SynapseGroupMergedBase::isWUVarInitDerivedParamHeterogeneous
 bool CodeGenerator::SynapseGroupMergedBase::isConnectivityInitParamHeterogeneous(size_t paramIndex) const
 {
     const auto *connectivityInitSnippet = getArchetype().getConnectivityInitialiser().getSnippet();
+    const auto rowBuildStateVars = connectivityInitSnippet->getRowBuildStateVars();
+
+    // Build list of code strings containing row build code and any row build state variable values
+    std::vector<std::string> codeStrings{connectivityInitSnippet->getRowBuildCode()};
+    std::transform(rowBuildStateVars.cbegin(), rowBuildStateVars.cend(), std::back_inserter(codeStrings),
+                   [](const Snippet::Base::ParamVal &p) { return p.value; });
+
     const std::string paramName = connectivityInitSnippet->getParamNames().at(paramIndex);
-    return isParamValueHeterogeneous({connectivityInitSnippet->getRowBuildCode()}, paramName, paramIndex,
+    return isParamValueHeterogeneous(codeStrings, paramName, paramIndex,
                                      [](const SynapseGroupInternal &sg) { return sg.getConnectivityInitialiser().getParams(); });
 }
 //----------------------------------------------------------------------------
 bool CodeGenerator::SynapseGroupMergedBase::isConnectivityInitDerivedParamHeterogeneous(size_t paramIndex) const
 {
     const auto *connectivityInitSnippet = getArchetype().getConnectivityInitialiser().getSnippet();
+    const auto rowBuildStateVars = connectivityInitSnippet->getRowBuildStateVars();
+
+    // Build list of code strings containing row build code and any row build state variable values
+    std::vector<std::string> codeStrings{connectivityInitSnippet->getRowBuildCode()};
+    std::transform(rowBuildStateVars.cbegin(), rowBuildStateVars.cend(), std::back_inserter(codeStrings),
+                   [](const Snippet::Base::ParamVal &p) { return p.value; });
+
     const std::string derivedParamName = connectivityInitSnippet->getDerivedParams().at(paramIndex).name;
-    return isParamValueHeterogeneous({connectivityInitSnippet->getRowBuildCode()}, derivedParamName, paramIndex,
+    return isParamValueHeterogeneous(codeStrings, derivedParamName, paramIndex,
                                      [](const SynapseGroupInternal &sg) { return sg.getConnectivityInitialiser().getDerivedParams(); });
 }
 //----------------------------------------------------------------------------


### PR DESCRIPTION
In #316 I added the concept of "heterogeneous parameters" which is an internal thing where, if parameter values change between members of a merged group, their values get stuck in the merged group structure rather than being hard-coded. However, with synapse groups, where there's lots of code strings that get used in various contexts we don't just want to fill the struct (and hence the precious constant cache) with values of parameters that aren't refered to e.g. those that are only used to initialise a derived parameter. Therefore in the multitude of ``GroupMergedXXX::isYYYParamHeterogeneous`` methods we search the relevant code strings to check if there's actually any references to a parameter before adding it to a structure. However, in #298, we added an extra place parameters could be referenced to in sparse connectivity initialisation snippets - in the initialisers for row build state variables. e.g. in ``FixedNumberPostWithReplacement``:

```c++
SET_ROW_BUILD_CODE(
    "if(c == 0) {\n"
    "   $(endRow);\n"
    "}\n"
    "const scalar u = $(gennrand_uniform);\n"
    "x += (1.0 - x) * (1.0 - pow(u, 1.0 / (scalar)c));\n"
    "unsigned int postIdx = (unsigned int)(x * $(num_post));\n"
    "postIdx = (postIdx < $(num_post)) ? postIdx : ($(num_post) - 1);\n"
    "$(addSynapse, postIdx + $(id_post_begin));\n"
    "c--;\n");
SET_ROW_BUILD_STATE_VARS({{"x", "scalar", 0.0},{"c", "unsigned int", "$(rowLength)"}});
```

Turns out that these code strings _weren't_ being checked so some initialisation snippets ended up with a somewhat arbitrary hard-coded values - I was either lucky or unlucky depending on how you look at it and this led to simulations with mysteriously lower activity compared to NEST 😄 

This P.R. includes these strings in appropriate tests and adds additional unit tests.