### PR TITLE
Tidied up handling of Extra Global Parameters in PyGeNN

### DIFF
--- a/pygenn/genn_groups.py
+++ b/pygenn/genn_groups.py
@@ -88,7 +88,7 @@ class Group(object):
         egp_name    --  string with the name of the variable
         size        --  number of entries in EGP array
         """
-        self._pull_extra_global_param_to_device(egp_name, size)
+        self._pull_extra_global_param_from_device(egp_name, size)
 
     def push_state_to_device(self):
         """Wrapper around GeNNModel.push_state_to_device"""
@@ -192,9 +192,9 @@ class Group(object):
         self._model.push_extra_global_param_to_device(self.name, egp_name,
                                                       len(egp.values))
 
-    def _pull_extra_global_param_to_device(self, egp_name, size=None,
+    def _pull_extra_global_param_from_device(self, egp_name, size=None,
                                            egp_dict=None):
-        """Wrapper around GeNNModel.pull_extra_global_param_to_device
+        """Wrapper around GeNNModel.pull_extra_global_param_from_device
 
         Args:
         egp_name    --  string with the name of the variable
@@ -898,7 +898,7 @@ class SynapseGroup(Group):
         Args:
         egp_name    --  string with the name of the variable
         """
-        self._pull_extra_global_param_to_device(
+        self._pull_extra_global_param_from_device(
             egp_name, size, egp_dict=self.psm_extra_global_params)
 
     def push_psm_extra_global_param_to_device(self, egp_name):

--- a/pygenn/genn_groups.py
+++ b/pygenn/genn_groups.py
@@ -13,7 +13,7 @@ from six import iteritems, iterkeys, itervalues
 import numpy as np
 from . import genn_wrapper
 from . import model_preprocessor
-from .model_preprocessor import ExtraGlobalVariable, Variable
+from .model_preprocessor import Variable
 from .genn_wrapper import (SynapseMatrixConnectivity_SPARSE,
                            SynapseMatrixConnectivity_BITMASK,
                            SynapseMatrixConnectivity_DENSE,

--- a/pygenn/genn_model.py
+++ b/pygenn/genn_model.py
@@ -46,6 +46,7 @@ from platform import system
 from psutil import cpu_count
 from subprocess import check_call  # to call make
 from textwrap import dedent
+from warnings import warn
 
 # 3rd party imports
 import numpy as np
@@ -721,8 +722,13 @@ class GeNNModel(object):
 
         self._slm.pull_var_from_device(pop_name, var_name)
 
-    def pull_extra_global_param_from_device(self, pop_name, egp_name, size=1):
+    def pull_extra_global_param_from_device(self, pop_name, egp_name, size=None):
         """Pull extra global parameter from the device for a given population"""
+        if size is None:
+            warn("the default of size=1 is very counter-intuitive and "
+                 "will be removed in future", DeprecationWarning)
+            size = 1
+
         if not self._loaded:
             raise Exception("GeNN model has to be loaded before pulling")
 
@@ -763,8 +769,12 @@ class GeNNModel(object):
 
         self._slm.push_var_to_device(pop_name, var_name)
 
-    def push_extra_global_param_to_device(self, pop_name, egp_name, size=1):
+    def push_extra_global_param_to_device(self, pop_name, egp_name, size=None):
         """Push extra global parameter to the device for a given population"""
+        if size is None:
+            warn("the default of size=1 is very counter-intuitive and "
+                 "will be removed in future", DeprecationWarning)
+            size = 1
         if not self._loaded:
             raise Exception("GeNN model has to be loaded before pushing")
 

--- a/pygenn/genn_model.py
+++ b/pygenn/genn_model.py
@@ -615,11 +615,11 @@ class GeNNModel(object):
         # Loop through current sources
         for src_data in itervalues(self.current_sources):
             src_data.load_init_egps()
-        
+
         # Loop through custom updates
         for cu_data in itervalues(self.custom_updates):
             cu_data.load_init_egps()
-            
+
         # Initialize model
         self._slm.initialize()
 
@@ -634,11 +634,11 @@ class GeNNModel(object):
         # Loop through current sources
         for src_data in itervalues(self.current_sources):
             src_data.load()
-        
+
         # Loop through custom updates
         for cu_data in itervalues(self.custom_updates):
             cu_data.load()
-            
+
         # Now everything is set up call the sparse initialisation function
         self._slm.initialize_sparse()
 
@@ -725,7 +725,7 @@ class GeNNModel(object):
     def pull_extra_global_param_from_device(self, pop_name, egp_name, size=None):
         """Pull extra global parameter from the device for a given population"""
         if size is None:
-            warn("the default of size=1 is very counter-intuitive and "
+            warn("The default of size=1 is very counter-intuitive and "
                  "will be removed in future", DeprecationWarning)
             size = 1
 
@@ -772,9 +772,10 @@ class GeNNModel(object):
     def push_extra_global_param_to_device(self, pop_name, egp_name, size=None):
         """Push extra global parameter to the device for a given population"""
         if size is None:
-            warn("the default of size=1 is very counter-intuitive and "
+            warn("The default of size=1 is very counter-intuitive and "
                  "will be removed in future", DeprecationWarning)
             size = 1
+
         if not self._loaded:
             raise Exception("GeNN model has to be loaded before pushing")
 

--- a/pygenn/model_preprocessor.py
+++ b/pygenn/model_preprocessor.py
@@ -46,7 +46,7 @@ def prepare_model(model, group, param_space, var_space, model_family):
     vars = {vnt.name: Variable(vnt.name, vnt.type, var_space[vnt.name], group)
             for vnt in m_instance.get_vars()}
 
-    egps = {egp.name: ExtraGlobalVariable(egp.name, egp.type, group)
+    egps = {egp.name: ExtraGlobalParameter(egp.name, egp.type, group)
             for egp in m_instance.get_extra_global_params()}
 
     return (m_instance, m_type, param_names, params,
@@ -272,9 +272,9 @@ class Variable(object):
             except TypeError:
                 self.init_val = VarInit(values)
 
-class ExtraGlobalVariable(object):
+class ExtraGlobalParameter(object):
 
-    """Class holding information about GeNN extra global pointer variable"""
+    """Class holding information about GeNN extra global parameter"""
 
     def __init__(self, variable_name, variable_type, group, values=None):
         """Init Variable

--- a/pygenn/model_preprocessor.py
+++ b/pygenn/model_preprocessor.py
@@ -4,7 +4,7 @@ This module provides functions for model validation, parameter type conversions
 and defines class Variable
 """
 from numbers import Number
-from weakref import proxy
+from weakref import proxy, ProxyTypes
 import numpy as np
 from six import iterkeys, itervalues
 from . import genn_wrapper
@@ -225,22 +225,19 @@ class Variable(object):
         self.name = variable_name
         self.type = variable_type
         self.group = proxy(group)
-        self.extra_global_params = {}
         self.view = None
         self.needs_allocation = False
         self.set_values(values)
 
     def set_extra_global_init_param(self, param_name, param_values):
-        # Check that this variable is initialised with 
-        if not isinstance(self.init_val, VarInit):
-            raise ValueError("Extra global initialisation parameters can only "
-                             "be set on variables configured using variable "
-                             "initialization snippets")
+        """Set values of extra global parameter associated with
+        variable initialisation snippet
 
-        # Set extra global init params
-        self.group._set_extra_global_param(param_name, param_values, 
-                                           self.init_val.get_snippet(),
-                                           self.extra_global_params)
+        Args
+        param_name      -- string, name of parameter
+        param_values    -- iterable or single value
+        """
+        self.extra_global_params[param_name].set_values(param_values)
 
     def set_values(self, values):
         """Set Variable's values
@@ -252,12 +249,19 @@ class Variable(object):
         # By default variable doesn't need initialising
         self.init_required = False
 
-        # If an var initialiser is specified, set it directly
+        # If an var initialiser is specified
         if isinstance(values, VarInit):
+            # Use it as initial value
             self.init_val = values
+
+            # Build extra global parameters dictionary from var init snippet
+            self.extra_global_params =\
+                {egp.name: ExtraGlobalParameter(egp.name, egp.type, self.group)
+                 for egp in self.init_val.get_snippet().get_extra_global_params()}
         # If no values are specified - mark as uninitialised
         elif values is None:
             self.init_val = genn_wrapper.uninitialised_var()
+            self.extra_global_params = {}
         # Otherwise
         else:
             # Try and iterate values - if they are iterable
@@ -268,9 +272,11 @@ class Variable(object):
                 self.values = np.asarray(
                     values, dtype=self.group._model.genn_types[self.type].np_dtype)
                 self.init_required = True
+                self.extra_global_params = {}
             # Otherwise - they can be initialised on device as a scalar
             except TypeError:
                 self.init_val = VarInit(values)
+                self.extra_global_params = {}
 
 class ExtraGlobalParameter(object):
 
@@ -295,7 +301,7 @@ class ExtraGlobalParameter(object):
             self.is_scalar = True
             self.type = variable_type
 
-        self.group = proxy(group)
+        self.group = group if type(group) in ProxyTypes else proxy(group)
         self.name = variable_name
         self.view = None
         self.set_values(values)


### PR DESCRIPTION
This fixes two issues:

1. You needed to pass the size of extra global parameter arrays to ``Group.pull_extra_global_param_from_device`` and ``Group.push_extra_global_param_to_device`` even though it was already know (#342)
2. When using non-array extra global parameters, you needed to call ``Group.set_extra_global_param`` before you loaded your model in order for them to be accessible via their views later.

I've solved both of these problems by, essentially handling them more like normal variables i.e. populating each group's extra global parameters dictionary from the model as soon as it is created. The ``Group.set_extra_global_param`` style methods simple call the ``set_values`` method on the appropriate ``ExtraGlobalParameter`` object in this dictionary and ``Group.pull_extra_global_param_from_device`` and ``Group.push_extra_global_param_to_device`` use the length of the values array (they shouldn't be used on non-array extra global parameters and this is now checked). I've tried to do this in a backward compatible manner and I think I've succeeded aside from the new requirement that postsynaptic model extra global parameters need to be pushed and pulled via ``SynapseGroup.pull_psm_extra_global_param_from_device`` and ``push_psm_extra_global_param_to_device`` which is pretty niche and thus I think is ok.

Fixes #342
