### PR TITLE
Fixed nasty race condition

### DIFF
--- a/include/genn/genn/code_generator/backendSIMT.h
+++ b/include/genn/genn/code_generator/backendSIMT.h
@@ -28,8 +28,9 @@ enum Kernel
     KernelSynapseDynamicsUpdate,
     KernelInitialize,
     KernelInitializeSparse,
-    KernelPreNeuronReset,
-    KernelPreSynapseReset,
+    KernelNeuronSpikeQueueUpdate,
+    KernelNeuronPrevSpikeTimeUpdate,
+    KernelSynapseDendriticDelayUpdate,
     KernelCustomUpdate,
     KernelCustomTransposeUpdate,
     KernelMax
@@ -92,7 +93,7 @@ public:
     //! Get name of atomic operation
     virtual std::string getAtomic(const std::string &type, AtomicOperation op = AtomicOperation::ADD, 
                                   AtomicMemSpace memSpace = AtomicMemSpace::GLOBAL) const = 0;
-    
+
     //! Generate a shared memory barrier
     virtual void genSharedMemBarrier(CodeStream &os) const = 0;
 
@@ -176,11 +177,13 @@ protected:
     //------------------------------------------------------------------------
     // Protected API
     //------------------------------------------------------------------------
-    void genPreNeuronResetKernel(CodeStream &os, const Substitutions &kernelSubs, const ModelSpecMerged &modelMerged, size_t &idStart) const;
+    void genNeuronPrevSpikeTimeUpdateKernel(CodeStream &os, const Substitutions &kernelSubs, const ModelSpecMerged &modelMerged, size_t &idStart) const;
+    void genNeuronSpikeQueueUpdateKernel(CodeStream &os, const ModelSpecMerged &modelMerged, size_t &idStart) const;
+
     void genNeuronUpdateKernel(CodeStream &os, const Substitutions &kernelSubs, const ModelSpecMerged &modelMerged,
                                NeuronGroupSimHandler simHandler, NeuronUpdateGroupMergedHandler wuVarUpdateHandler, size_t &idStart) const;
 
-    void genPreSynapseResetKernel(CodeStream &os, const ModelSpecMerged &modelMerged, size_t &idStart) const;
+    void genSynapseDendriticDelayUpdateKernel(CodeStream &os, const ModelSpecMerged &modelMerged, size_t &idStart) const;
     void genPresynapticUpdateKernel(CodeStream &os, const Substitutions &kernelSubs, const ModelSpecMerged &modelMerged,
                                     PresynapticUpdateGroupMergedHandler wumThreshHandler, PresynapticUpdateGroupMergedHandler wumSimHandler,
                                     PresynapticUpdateGroupMergedHandler wumEventHandler, PresynapticUpdateGroupMergedHandler wumProceduralConnectHandler, size_t &idStart) const;
@@ -227,52 +230,6 @@ private:
     //--------------------------------------------------------------------------
     // Private methods
     //--------------------------------------------------------------------------
-    template<typename T>
-    void genGroupMergedSearch(CodeStream &os, Substitutions &popSubs, const T &g, size_t idStart) const
-    {
-        if(g.getGroups().size() == 1) {
-            os << getPointerPrefix() << "struct Merged" << T::name << "Group" << g.getIndex() << " *group";
-            os << " = &d_merged" << T::name << "Group" << g.getIndex() << "[0]; " << std::endl;
-            os << "const unsigned int lid = id - " << idStart << ";" << std::endl;
-
-            // Use the starting thread ID of the whole merged group as group_start_id
-            popSubs.addVarSubstitution("group_start_id", std::to_string(idStart));
-        }
-        else {
-            // Perform bisect operation to get index of merged struct
-            os << "unsigned int lo = 0;" << std::endl;
-            os << "unsigned int hi = " << g.getGroups().size() << ";" << std::endl;
-            os << "while(lo < hi)" << std::endl;
-            {
-                CodeStream::Scope b(os);
-                os << "const unsigned int mid = (lo + hi) / 2;" << std::endl;
-
-                os << "if(id < d_merged" << T::name << "GroupStartID" << g.getIndex() << "[mid])";
-                {
-                    CodeStream::Scope b(os);
-                    os << "hi = mid;" << std::endl;
-                }
-                os << "else";
-                {
-                    CodeStream::Scope b(os);
-                    os << "lo = mid + 1;" << std::endl;
-                }
-            }
-
-            // Use this to get reference to merged group structure
-            os << getPointerPrefix() << "struct Merged" << T::name << "Group" << g.getIndex() << " *group";
-            os << " = &d_merged" << T::name << "Group" << g.getIndex() << "[lo - 1]; " << std::endl;
-
-            // Get group start thread ID and use as group_start_id
-            os << "const unsigned int groupStartID = d_merged" << T::name << "GroupStartID" << g.getIndex() << "[lo - 1];" << std::endl;
-            popSubs.addVarSubstitution("group_start_id", "groupStartID");
-
-            // Use this to calculate local id within group
-            os << "const unsigned int lid = id - groupStartID;" << std::endl;
-        }
-        popSubs.addVarSubstitution("id", "lid");
-    }
-
     template<typename T, typename S, typename F>
     void genParallelGroup(CodeStream &os, const Substitutions &kernelSubs, const std::vector<T> &groups, size_t &idStart,
                           S getPaddedSizeFunc, F filter, GroupHandler<T> handler) const
@@ -301,7 +258,47 @@ private:
                     CodeStream::Scope b(os);
                     Substitutions popSubs(&kernelSubs);
 
