### PR TITLE
Correct calculation of neuronIDs in writeTextSpikeRecording

### DIFF
--- a/userproject/include/spikeRecorder.h
+++ b/userproject/include/spikeRecorder.h
@@ -270,6 +270,9 @@ inline void writeTextSpikeRecording(const std::string &filename, const uint32_t 
                 
                 // Write out CSV line
                 stream << time << delimiter << neuronID << std::endl;
+                
+                // New neuron id of the highest bit of this word
+                neuronID--;
             }
         }
     }


### PR DESCRIPTION
Hi, 

for the read-out of the spike data using the new efficient spike recording I had a look at the writeTextSpikeRecording in spikeRecorder.h and found a bug: in line 257 the highest possible neuronID is calculated, while it is decremented only if there are leading zeros (not spiking neurons). Thus, the neuronID needs to be decremented at the end of the while loop, as this decremented value is the new "highest possible".  Below is some code to reproduce the issue (provided by @neworderofjamie  :D ).

```c++
// Example program
#include <iostream>
#include <string>
#include <cstdint>

int main()
{
    unsigned int neuronID = 31;
    uint32_t spikeWord = 0x0;
    spikeWord |= (1 << 12);
    spikeWord |= (1 << 10);
    spikeWord |= (1 << 8);
    
    // While bits remain
    while(spikeWord != 0) {
        // Calculate leading zeros
        const int numLZ = __builtin_clz(spikeWord);
        
        // If all bits have now been processed, zero spike word
        // Otherwise shift past the spike we have found
        spikeWord = (numLZ == 31) ? 0 : (spikeWord << (numLZ + 1));
        
        // Subtract number of leading zeros from neuron ID
        neuronID -= numLZ;             // <--- Only decremented if numLZ > 0
        
        // Write out CSV line
        std::cout << neuronID << std::endl;
        //neuronID--;                          // <--- Fixes the issue
    }
}
```

Target output:   12 10 8
Current output: 12 11 10