### PR TITLE
Actually, option to suppress warnings only exists on CUDA >= 9.2

### DIFF
--- a/src/genn/backends/cuda/backend.cc
+++ b/src/genn/backends/cuda/backend.cc
@@ -1677,7 +1677,7 @@ std::string Backend::getNVCCFlags() const
 #ifndef _WIN32
     nvccFlags += " -std=c++11 --compiler-options \"-fPIC -Wno-return-type-c-linkage\"";
 #endif
-    if(m_RuntimeVersion >= 9000) {
+    if(m_RuntimeVersion >= 9020) {
         nvccFlags += " -Xcudafe \"--diag_suppress=extern_entity_treated_as_static\"";
     }
 


### PR DESCRIPTION
Clearly, assuming this is something that would only be introduced on a major version was naive. Works fine on CUDA 9.2 but not on CUDA 9.1.

Fixes #412