### PR TITLE
Applied previous fix to connectivity initialisation snippets

### DIFF
--- a/pygenn/genn_model.py
+++ b/pygenn/genn_model.py
@@ -729,6 +729,13 @@ def init_connectivity(init_sparse_connect_snippet, param_space):
         prepare_snippet(init_sparse_connect_snippet, param_space,
                         genn_wrapper.InitSparseConnectivitySnippet)
 
+    # **YUCK** VarInit (and GeNN) assume that the snippet will live forever but
+    # as far as Python is concerned, s_instance is never used again so it will be
+    # destroyed. Disowning it here hands over it's ownership to C++
+    # **NOTE** this isn't the case with models as references to neuron and synapse
+    # models are kept within NeuronGroup and SynapseGroup objects
+    s_instance.__disown__()
+
     # Use add function to create suitable VarInit
     return Init(s_instance, params)
 


### PR DESCRIPTION
For reasons that aren't entirely clear I didn't apply the fix for the [nasty bug with variable initialisation snippets ](https://github.com/genn-team/genn/pull/331) to connectivity but I didn't! This does just that.