-                    genGroupMergedSearch(os, popSubs, gMerge, idStart);
+                    if(gMerge.getGroups().size() == 1) {
+                        os << getPointerPrefix() << "struct Merged" << T::name << "Group" << gMerge.getIndex() << " *group";
+                        os << " = &d_merged" << T::name << "Group" << gMerge.getIndex() << "[0]; " << std::endl;
+                        os << "const unsigned int lid = id - " << idStart << ";" << std::endl;
+
+                        // Use the starting thread ID of the whole merged group as group_start_id
+                        popSubs.addVarSubstitution("group_start_id", std::to_string(idStart));
+                    }
+                    else {
+                        // Perform bisect operation to get index of merged struct
+                        os << "unsigned int lo = 0;" << std::endl;
+                        os << "unsigned int hi = " << gMerge.getGroups().size() << ";" << std::endl;
+                        os << "while(lo < hi)" << std::endl;
+                        {
+                            CodeStream::Scope b(os);
+                            os << "const unsigned int mid = (lo + hi) / 2;" << std::endl;
+
+                            os << "if(id < d_merged" << T::name << "GroupStartID" << gMerge.getIndex() << "[mid])";
+                            {
+                                CodeStream::Scope b(os);
+                                os << "hi = mid;" << std::endl;
+                            }
+                            os << "else";
+                            {
+                                CodeStream::Scope b(os);
+                                os << "lo = mid + 1;" << std::endl;
+                            }
+                        }
+
+                        // Use this to get reference to merged group structure
+                        os << getPointerPrefix() << "struct Merged" << T::name << "Group" << gMerge.getIndex() << " *group";
+                        os << " = &d_merged" << T::name << "Group" << gMerge.getIndex() << "[lo - 1]; " << std::endl;
+
+                        // Get group start thread ID and use as group_start_id
+                        os << "const unsigned int groupStartID = d_merged" << T::name << "GroupStartID" << gMerge.getIndex() << "[lo - 1];" << std::endl;
+                        popSubs.addVarSubstitution("group_start_id", "groupStartID");
+
+                        // Use this to calculate local id within group
+                        os << "const unsigned int lid = id - groupStartID;" << std::endl;
+                    }
+                    popSubs.addVarSubstitution("id", "lid");
 
                     handler(os, gMerge, popSubs);
 

--- a/include/genn/genn/code_generator/groupMerged.h
+++ b/include/genn/genn/code_generator/groupMerged.h
@@ -445,6 +445,32 @@ public:
 };
 
 //----------------------------------------------------------------------------
+// CodeGenerator::NeuronPrevSpikeTimeUpdateGroupMerged
+//----------------------------------------------------------------------------
+class GENN_EXPORT NeuronPrevSpikeTimeUpdateGroupMerged : public GroupMerged<NeuronGroupInternal>
+{
+public:
+    NeuronPrevSpikeTimeUpdateGroupMerged(size_t index, const std::string &precision, const std::string &timePrecison, const BackendBase &backend,
+                                         const std::vector<std::reference_wrapper<const NeuronGroupInternal>> &groups);
+
+    //------------------------------------------------------------------------
+    // Public API
+    //------------------------------------------------------------------------
+    void generateRunner(const BackendBase &backend, CodeStream &definitionsInternal,
+                  CodeStream &definitionsInternalFunc, CodeStream &definitionsInternalVar,
+                  CodeStream &runnerVarDecl, CodeStream &runnerMergedStructAlloc) const
+    {
+        generateRunnerBase(backend, definitionsInternal, definitionsInternalFunc, definitionsInternalVar,
+                           runnerVarDecl, runnerMergedStructAlloc, name);
+    }
+
+    //----------------------------------------------------------------------------
+    // Static constants
+    //----------------------------------------------------------------------------
+    static const std::string name;
+};
+
+//----------------------------------------------------------------------------
 // CodeGenerator::NeuronGroupMergedBase
 //----------------------------------------------------------------------------
 class GENN_EXPORT NeuronGroupMergedBase : public GroupMerged<NeuronGroupInternal>

--- a/include/genn/genn/code_generator/modelSpecMerged.h
+++ b/include/genn/genn/code_generator/modelSpecMerged.h
@@ -129,6 +129,9 @@ public:
     //! Get merged neuron groups which require their spike queues updating
     const std::vector<NeuronSpikeQueueUpdateGroupMerged> &getMergedNeuronSpikeQueueUpdateGroups() const { return m_MergedNeuronSpikeQueueUpdateGroups; }
 
+    //! Get merged neuron groups which require their previous spike times updating
+    const std::vector<NeuronPrevSpikeTimeUpdateGroupMerged> &getMergedNeuronPrevSpikeTimeUpdateGroups() const{ return m_MergedNeuronPrevSpikeTimeUpdateGroups; }
+
     //! Get merged synapse groups which require their dendritic delay updating
     const std::vector<SynapseDendriticDelayUpdateGroupMerged> &getMergedSynapseDendriticDelayUpdateGroups() const { return m_MergedSynapseDendriticDelayUpdateGroups; }
 
@@ -156,6 +159,7 @@ public:
     void genMergedSynapseSparseInitGroupStructs(CodeStream &os, const BackendBase &backend) const { genMergedStructures(os, backend, m_MergedSynapseSparseInitGroups); }
     void genMergedCustomWUUpdateSparseInitGroupStructs(CodeStream &os, const BackendBase &backend) const { genMergedStructures(os, backend, m_MergedCustomWUUpdateSparseInitGroups); }
     void genMergedNeuronSpikeQueueUpdateStructs(CodeStream &os, const BackendBase &backend) const{ genMergedStructures(os, backend, m_MergedNeuronSpikeQueueUpdateGroups); }
