### PR TITLE
Build wheels using Python3

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -227,7 +227,7 @@ for(b = 0; b < builderNodes.size(); b++) {
                             ${env.PYTHON} -m venv virtualenv
                             . virtualenv/bin/activate
 
-                            pip install "numpy>=1.17"
+                            pip install wheel "numpy>=1.17"
 
                             python setup.py clean --all
                             python setup.py bdist_wheel -d . 1>> "${uniqueMsg}" 2>> "${uniqueMsg}"
@@ -276,7 +276,7 @@ for(b = 0; b < builderNodes.size(); b++) {
                             call activate
                             popd
 
-                            pip install "numpy>1.6, < 1.15"
+                            pip install wheel "numpy>=1.17"
 
                             copy /Y lib\\genn*Release_DLL.* pygenn\\genn_wrapper
 

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -224,7 +224,7 @@ for(b = 0; b < builderNodes.size(); b++) {
                             echo "Creating Python wheels";
                             script = """
                             rm -rf virtualenv
-                            virtualenv virtualenv --python=${env.PYTHON}
+                            ${env.PYTHON} -m venv virtualenv
                             . virtualenv/bin/activate
 
                             pip install "numpy>=1.17"
@@ -271,7 +271,7 @@ for(b = 0; b < builderNodes.size(); b++) {
 
                             CALL conda install -y swig
 
-                            virtualenv virtualenv --python=${env.PYTHON}
+                            ${env.PYTHON} -m venv virtualenv
                             pushd virtualenv\\Scripts
                             call activate
                             popd


### PR DESCRIPTION
I've added environment variables to Jenkins so ``PYTHON`` specifies the python executable. I've set this to ``python3`` on the Ubuntu 18 machines, ``python`` on the arch machine and ``python3.8`` on the mac so Jenkins now builds Python 3 rather than 2 wheels

Fixed #334 