### PR TITLE
Fix for old CUDA versions and impove warning suppression

### DIFF
--- a/src/genn/backends/cuda/backend.cc
+++ b/src/genn/backends/cuda/backend.cc
@@ -2040,7 +2040,13 @@ std::string Backend::getNVCCFlags() const
 #ifdef _WIN32
     nvccFlags += " -Xcudafe \"--diag_suppress=2961\"";
 #else
-    nvccFlags += " -Xcudafe \"--diag_suppress=2937\" -std=c++11 --compiler-options \"-fPIC -Wno-return-type-c-linkage\"";
+    nvccFlags += " -std=c++11 --compiler-options \"-fPIC -Wno-return-type-c-linkage\"";
+
+    // If runtime is new enough, hide forementioned warnings. On CUDA 7.5 and 8.0 this causes a fatal error
+    // and, as no warnings are shown, presumably this is because this warning simply isn't implemented until CUDA 9
+    if(m_RuntimeVersion >= 9000) {
+        nvccFlags += " -Xcudafe \"--diag_suppress=2937\"";
+    }
 #endif
 
     nvccFlags += " " + m_Preferences.userNvccFlags;

--- a/src/genn/backends/cuda/backend.cc
+++ b/src/genn/backends/cuda/backend.cc
@@ -2039,16 +2039,12 @@ std::string Backend::getNVCCFlags() const
     // presumably this is because this warning simply wasn't implemented until CUDA 9
     const std::string architecture = "sm_" + std::to_string(getChosenCUDADevice().major) + std::to_string(getChosenCUDADevice().minor);
     std::string nvccFlags = "-x cu -arch " + architecture;
-#ifdef _WIN32
-    if(m_RuntimeVersion >= 9000) {
-        nvccFlags += " -Xcudafe \"--diag_suppress=2961\"";
-    }
-#else
+#ifndef _WIN32
     nvccFlags += " -std=c++11 --compiler-options \"-fPIC -Wno-return-type-c-linkage\"";
-    if(m_RuntimeVersion >= 9000) {
-        nvccFlags += " -Xcudafe \"--diag_suppress=2937\"";
-    }
 #endif
+    if(m_RuntimeVersion >= 9000) {
+        nvccFlags += " -Xcudafe \"--diag_suppress=extern_entity_treated_as_static\"";
+    }
 
     nvccFlags += " " + m_Preferences.userNvccFlags;
     if(m_Preferences.optimizeCode) {

--- a/src/genn/backends/cuda/backend.cc
+++ b/src/genn/backends/cuda/backend.cc
@@ -2035,15 +2035,16 @@ std::string Backend::getNVCCFlags() const
     // **NOTE** now we don't include runner.cc when building standalone modules we get loads of warnings about
     // How you hide device compiler warnings is totally non-documented but https://stackoverflow.com/a/17095910/1476754
     // holds the answer! For future reference --display_error_number option can be used to get warning ids to use in --diag-supress
+    // HOWEVER, on CUDA 7.5 and 8.0 this causes a fatal error and, as no warnings are shown when --diag-suppress is removed,
+    // presumably this is because this warning simply wasn't implemented until CUDA 9
     const std::string architecture = "sm_" + std::to_string(getChosenCUDADevice().major) + std::to_string(getChosenCUDADevice().minor);
     std::string nvccFlags = "-x cu -arch " + architecture;
 #ifdef _WIN32
-    nvccFlags += " -Xcudafe \"--diag_suppress=2961\"";
+    if(m_RuntimeVersion >= 9000) {
+        nvccFlags += " -Xcudafe \"--diag_suppress=2961\"";
+    }
 #else
     nvccFlags += " -std=c++11 --compiler-options \"-fPIC -Wno-return-type-c-linkage\"";
-
-    // If runtime is new enough, hide forementioned warnings. On CUDA 7.5 and 8.0 this causes a fatal error
-    // and, as no warnings are shown, presumably this is because this warning simply isn't implemented until CUDA 9
     if(m_RuntimeVersion >= 9000) {
         nvccFlags += " -Xcudafe \"--diag_suppress=2937\"";
     }


### PR DESCRIPTION
Slightly embarassingly, this came to light when @agarwalmanvi was trying to show her supervisor GeNN. 

Nonetheless, the undocumented nvcc option I was using to hide annoying warnings when optimizing block sizes aren't implemented in CUDA 7.5 or 8 and cause nvcc to keel over with a fatal warning. This change only tries to hide these warnings on CUDA 9 and later. Also, after realising the magic numbers I was using to repress these warnings changed not only between platforms but between minor CUDA versions and are thus entirely unmaintainable, I figured out the string equivalent by dissambling the ``cudafe`` executable and grepping at the strings section.

Also, after testing this on the K40 still somehow hanging in on apollo, I can confirm that GeNN still works with GCC 4.9.4 and CUDA 7.5 😄 