+    void genMergedNeuronPrevSpikeTimeUpdateStructs(CodeStream &os, const BackendBase &backend) const{ genMergedStructures(os, backend, m_MergedNeuronPrevSpikeTimeUpdateGroups); }
     void genMergedSynapseDendriticDelayUpdateStructs(CodeStream &os, const BackendBase &backend) const { genMergedStructures(os, backend, m_MergedSynapseDendriticDelayUpdateGroups); }
     void genMergedSynapseConnectivityHostInitStructs(CodeStream &os, const BackendBase &backend) const { genMergedStructures(os, backend, m_MergedSynapseConnectivityHostInitGroups); }
     void genMergedCustomUpdateStructs(CodeStream &os, const BackendBase &backend) const { genMergedStructures(os, backend, m_MergedCustomUpdateGroups); }
@@ -384,6 +388,9 @@ private:
 
     //! Merged neuron groups which require their spike queues updating
     std::vector<NeuronSpikeQueueUpdateGroupMerged> m_MergedNeuronSpikeQueueUpdateGroups;
+
+    //! Merged neuron groups which require their previous spike times updating
+    std::vector<NeuronPrevSpikeTimeUpdateGroupMerged> m_MergedNeuronPrevSpikeTimeUpdateGroups;
 
     //! Merged synapse groups which require their dendritic delay updating
     std::vector<SynapseDendriticDelayUpdateGroupMerged> m_MergedSynapseDendriticDelayUpdateGroups;

--- a/src/genn/backends/cuda/backend.cc
+++ b/src/genn/backends/cuda/backend.cc
@@ -305,9 +305,10 @@ void Backend::genNeuronUpdate(CodeStream &os, const ModelSpecMerged &modelMerged
                                             getGroupStartIDSize(modelMerged.getMergedPostsynapticUpdateGroups()) +
                                             getGroupStartIDSize(modelMerged.getMergedSynapseDynamicsGroups()));
     size_t totalConstMem = (getChosenDeviceSafeConstMemBytes() > synapseGroupStartIDSize) ? (getChosenDeviceSafeConstMemBytes() - synapseGroupStartIDSize) : 0;
