### PR TITLE
Ensure PyGeNN never select OpenCL automatically

### DIFF
--- a/pygenn/genn_model.py
+++ b/pygenn/genn_model.py
@@ -67,7 +67,7 @@ from .model_preprocessor import prepare_snippet
 
 # Loop through backends in preferential order
 backend_modules = OrderedDict()
-for b in ["CUDA", "OpenCL", "SingleThreadedCPU"]:
+for b in ["CUDA", "SingleThreadedCPU", "OpenCL"]:
     # Try and import
     try:
         m = import_module(".genn_wrapper." + b + "Backend", "pygenn")


### PR DESCRIPTION
Following my initial concern on your Mac. Assuming the single-threaded CPU backend always gets built, this change effectively means that, for now, you have explicitly create your ``GeNNModel`` with ``backend="OpenCL"`` if you want to try out OpenCL.