### PR TITLE
PyGeNN time precision

### DIFF
--- a/pygenn/genn_groups.py
+++ b/pygenn/genn_groups.py
@@ -13,7 +13,7 @@ from six import iteritems
 import numpy as np
 from . import genn_wrapper
 from . import model_preprocessor
-from .model_preprocessor import ExtraGlobalVariable, Variable, genn_types
+from .model_preprocessor import ExtraGlobalVariable, Variable
 from .genn_wrapper import (SynapseMatrixConnectivity_SPARSE,
                            SynapseMatrixConnectivity_BITMASK,
                            SynapseMatrixConnectivity_DENSE,
@@ -109,7 +109,7 @@ class Group(object):
 
         assert param_type is not None
         egp_dict[param_name] = ExtraGlobalVariable(param_name, param_type,
-                                                   param_values)
+                                                   param_values, self)
 
     def _assign_ext_ptr_array(self, var_name, var_size, var_type):
         """Assign a variable to an external numpy array
@@ -133,9 +133,8 @@ class Group(object):
         if var_type == "scalar":
             var_type = self._model._scalar
 
-        return genn_types[var_type].assign_ext_ptr_array(self._model._slm,
-                                                         internal_var_name,
-                                                         var_size)
+        return self._model.genn_types[var_type].assign_ext_ptr_array(
+            internal_var_name, var_size)
 
     def _assign_ext_ptr_single(self, var_name, var_type):
         """Assign a variable to an external scalar value containing one element
@@ -158,8 +157,8 @@ class Group(object):
         if var_type == "scalar":
             var_type = self._model._scalar
 
-        return genn_types[var_type].assign_ext_ptr_single(self._model._slm,
-                                                          internal_var_name)
+        return self._model.genn_types[var_type].assign_ext_ptr_single(
+            internal_var_name)
 
     def _load_vars(self, size=None, var_dict=None, get_location_fn=None):
         # If no size is specified, use standard size

--- a/pygenn/genn_groups.py
+++ b/pygenn/genn_groups.py
@@ -109,7 +109,7 @@ class Group(object):
 
         assert param_type is not None
         egp_dict[param_name] = ExtraGlobalVariable(param_name, param_type,
-                                                   param_values, self)
+                                                   self, param_values)
 
     def _assign_ext_ptr_array(self, var_name, var_size, var_type):
         """Assign a variable to an external numpy array

--- a/pygenn/model_preprocessor.py
+++ b/pygenn/model_preprocessor.py
@@ -2,37 +2,13 @@
 This module provides functions for model validation, parameter type conversions
 and defines class Variable
 """
-from collections import namedtuple
 from numbers import Number
 from weakref import proxy
 import numpy as np
 from six import iterkeys, itervalues
 from . import genn_wrapper
-from .genn_wrapper.SharedLibraryModelNumpy import SharedLibraryModelNumpy_f as slm
 from .genn_wrapper.Models import VarInit, VarInitVector
 from .genn_wrapper.StlContainers import DoubleVector
-
-GeNNType = namedtuple("GeNNType", ["np_dtype", "assign_ext_ptr_array", "assign_ext_ptr_single"])
-
-"""Dictionary containing conversions between GeNN C++ types and numpy types"""
-genn_types = {
-    "scalar":           GeNNType(np.float32, slm.assign_external_pointer_array_f, slm.assign_external_pointer_single_f),
-    "float":            GeNNType(np.float32, slm.assign_external_pointer_array_f, slm.assign_external_pointer_single_f),
-    "double":           GeNNType(np.float64, slm.assign_external_pointer_array_d, slm.assign_external_pointer_single_d),
-    "int":              GeNNType(np.int32, slm.assign_external_pointer_array_i, slm.assign_external_pointer_single_i),
-    "unsigned int":     GeNNType(np.uint32, slm.assign_external_pointer_array_ui, slm.assign_external_pointer_single_ui),
-    "short":            GeNNType(np.int16, slm.assign_external_pointer_array_s, slm.assign_external_pointer_single_s),
-    "unsigned short":   GeNNType(np.uint16, slm.assign_external_pointer_array_us, slm.assign_external_pointer_single_us),
-    "char":             GeNNType(np.int8, slm.assign_external_pointer_array_sc, slm.assign_external_pointer_single_sc),
-    "unsigned char":    GeNNType(np.uint8, slm.assign_external_pointer_array_uc, slm.assign_external_pointer_single_uc),
-    "uint64_t":         GeNNType(np.uint64, None, None),
-    "int64_t":          GeNNType(np.int64, None, None),
-    "uint32_t":         GeNNType(np.uint32, slm.assign_external_pointer_array_ui, slm.assign_external_pointer_single_ui),
-    "int32_t":          GeNNType(np.int32, slm.assign_external_pointer_array_i, slm.assign_external_pointer_single_i),
-    "uint16_t":         GeNNType(np.uint16, slm.assign_external_pointer_array_us, slm.assign_external_pointer_single_us),
-    "int16_t":          GeNNType(np.int16, slm.assign_external_pointer_array_s, slm.assign_external_pointer_single_s),
-    "uint8_t":          GeNNType(np.uint8, slm.assign_external_pointer_array_uc, slm.assign_external_pointer_single_uc),
-    "int8_t":           GeNNType(np.int8, slm.assign_external_pointer_array_sc, slm.assign_external_pointer_single_sc)}
 
 def prepare_model(model, group, param_space, var_space, pre_var_space=None,
                   post_var_space=None, model_family=None):
@@ -286,7 +262,8 @@ class Variable(object):
             try:
                 iter(values)
                 self.init_val = genn_wrapper.uninitialised_var()
-                self.values = np.asarray(values, dtype=genn_types[self.type].np_dtype)
+                self.values = np.asarray(
+                    values, dtype=self.group._model.genn_types[self.type].np_dtype)
                 self.init_required = True
             # Otherwise - they can be initialised on device as a scalar
             except TypeError:
@@ -296,7 +273,7 @@ class ExtraGlobalVariable(object):
 
     """Class holding information about GeNN extra global pointer variable"""
 
-    def __init__(self, variable_name, variable_type, values=None):
+    def __init__(self, variable_name, variable_type, group, values=None):
         """Init Variable
 
         Args:
@@ -312,7 +289,8 @@ class ExtraGlobalVariable(object):
         else:
             self.is_scalar = True
             self.type = variable_type
-
+        
+        self.group = proxy(group)
         self.name = variable_name
         self.view = None
         self.set_values(values)
@@ -333,7 +311,8 @@ class ExtraGlobalVariable(object):
             # Try and iterate values
             try:
                 iter(values)
-                self.values = np.asarray(values, dtype=genn_types[self.type].np_dtype)
+                self.values = np.asarray(
+                    values, dtype=self.group._model.genn_types[self.type].np_dtype)
             # Otherwise give an error
             except TypeError:
                 raise ValueError("extra global variables can only be "


### PR DESCRIPTION
By default GeNN represents time using the standard "scalar" type which is often 32-bit float. However, as this demonstrates:

```python
import numpy as np
d = np.asarray([2260350.0],dtype=np.float32)
print(d[0])
d[0]+=0.1
print(d[0])
```

Float stops being able to represent the timestep and the current time in long simulations. GeNN has supported seperate time precision since #207 but it's never made its way into PyGeNN. When you create a ``GeNNModel`` you can now control the time precision like this:

```python
model = genn_model.GeNNModel("float", "va_benchmark", time_precision="double")
```
A quick review and test this doesn't break PyNN or TensorGeNN is exciting ways would be much appreciated!

Additionally, this also goes some way to helping with #289 but more testing is required.