-    genMergedKernelDataStructures(os, totalConstMem,
-                                  modelMerged.getMergedNeuronUpdateGroups(),
+    genMergedKernelDataStructures(os, totalConstMem, modelMerged.getMergedNeuronUpdateGroups(),
                                   [this](const NeuronGroupInternal &ng){ return padKernelSize(ng.getNumNeurons(), KernelNeuronUpdate); });
+    genMergedKernelDataStructures(os, totalConstMem, modelMerged.getMergedNeuronPrevSpikeTimeUpdateGroups(),
+                                  [this](const NeuronGroupInternal &ng){ return padKernelSize(ng.getNumNeurons(), KernelNeuronPrevSpikeTimeUpdate); });
     os << std::endl;
 
     // If any neuron groups require their previous spike times updating

--- a/src/genn/backends/cuda/optimiser.cc
+++ b/src/genn/backends/cuda/optimiser.cc
@@ -129,7 +129,7 @@ void calcGroupSizes(const CUDA::Preferences &preferences, const ModelSpecInterna
         // If neuron group requires previous spike or spike-like-event times to be reset after update 
         // i.e. in the pre-neuron reset kernel, add number of neurons to kernel
         if(n.second.isPrevSpikeTimeRequired() || n.second.isPrevSpikeEventTimeRequired()) {
-            groupSizes[KernelPreNeuronReset].push_back((size_t)model.getBatchSize() * n.second.getNumNeurons());
+            groupSizes[KernelNeuronPrevSpikeTimeUpdate].push_back((size_t)model.getBatchSize() * n.second.getNumNeurons());
         }
     }
 
@@ -196,10 +196,8 @@ void calcGroupSizes(const CUDA::Preferences &preferences, const ModelSpecInterna
     }
 
     // Add group sizes for reset kernels
-    // **NOTE** individual pre-neuron reset groups have already been added for neuron groups 
-    // which require previous spike or spike-like-event times, just add single big group for remainder here
-    groupSizes[KernelPreNeuronReset].push_back(model.getNeuronGroups().size() - groupSizes[KernelPreNeuronReset].size());
-    groupSizes[KernelPreSynapseReset].push_back(numPreSynapseResetGroups);
+    groupSizes[KernelNeuronSpikeQueueUpdate].push_back(model.getNeuronGroups().size());
+    groupSizes[KernelSynapseDendriticDelayUpdate].push_back(numPreSynapseResetGroups);
 }
 //--------------------------------------------------------------------------
 KernelOptimisationOutput optimizeBlockSize(int deviceID, const cudaDeviceProp &deviceProps, const ModelSpecInternal &model,

--- a/src/genn/backends/opencl/backend.cc
+++ b/src/genn/backends/opencl/backend.cc
@@ -247,17 +247,16 @@ void Backend::genNeuronUpdate(CodeStream &os, const ModelSpecMerged &modelMerged
     os << "// OpenCL program and kernels" << std::endl;
     os << "//--------------------------------------------------------------------------" << std::endl;
     os << "cl::Program neuronUpdateProgram;" << std::endl;
-    os << "cl::Kernel " << KernelNames[KernelPreNeuronReset] << ";" << std::endl;
+    os << "cl::Kernel " << KernelNames[KernelNeuronSpikeQueueUpdate] << ";" << std::endl;
+    os << "cl::Kernel " << KernelNames[KernelNeuronPrevSpikeTimeUpdate] << ";" << std::endl;
     os << "cl::Kernel " << KernelNames[KernelNeuronUpdate] << ";" << std::endl;
     genMergedStructPreamble(os, modelMerged, modelMerged.getMergedNeuronSpikeQueueUpdateGroups());
+    genMergedStructPreamble(os, modelMerged, modelMerged.getMergedNeuronPrevSpikeTimeUpdateGroups());
     genMergedStructPreamble(os, modelMerged, modelMerged.getMergedNeuronUpdateGroups());
     os << std::endl;
 
     // Generate preamble
     preambleHandler(os);
-
-    //! KernelPreNeuronReset START
-    size_t idPreNeuronReset = 0;
 
     // Creating the kernel body separately so it can be split into multiple string literals
     std::stringstream neuronUpdateKernelsStream;
@@ -275,6 +274,7 @@ void Backend::genNeuronUpdate(CodeStream &os, const ModelSpecMerged &modelMerged
     // Generate struct definitions
     modelMerged.genMergedNeuronUpdateGroupStructs(neuronUpdateKernels, *this);
     modelMerged.genMergedNeuronSpikeQueueUpdateStructs(neuronUpdateKernels, *this);
+    modelMerged.genMergedNeuronPrevSpikeTimeUpdateStructs(neuronUpdateKernels, *this);
 
     // Generate merged data structures
     genMergedKernelDataStructures(
@@ -284,28 +284,56 @@ void Backend::genNeuronUpdate(CodeStream &os, const ModelSpecMerged &modelMerged
 
     // Generate kernels used to populate merged structs
     genMergedStructBuildKernels(neuronUpdateKernels, modelMerged, modelMerged.getMergedNeuronSpikeQueueUpdateGroups());
+    genMergedStructBuildKernels(neuronUpdateKernels, modelMerged, modelMerged.getMergedNeuronPrevSpikeTimeUpdateGroups());
     genMergedStructBuildKernels(neuronUpdateKernels, modelMerged, modelMerged.getMergedNeuronUpdateGroups());
 
+    //! KernelPreNeuronReset START
+    size_t idNeuronPrevSpikeTimeUpdate = 0;
+
+    // If any neuron groups require their previous spike times updating
+    if(!modelMerged.getMergedNeuronPrevSpikeTimeUpdateGroups().empty()) {
+        // Declare neuron spike queue update kernel
+        neuronUpdateKernels << "__attribute__((reqd_work_group_size(" << getKernelBlockSize(KernelNeuronPrevSpikeTimeUpdate) << ", 1, 1)))" << std::endl;
+        neuronUpdateKernels << "__kernel void " << KernelNames[KernelNeuronPrevSpikeTimeUpdate] << "(";
+        genMergedGroupKernelParams(neuronUpdateKernels, modelMerged.getMergedNeuronPrevSpikeTimeUpdateGroups(), true);
+        neuronUpdateKernels << model.getTimePrecision() << " t)";
+        {
+            CodeStream::Scope b(neuronUpdateKernels);
+
+            neuronUpdateKernels << "const unsigned int id = get_global_id(0);" << std::endl;
+            Substitutions kernelSubs(openclLFSRFunctions);
+            kernelSubs.addVarSubstitution("t", "t");
+            if(model.getBatchSize() > 1) {
+                neuronUpdateKernels << "const unsigned int batch = get_global_id(1);" << std::endl;
+                kernelSubs.addVarSubstitution("batch", "batch");
+            }
+            else {
+                kernelSubs.addVarSubstitution("batch", "0");
+            }
+            genNeuronPrevSpikeTimeUpdateKernel(neuronUpdateKernels, kernelSubs, modelMerged, idNeuronPrevSpikeTimeUpdate);
+        }
+        neuronUpdateKernels << std::endl;
+    }
+
+    //! KernelPreNeuronReset START
+    size_t idNeuronSpikeQueueUpdate = 0;
+
     // Declare neuron spike queue update kernel
-    neuronUpdateKernels << "__attribute__((reqd_work_group_size(" << getKernelBlockSize(KernelPreNeuronReset) << ", 1, 1)))" << std::endl;
-    neuronUpdateKernels << "__kernel void " << KernelNames[KernelPreNeuronReset] << "(";
-    genMergedGroupKernelParams(neuronUpdateKernels, modelMerged.getMergedNeuronSpikeQueueUpdateGroups(), true);
-    neuronUpdateKernels << model.getTimePrecision() << " t)";
+    neuronUpdateKernels << "__attribute__((reqd_work_group_size(" << getKernelBlockSize(KernelNeuronSpikeQueueUpdate) << ", 1, 1)))" << std::endl;
+    neuronUpdateKernels << "__kernel void " << KernelNames[KernelNeuronSpikeQueueUpdate] << "(";
+    genMergedGroupKernelParams(neuronUpdateKernels, modelMerged.getMergedNeuronSpikeQueueUpdateGroups(), false);
+    neuronUpdateKernels << ")";
     {
         CodeStream::Scope b(neuronUpdateKernels);
 
         neuronUpdateKernels << "const unsigned int id = get_global_id(0);" << std::endl;
 
-        Substitutions kernelSubs(openclLFSRFunctions);
-        kernelSubs.addVarSubstitution("t", "t");
-
-        genPreNeuronResetKernel(neuronUpdateKernels, kernelSubs, modelMerged, idPreNeuronReset);
+        genNeuronSpikeQueueUpdateKernel(neuronUpdateKernels, modelMerged, idNeuronSpikeQueueUpdate);
     }
     neuronUpdateKernels << std::endl;
-    //! KernelPreNeuronReset END
+
     size_t idStart = 0;
 
-    //! KernelNeuronUpdate BODY START
     neuronUpdateKernels << "__attribute__((reqd_work_group_size(" << getKernelBlockSize(KernelNeuronUpdate) << ", 1, 1)))" << std::endl;
     neuronUpdateKernels << "__kernel void " << KernelNames[KernelNeuronUpdate] << "(";
     genMergedGroupKernelParams(neuronUpdateKernels, modelMerged.getMergedNeuronUpdateGroups(), true);
@@ -347,7 +375,7 @@ void Backend::genNeuronUpdate(CodeStream &os, const ModelSpecMerged &modelMerged
         CodeStream::Scope b(os);
 
         // If there are any kernels (some implementations complain)
-        if(idPreNeuronReset > 0 || idStart > 0) {
+        if(idNeuronSpikeQueueUpdate > 0 || idNeuronSpikeQueueUpdate > 0 || idNeuronPrevSpikeTimeUpdate > 0) {
             os << "// Build program" << std::endl;
             os << "CHECK_OPENCL_ERRORS_POINTER(neuronUpdateProgram = cl::Program(clContext, neuronUpdateSrc, false, &error));" << std::endl;
             genBuildProgramFlagsString(os);
@@ -361,15 +389,24 @@ void Backend::genNeuronUpdate(CodeStream &os, const ModelSpecMerged &modelMerged
 
             os << "// Configure merged struct buffers and kernels" << std::endl;
             genMergedStructBuild(os, modelMerged, modelMerged.getMergedNeuronSpikeQueueUpdateGroups(), "neuronUpdateProgram");
+            genMergedStructBuild(os, modelMerged, modelMerged.getMergedNeuronPrevSpikeTimeUpdateGroups(), "neuronUpdateProgram");
             genMergedStructBuild(os, modelMerged, modelMerged.getMergedNeuronUpdateGroups(), "neuronUpdateProgram");
             os << std::endl;
         }
 
-        // KernelPreNeuronReset initialization
-        if(idPreNeuronReset > 0) {
+        // KernelNeuronPrevSpikeTimeUpdate initialisation
+        if(idNeuronPrevSpikeTimeUpdate > 0) {
+            os << "// Configure neuron previous spike time update kernel" << std::endl;
+            os << "CHECK_OPENCL_ERRORS_POINTER(" << KernelNames[KernelNeuronPrevSpikeTimeUpdate] << " = cl::Kernel(neuronUpdateProgram, \"" << KernelNames[KernelNeuronPrevSpikeTimeUpdate] << "\", &error));" << std::endl;
+            setMergedGroupKernelParams(os, KernelNames[KernelNeuronPrevSpikeTimeUpdate], modelMerged.getMergedNeuronPrevSpikeTimeUpdateGroups());
+            os << std::endl;
+        }
+
+        // KernelNeuronSpikeQueueUpdate initialization
+        if(idNeuronSpikeQueueUpdate > 0) {
             os << "// Configure neuron spike queue update kernel" << std::endl;
-            os << "CHECK_OPENCL_ERRORS_POINTER(" << KernelNames[KernelPreNeuronReset] << " = cl::Kernel(neuronUpdateProgram, \"" << KernelNames[KernelPreNeuronReset] << "\", &error));" << std::endl;
-            setMergedGroupKernelParams(os, KernelNames[KernelPreNeuronReset], modelMerged.getMergedNeuronSpikeQueueUpdateGroups());
+            os << "CHECK_OPENCL_ERRORS_POINTER(" << KernelNames[KernelNeuronSpikeQueueUpdate] << " = cl::Kernel(neuronUpdateProgram, \"" << KernelNames[KernelNeuronSpikeQueueUpdate] << "\", &error));" << std::endl;
+            setMergedGroupKernelParams(os, KernelNames[KernelNeuronSpikeQueueUpdate], modelMerged.getMergedNeuronSpikeQueueUpdateGroups());
             os << std::endl;
         }
 
@@ -395,11 +432,18 @@ void Backend::genNeuronUpdate(CodeStream &os, const ModelSpecMerged &modelMerged
         // Push any required EGPS
         pushEGPHandler(os);
 
-        if (idPreNeuronReset > 0) {
+        if (idNeuronPrevSpikeTimeUpdate > 0) {
             CodeStream::Scope b(os);
-            os << "CHECK_OPENCL_ERRORS(" << KernelNames[KernelPreNeuronReset] << ".setArg(" << modelMerged.getMergedNeuronSpikeQueueUpdateGroups().size() << ", t));" << std::endl;
-            genKernelDimensions(os, KernelPreNeuronReset, idPreNeuronReset, 1);
-            os << "CHECK_OPENCL_ERRORS(commandQueue.enqueueNDRangeKernel(" << KernelNames[KernelPreNeuronReset] << ", cl::NullRange, globalWorkSize, localWorkSize));" << std::endl;
+            os << "CHECK_OPENCL_ERRORS(" << KernelNames[KernelNeuronPrevSpikeTimeUpdate] << ".setArg(" << modelMerged.getMergedNeuronPrevSpikeTimeUpdateGroups().size() << ", t));" << std::endl;
+            genKernelDimensions(os, KernelNeuronPrevSpikeTimeUpdate, idNeuronPrevSpikeTimeUpdate, model.getBatchSize());
+            os << "CHECK_OPENCL_ERRORS(commandQueue.enqueueNDRangeKernel(" << KernelNames[KernelNeuronPrevSpikeTimeUpdate] << ", cl::NullRange, globalWorkSize, localWorkSize));" << std::endl;
+            genPostKernelFlush(os);
+            os << std::endl;
+        }
+        if (idNeuronSpikeQueueUpdate > 0) {
+            CodeStream::Scope b(os);
+            genKernelDimensions(os, KernelNeuronSpikeQueueUpdate, idNeuronSpikeQueueUpdate, 1);
+            os << "CHECK_OPENCL_ERRORS(commandQueue.enqueueNDRangeKernel(" << KernelNames[KernelNeuronSpikeQueueUpdate] << ", cl::NullRange, globalWorkSize, localWorkSize));" << std::endl;
             genPostKernelFlush(os);
             os << std::endl;
         }
@@ -434,7 +478,7 @@ void Backend::genSynapseUpdate(CodeStream &os, const ModelSpecMerged &modelMerge
     os << "// OpenCL program and kernels" << std::endl;
     os << "//--------------------------------------------------------------------------" << std::endl;
     os << "cl::Program synapseUpdateProgram;" << std::endl;
-    os << "cl::Kernel " << KernelNames[KernelPreSynapseReset] << ";" << std::endl;
+    os << "cl::Kernel " << KernelNames[KernelSynapseDendriticDelayUpdate] << ";" << std::endl;
     os << "cl::Kernel " << KernelNames[KernelPresynapticUpdate] << ";" << std::endl;
     os << "cl::Kernel " << KernelNames[KernelPostsynapticUpdate] << ";" << std::endl;
     os << "cl::Kernel " << KernelNames[KernelSynapseDynamicsUpdate] << ";" << std::endl;
@@ -493,16 +537,16 @@ void Backend::genSynapseUpdate(CodeStream &os, const ModelSpecMerged &modelMerge
     genMergedStructBuildKernels(synapseUpdateKernels, modelMerged, modelMerged.getMergedSynapseDynamicsGroups());
 
     // Declare neuron spike queue update kernel
-    size_t idPreSynapseReset = 0;
+    size_t idSynapseDendriticDelayUpdate = 0;
     if(!modelMerged.getMergedSynapseDendriticDelayUpdateGroups().empty()) {
-        synapseUpdateKernels << "__attribute__((reqd_work_group_size(" << getKernelBlockSize(KernelPreSynapseReset) << ", 1, 1)))" << std::endl;
-        synapseUpdateKernels << "__kernel void " << KernelNames[KernelPreSynapseReset] << "(";
+        synapseUpdateKernels << "__attribute__((reqd_work_group_size(" << getKernelBlockSize(KernelSynapseDendriticDelayUpdate) << ", 1, 1)))" << std::endl;
+        synapseUpdateKernels << "__kernel void " << KernelNames[KernelSynapseDendriticDelayUpdate] << "(";
         genMergedGroupKernelParams(synapseUpdateKernels, modelMerged.getMergedSynapseDendriticDelayUpdateGroups());
         synapseUpdateKernels << ")";
         {
             CodeStream::Scope b(synapseUpdateKernels);
             synapseUpdateKernels << "const unsigned int id = get_global_id(0);" << std::endl;
-            genPreSynapseResetKernel(synapseUpdateKernels, modelMerged, idPreSynapseReset);
+            genSynapseDendriticDelayUpdateKernel(synapseUpdateKernels, modelMerged, idSynapseDendriticDelayUpdate);
         }
     }
 
@@ -599,7 +643,7 @@ void Backend::genSynapseUpdate(CodeStream &os, const ModelSpecMerged &modelMerge
         CodeStream::Scope b(os);
 
         // If there are any kernels (some implementations complain)
-        if(idPreSynapseReset > 0 || idPresynapticStart > 0 || idPostsynapticStart > 0 || idSynapseDynamicsStart > 0) {
+        if(idSynapseDendriticDelayUpdate > 0 || idPresynapticStart > 0 || idPostsynapticStart > 0 || idSynapseDynamicsStart > 0) {
             os << "// Build program" << std::endl;
             os << "CHECK_OPENCL_ERRORS_POINTER(synapseUpdateProgram = cl::Program(clContext, synapseUpdateSrc, false, &error));" << std::endl;
             genBuildProgramFlagsString(os);
@@ -619,10 +663,10 @@ void Backend::genSynapseUpdate(CodeStream &os, const ModelSpecMerged &modelMerge
             os << std::endl;
         }
 
-        if(idPreSynapseReset > 0) {
+        if(idSynapseDendriticDelayUpdate > 0) {
             os << "// Configure dendritic delay update kernel" << std::endl;
-            os << "CHECK_OPENCL_ERRORS_POINTER(" << KernelNames[KernelPreSynapseReset] << " = cl::Kernel(synapseUpdateProgram, \"" << KernelNames[KernelPreSynapseReset] << "\", &error));" << std::endl;
-            setMergedGroupKernelParams(os, KernelNames[KernelPreSynapseReset], modelMerged.getMergedSynapseDendriticDelayUpdateGroups());
+            os << "CHECK_OPENCL_ERRORS_POINTER(" << KernelNames[KernelSynapseDendriticDelayUpdate] << " = cl::Kernel(synapseUpdateProgram, \"" << KernelNames[KernelSynapseDendriticDelayUpdate] << "\", &error));" << std::endl;
+            setMergedGroupKernelParams(os, KernelNames[KernelSynapseDendriticDelayUpdate], modelMerged.getMergedSynapseDendriticDelayUpdateGroups());
             os << std::endl;
         }
 
@@ -661,10 +705,10 @@ void Backend::genSynapseUpdate(CodeStream &os, const ModelSpecMerged &modelMerge
         pushEGPHandler(os);
 
         // Launch pre-synapse reset kernel if required
-        if (idPreSynapseReset > 0) {
+        if (idSynapseDendriticDelayUpdate > 0) {
             CodeStream::Scope b(os);
-            genKernelDimensions(os, KernelPreSynapseReset, idPreSynapseReset, 1);
-            os << "CHECK_OPENCL_ERRORS(commandQueue.enqueueNDRangeKernel(" << KernelNames[KernelPreSynapseReset] << ", cl::NullRange, globalWorkSize, localWorkSize));" << std::endl;
+            genKernelDimensions(os, KernelSynapseDendriticDelayUpdate, idSynapseDendriticDelayUpdate, 1);
+            os << "CHECK_OPENCL_ERRORS(commandQueue.enqueueNDRangeKernel(" << KernelNames[KernelSynapseDendriticDelayUpdate] << ", cl::NullRange, globalWorkSize, localWorkSize));" << std::endl;
             genPostKernelFlush(os);
         }
 

--- a/src/genn/backends/opencl/backend.cc
+++ b/src/genn/backends/opencl/backend.cc
@@ -277,9 +277,10 @@ void Backend::genNeuronUpdate(CodeStream &os, const ModelSpecMerged &modelMerged
     modelMerged.genMergedNeuronPrevSpikeTimeUpdateStructs(neuronUpdateKernels, *this);
 
     // Generate merged data structures
-    genMergedKernelDataStructures(
-        neuronUpdateKernels,
-        modelMerged.getMergedNeuronUpdateGroups(), [this](const NeuronGroupInternal &ng) { return padKernelSize(ng.getNumNeurons(), KernelNeuronUpdate); });
+    genMergedKernelDataStructures(neuronUpdateKernels, modelMerged.getMergedNeuronUpdateGroups(),
+                                  [this](const NeuronGroupInternal &ng) { return padKernelSize(ng.getNumNeurons(), KernelNeuronUpdate); });
+    genMergedKernelDataStructures(neuronUpdateKernels, modelMerged.getMergedNeuronPrevSpikeTimeUpdateGroups(),
+                                  [this](const NeuronGroupInternal &ng) { return padKernelSize(ng.getNumNeurons(), KernelNeuronPrevSpikeTimeUpdate); });
     neuronUpdateKernels << std::endl;
 
     // Generate kernels used to populate merged structs

--- a/src/genn/genn/code_generator/generateRunner.cc
+++ b/src/genn/genn/code_generator/generateRunner.cc
@@ -756,6 +756,12 @@ MemAlloc CodeGenerator::generateRunner(CodeStream &definitions, CodeStream &defi
                          runnerVarDecl, runnerMergedStructAlloc);
     }
 
+    // Loop through neuron groups whose previous spike times need resetting
+    for(const auto &m : modelMerged.getMergedNeuronPrevSpikeTimeUpdateGroups()) {
+        m.generateRunner(backend, definitionsInternal, definitionsInternalFunc, definitionsInternalVar,
+                         runnerVarDecl, runnerMergedStructAlloc);
+    }
+
     // Loop through neuron groups whose spike queues need resetting
     for(const auto &m : modelMerged.getMergedNeuronSpikeQueueUpdateGroups()) {
         m.generateRunner(backend, definitionsInternal, definitionsInternalFunc, definitionsInternalVar,

--- a/src/genn/genn/code_generator/groupMerged.cc
+++ b/src/genn/genn/code_generator/groupMerged.cc
@@ -18,8 +18,8 @@ using namespace CodeGenerator;
 //----------------------------------------------------------------------------
 const std::string NeuronSpikeQueueUpdateGroupMerged::name = "NeuronSpikeQueueUpdate";
 //----------------------------------------------------------------------------
-NeuronSpikeQueueUpdateGroupMerged::NeuronSpikeQueueUpdateGroupMerged(size_t index, const std::string &precision, const std::string &timePrecision, const BackendBase &backend,
-                                                                                    const std::vector<std::reference_wrapper<const NeuronGroupInternal>> &groups)
+NeuronSpikeQueueUpdateGroupMerged::NeuronSpikeQueueUpdateGroupMerged(size_t index, const std::string &precision, const std::string &, const BackendBase &backend,
+                                                                     const std::vector<std::reference_wrapper<const NeuronGroupInternal>> &groups)
 :   GroupMerged<NeuronGroupInternal>(index, precision, groups)
 {
     if(getArchetype().isDelayRequired()) {
@@ -33,22 +33,6 @@ NeuronSpikeQueueUpdateGroupMerged::NeuronSpikeQueueUpdateGroupMerged(size_t inde
 
     if(getArchetype().isSpikeEventRequired()) {
         addPointerField("unsigned int", "spkCntEvnt", backend.getDeviceVarPrefix() + "glbSpkCntEvnt");
-    }
-
-    if(getArchetype().isPrevSpikeTimeRequired() || getArchetype().isPrevSpikeEventTimeRequired()) {
-        if(getArchetype().isPrevSpikeTimeRequired()) {
-            addPointerField("unsigned int", "spk", backend.getDeviceVarPrefix() + "glbSpk");
-            addPointerField(timePrecision, "prevST", backend.getDeviceVarPrefix() + "prevST");
-        }
-        if(getArchetype().isPrevSpikeEventTimeRequired()) {
-            addPointerField("unsigned int", "spkEvnt", backend.getDeviceVarPrefix() + "glbSpkEvnt");
-            addPointerField(timePrecision, "prevSET", backend.getDeviceVarPrefix() + "prevSET");
-        }
-
-        if(getArchetype().isDelayRequired()) {
-            addField("unsigned int", "numNeurons",
-                     [](const NeuronGroupInternal &ng, size_t) { return std::to_string(ng.getNumNeurons()); });
-        }
     }
 }
 //----------------------------------------------------------------------------
@@ -76,6 +60,43 @@ void NeuronSpikeQueueUpdateGroupMerged::genMergedGroupSpikeCountReset(CodeStream
     }
     else {
         os << "group->spkCnt[" << ((batchSize > 1) ? "batch" : "0") << "] = 0;" << std::endl;
+    }
+}
+
+//----------------------------------------------------------------------------
+// CodeGenerator::NeuronPrevSpikeTimeUpdateGroupMerged
+//----------------------------------------------------------------------------
+const std::string NeuronPrevSpikeTimeUpdateGroupMerged::name = "NeuronPrevSpikeTimeUpdate";
+//----------------------------------------------------------------------------
+NeuronPrevSpikeTimeUpdateGroupMerged::NeuronPrevSpikeTimeUpdateGroupMerged(size_t index, const std::string &precision, const std::string &timePrecision, const BackendBase &backend,
+                                                                           const std::vector<std::reference_wrapper<const NeuronGroupInternal>> &groups)
+:   GroupMerged<NeuronGroupInternal>(index, precision, groups)
+{
+    if(getArchetype().isDelayRequired()) {
+        addField("unsigned int", "numDelaySlots",
+                 [](const NeuronGroupInternal &ng, size_t) { return std::to_string(ng.getNumDelaySlots()); });
+
+        addPointerField("unsigned int", "spkQuePtr", backend.getScalarAddressPrefix() + "spkQuePtr");
+    } 
+
+    addPointerField("unsigned int", "spkCnt", backend.getDeviceVarPrefix() + "glbSpkCnt");
+
+    if(getArchetype().isSpikeEventRequired()) {
+        addPointerField("unsigned int", "spkCntEvnt", backend.getDeviceVarPrefix() + "glbSpkCntEvnt");
+    }
+
+    if(getArchetype().isPrevSpikeTimeRequired()) {
+        addPointerField("unsigned int", "spk", backend.getDeviceVarPrefix() + "glbSpk");
+        addPointerField(timePrecision, "prevST", backend.getDeviceVarPrefix() + "prevST");
+    }
+    if(getArchetype().isPrevSpikeEventTimeRequired()) {
+        addPointerField("unsigned int", "spkEvnt", backend.getDeviceVarPrefix() + "glbSpkEvnt");
+        addPointerField(timePrecision, "prevSET", backend.getDeviceVarPrefix() + "prevSET");
+    }
+
+    if(getArchetype().isDelayRequired()) {
+        addField("unsigned int", "numNeurons",
+                    [](const NeuronGroupInternal &ng, size_t) { return std::to_string(ng.getNumNeurons()); });
     }
 }
 

--- a/src/genn/genn/code_generator/modelSpecMerged.cc
+++ b/src/genn/genn/code_generator/modelSpecMerged.cc
@@ -88,6 +88,16 @@ CodeGenerator::ModelSpecMerged::ModelSpecMerged(const ModelSpecInternal &model, 
                        {
                            return ((a.getNumDelaySlots() == b.getNumDelaySlots())
                                    && (a.isSpikeEventRequired() == b.isSpikeEventRequired())
+                                   && (a.isTrueSpikeRequired() == b.isTrueSpikeRequired()));
+                       });
+
+    LOGD_CODE_GEN << "Merging neuron groups which require their previous spike times updating:";
+    createMergedGroups(model, backend, model.getNeuronGroups(), m_MergedNeuronPrevSpikeTimeUpdateGroups,
+                       [](const NeuronGroupInternal &ng){ return (ng.isPrevSpikeTimeRequired() || ng.isPrevSpikeEventTimeRequired()); },
+                       [](const NeuronGroupInternal &a, const NeuronGroupInternal &b)
+                       {
+                           return ((a.getNumDelaySlots() == b.getNumDelaySlots())
+                                   && (a.isSpikeEventRequired() == b.isSpikeEventRequired())
                                    && (a.isTrueSpikeRequired() == b.isTrueSpikeRequired())
                                    && (a.isPrevSpikeTimeRequired() == b.isPrevSpikeTimeRequired())
                                    && (a.isPrevSpikeEventTimeRequired() == b.isPrevSpikeEventTimeRequired()));


### PR DESCRIPTION
In #376 I added support for tracking 'previous' spike times. However, this generated ``preNeuronResetKernel`` code like this:

```c++
if(lid < group->spkCnt[0]) {
    group->prevST[group->spk[lid]] = t - DT;
}
        
if(lid == 0) {
    group->spkCnt[0] = 0;
}
```

Which has a nasty race condition in that the spike count may have been reset by the time other blocks try and access it. Presumably, this wasn't hit in our tests or the Pavlovian conditioning model because they were small enough that the whole kernel ran simultaneously. Better performing (this adds approximately 1.5 microseconds per-timestep to the Pavlovian conditioning model), more complex solutions might be possible but for now I've just split the two stages into two separate kernels which has had the side benefit of tidying up several nasty bits of the previous implementation)