### PR TITLE
Ensure that 64-bit compiler is used on Windows

### DIFF
--- a/src/genn/genn/code_generator/generateMSBuild.cc
+++ b/src/genn/genn/code_generator/generateMSBuild.cc
@@ -43,6 +43,7 @@ void CodeGenerator::generateMSBuild(std::ostream &os, const BackendBase &backend
     os << "\t\t<UseDebugLibraries Condition=\"'$(Configuration)'=='Debug'\">true</UseDebugLibraries>" << std::endl;
     os << "\t\t<CharacterSet>MultiByte</CharacterSet>" << std::endl;
     os << "\t\t<PlatformToolset>$(DefaultPlatformToolset)</PlatformToolset>" << std::endl;
+    os << "\t\t<PreferredToolArchitecture>x64</PreferredToolArchitecture>" << std::endl;
     backend.genMSBuildConfigProperties(os);
     os << "\t</PropertyGroup>" << std::endl;
     


### PR DESCRIPTION
For reasons best known to itself, without explicitly preferring a 64-bit toolchain, MSBuild was using a 32-bit version of the 64-bit compiler (if that makes sense) with resulting 4GB memory limit. This prevented very large models like the multi-area model compiling.