### PR TITLE
izhikevich neurons shouldn't use auto-refractory

### DIFF
--- a/include/genn/genn/neuronModels.h
+++ b/include/genn/genn/neuronModels.h
@@ -171,6 +171,8 @@ public:
 
     SET_PARAM_NAMES({"a", "b", "c", "d"});
     SET_VARS({{"V","scalar"}, {"U", "scalar"}});
+
+    SET_NEEDS_AUTO_REFRACTORY(false);
 };
 
 //----------------------------------------------------------------------------


### PR DESCRIPTION
Otherwise, if you inject sufficient current for them to spike every timestep it doesn't work due to the voltage reset being at the start of the sim code (presumably to support reading the spike voltage from learning rules). Do you think the automatic refractory mechanism should be turned off for all models with reset code?