### PR TITLE
Replaced __linux macro in path library

### DIFF
--- a/include/genn/third_party/path.h
+++ b/include/genn/third_party/path.h
@@ -25,7 +25,7 @@
 #endif
 #include <sys/stat.h>
 
-#if defined(__linux)
+#if defined(__linux__)
 # include <linux/limits.h>
 #endif
 


### PR DESCRIPTION
https://sourceforge.net/p/predef/wiki/OperatingSystems/ suggests it's deprecated but it has never been an issue apart from on a POWER9 machine. Nonethless, replacing it with the more standard ``__linux__`` solves the problem.
