### PR TITLE
Neuron initialisation merge fix

### DIFF
--- a/src/genn/genn/neuronGroup.cc
+++ b/src/genn/genn/neuronGroup.cc
@@ -483,6 +483,7 @@ bool NeuronGroup::canInitBeMerged(const NeuronGroup &other) const
     if((isSpikeTimeRequired() == other.isSpikeTimeRequired())
        && (isPrevSpikeTimeRequired() == other.isPrevSpikeTimeRequired())
        && (isSpikeEventRequired() == other.isSpikeEventRequired())
+       && (isSimRNGRequired() == other.isSimRNGRequired())
        && (getNumDelaySlots() == other.getNumDelaySlots())
        && (m_VarQueueRequired == other.m_VarQueueRequired)
        && (getNeuronModel()->getVars() == other.getNeuronModel()->getVars()))


### PR DESCRIPTION
When we're determining if the initialisation of neuron groups can be merged together (i.e. done by the same kernel), the main thing we care about is whether the state variables associated with the neuron group (and stuff like postsynaptic models associated with it) can be initialised in the same way. What the neuron simulation code is is generally irrelevant at this point. Therefore, previously, two neuron groups with neuron/postsynaptic models which differ only in that one requires an RNG would get merged. This is bad because, based on their order, either the RNG for the group that needs it wouldn't get seeded or code would be generated to seed a non-existent RNG. 

Anyway, simple fix is to only merge neuron groups where ``isSimRNGRequired() == other.isSimRNGRequired()``

Will add some unit tests around this sort of issue before merging.