### PR TITLE
Added access to $(num_pre) in row_build_code  ...

### DIFF
--- a/src/genn/backends/single_threaded_cpu/backend.cc
+++ b/src/genn/backends/single_threaded_cpu/backend.cc
@@ -594,6 +594,7 @@ void Backend::genInit(CodeStream &os, const ModelSpecMerged &modelMerged, Memory
                     popSubs.addVarSubstitution("id_post_begin", "0");
                     popSubs.addVarSubstitution("id_thread", "0");
                     popSubs.addVarSubstitution("num_threads", "1");
+                    popSubs.addVarSubstitution("num_pre", "group->numSrcNeurons");
                     popSubs.addVarSubstitution("num_post", "group->numTrgNeurons");
                 }
                 // Otherwise
@@ -609,6 +610,7 @@ void Backend::genInit(CodeStream &os, const ModelSpecMerged &modelMerged, Memory
                     popSubs.addVarSubstitution("id_thread", "0");
                     popSubs.addVarSubstitution("num_threads", "1");
                     popSubs.addVarSubstitution("num_pre", "group->numSrcNeurons");
+                    popSubs.addVarSubstitution("num_post", "group->numTrgNeurons");
                 }
                 {
                     CodeStream::Scope b(os);

--- a/src/genn/genn/code_generator/backendSIMT.cc
+++ b/src/genn/genn/code_generator/backendSIMT.cc
@@ -897,6 +897,7 @@ void BackendSIMT::genInitializeKernel(CodeStream &os, const Substitutions &kerne
                 popSubs.addVarSubstitution("id_post_begin", "0");
                 popSubs.addVarSubstitution("id_thread", "0");
                 popSubs.addVarSubstitution("num_threads", "1");
+                popSubs.addVarSubstitution("num_pre", "group->numSrcNeurons");
                 popSubs.addVarSubstitution("num_post", "group->numTrgNeurons");
             }
             // Otherwise
@@ -912,6 +913,7 @@ void BackendSIMT::genInitializeKernel(CodeStream &os, const Substitutions &kerne
                 popSubs.addVarSubstitution("id_thread", "0");
                 popSubs.addVarSubstitution("num_threads", "1");
                 popSubs.addVarSubstitution("num_pre", "group->numSrcNeurons");
+                popSubs.addVarSubstitution("num_post", "group->numTrgNeurons");
             }
             {
                 CodeStream::Scope b(os);

--- a/src/genn/genn/code_generator/presynapticUpdateStrategySIMT.cc
+++ b/src/genn/genn/code_generator/presynapticUpdateStrategySIMT.cc
@@ -555,11 +555,13 @@ void PreSpanProcedural::genUpdate(CodeStream &os, const ModelSpecMerged &modelMe
             connSubs.addVarSubstitution("id_post_begin", "idPostStart");
             connSubs.addVarSubstitution("id_thread", "thread");
             connSubs.addVarSubstitution("num_post", "numPost");
+            connSubs.addVarSubstitution("num_pre", "group->numSrcNeurons");
         }
         else {
             connSubs.addVarSubstitution("id_post_begin", "0");
             connSubs.addVarSubstitution("id_thread", "0");
             connSubs.addVarSubstitution("num_post", "group->numTrgNeurons");
+            connSubs.addVarSubstitution("num_pre", "group->numSrcNeurons");
         }
 
         // Create another substitution stack for generating presynaptic simulation code


### PR DESCRIPTION
… and to $(num_post) in col_build_code.

I found this useful in an application for a specific connectivity. In particular, I was trying to build a simple rectangular matrix where neuron 0 was connected to neuron 0 to n-1 and neuron 1 to neuron n to 2n-1 and so on.
So I tried
```python
 row_build_code=
        """
        const unsigned int row_length= $(num_post)/$(num_pre);
        const unsigned int offset= $(id_pre)*row_length;
        for (unsigned int i= 0; i < row_length; i++) {
            $(addSynapse, (offset + i));
        }
        $(endRow);
        """
```
... but it failed because in row_build_code ```num_pre``` was not translated. I don't see why one would not allow this and how the above code could be done as easily without it, so suggest to do the translation for ```num_pre``` as in this pull request. I hope I have covered all backends. I have tested it on the cuda backend where the above code now works fine in pygenn. 