### PR TITLE
Fixing OpenCL backend for AMD devices

### DIFF
--- a/include/genn/backends/cuda/backend.h
+++ b/include/genn/backends/cuda/backend.h
@@ -172,7 +172,7 @@ public:
     virtual void genDefinitionsPreamble(CodeStream &os, const ModelSpecMerged &modelMerged) const override;
     virtual void genDefinitionsInternalPreamble(CodeStream &os, const ModelSpecMerged &modelMerged) const override;
     virtual void genRunnerPreamble(CodeStream &os, const ModelSpecMerged &modelMerged) const override;
-    virtual void genAllocateMemPreamble(CodeStream &os, const ModelSpecMerged &modelMerged) const override;
+    virtual void genAllocateMemPreamble(CodeStream &os, const ModelSpecMerged &modelMerged, const MemAlloc &allocations) const override;
     virtual void genStepTimeFinalisePreamble(CodeStream &os, const ModelSpecMerged &modelMerged) const override;
 
     virtual void genVariableDefinition(CodeStream &definitions, CodeStream &definitionsInternal, const std::string &type, const std::string &name, VarLocation loc) const override;

--- a/include/genn/backends/cuda/backend.h
+++ b/include/genn/backends/cuda/backend.h
@@ -171,7 +171,7 @@ public:
 
     virtual void genDefinitionsPreamble(CodeStream &os, const ModelSpecMerged &modelMerged) const override;
     virtual void genDefinitionsInternalPreamble(CodeStream &os, const ModelSpecMerged &modelMerged) const override;
-    virtual void genRunnerPreamble(CodeStream &os, const ModelSpecMerged &modelMerged) const override;
+    virtual void genRunnerPreamble(CodeStream &os, const ModelSpecMerged &modelMerged, const MemAlloc &memAlloc) const override;
     virtual void genAllocateMemPreamble(CodeStream &os, const ModelSpecMerged &modelMerged, const MemAlloc &memAlloc) const override;
     virtual void genStepTimeFinalisePreamble(CodeStream &os, const ModelSpecMerged &modelMerged) const override;
 

--- a/include/genn/backends/cuda/backend.h
+++ b/include/genn/backends/cuda/backend.h
@@ -172,12 +172,12 @@ public:
     virtual void genDefinitionsPreamble(CodeStream &os, const ModelSpecMerged &modelMerged) const override;
     virtual void genDefinitionsInternalPreamble(CodeStream &os, const ModelSpecMerged &modelMerged) const override;
     virtual void genRunnerPreamble(CodeStream &os, const ModelSpecMerged &modelMerged) const override;
-    virtual void genAllocateMemPreamble(CodeStream &os, const ModelSpecMerged &modelMerged, const MemAlloc &allocations) const override;
+    virtual void genAllocateMemPreamble(CodeStream &os, const ModelSpecMerged &modelMerged, const MemAlloc &memAlloc) const override;
     virtual void genStepTimeFinalisePreamble(CodeStream &os, const ModelSpecMerged &modelMerged) const override;
 
     virtual void genVariableDefinition(CodeStream &definitions, CodeStream &definitionsInternal, const std::string &type, const std::string &name, VarLocation loc) const override;
     virtual void genVariableImplementation(CodeStream &os, const std::string &type, const std::string &name, VarLocation loc) const override;
-    virtual MemAlloc genVariableAllocation(CodeStream &os, const std::string &type, const std::string &name, VarLocation loc, size_t count) const override;
+    virtual void genVariableAllocation(CodeStream &os, const std::string &type, const std::string &name, VarLocation loc, size_t count, MemAlloc &memAlloc) const override;
     virtual void genVariableFree(CodeStream &os, const std::string &name, VarLocation loc) const override;
 
     virtual void genExtraGlobalParamDefinition(CodeStream &definitions, CodeStream &definitionsInternal, const std::string &type, const std::string &name, VarLocation loc) const override;
@@ -225,9 +225,12 @@ public:
         genCurrentSpikePull(os, ng, batchSize, true);
     }
     
-    virtual MemAlloc genGlobalDeviceRNG(CodeStream &definitions, CodeStream &definitionsInternal, CodeStream &runner, CodeStream &allocations, CodeStream &free) const override;
-    virtual MemAlloc genPopulationRNG(CodeStream &definitions, CodeStream &definitionsInternal, CodeStream &runner,
-                                      CodeStream &allocations, CodeStream &free, const std::string &name, size_t count) const override;
+    virtual void genGlobalDeviceRNG(CodeStream &definitions, CodeStream &definitionsInternal, 
+                                    CodeStream &runner, CodeStream &allocations, CodeStream &free, 
+                                    MemAlloc &memAlloc) const override;
+    virtual void genPopulationRNG(CodeStream &definitions, CodeStream &definitionsInternal, 
+                                  CodeStream &runner, CodeStream &allocations, CodeStream &free, 
+                                  const std::string &name, size_t count, MemAlloc &memAlloc) const override;
     virtual void genTimer(CodeStream &definitions, CodeStream &definitionsInternal, CodeStream &runner,
                           CodeStream &allocations, CodeStream &free, CodeStream &stepTimeFinalise,
                           const std::string &name, bool updateInStepTime) const override;

--- a/include/genn/backends/opencl/backend.h
+++ b/include/genn/backends/opencl/backend.h
@@ -83,10 +83,6 @@ struct Preferences : public PreferencesBase
 
     //! If block size select method is set to BlockSizeSelect::MANUAL, block size to use for each kernel
     KernelBlockSize manualWorkGroupSizes;
-    
-    //! On AMD devices, command queue flushes are inserted after every kernel launch  
-    //! to workaround driver issues. Set this flag to disable this behaviour.
-    bool disableAMDFlush = false;
 };
 
 //--------------------------------------------------------------------------
@@ -305,7 +301,6 @@ private:
                 os << "const cl::NDRange globalWorkSize(1, 1);" << std::endl;
                 os << "const cl::NDRange localWorkSize(1, 1);" << std::endl;
                 os << "CHECK_OPENCL_ERRORS(commandQueue.enqueueNDRangeKernel(" << buildKernelName << ", cl::NullRange, globalWorkSize, localWorkSize));" << std::endl;
-                genPostKernelFlush(os);
             }
         }
 
@@ -429,8 +424,6 @@ private:
 
     //! Build a string called "buildProgramFlags" containing flags to pass to cl::Program::build
     void genBuildProgramFlagsString(CodeStream &os) const;
-
-    void genPostKernelFlush(CodeStream &os) const;
 
     void divideKernelStreamInParts(CodeStream &os, const std::stringstream &kernelCode, size_t partLength) const;
 

--- a/include/genn/backends/opencl/backend.h
+++ b/include/genn/backends/opencl/backend.h
@@ -449,6 +449,7 @@ private:
     //--------------------------------------------------------------------------
     const unsigned int m_ChosenPlatformIndex;
     const unsigned int m_ChosenDeviceIndex;
+    unsigned int m_AllocationAlignementBytes;
     cl::Device m_ChosenDevice;
     cl::Platform m_ChosenPlatform;
 };

--- a/include/genn/backends/opencl/backend.h
+++ b/include/genn/backends/opencl/backend.h
@@ -158,7 +158,7 @@ public:
 
     virtual void genDefinitionsPreamble(CodeStream &os, const ModelSpecMerged &modelMerged) const override;
     virtual void genDefinitionsInternalPreamble(CodeStream &os, const ModelSpecMerged &modelMerged) const override;
-    virtual void genRunnerPreamble(CodeStream &os, const ModelSpecMerged &modelMerged) const override;
+    virtual void genRunnerPreamble(CodeStream &os, const ModelSpecMerged &modelMerged, const MemAlloc &memAlloc) const override;
     virtual void genAllocateMemPreamble(CodeStream &os, const ModelSpecMerged &modelMerged, const MemAlloc &allocations) const override;
     virtual void genStepTimeFinalisePreamble(CodeStream &os, const ModelSpecMerged &modelMerged) const override;
 

--- a/include/genn/backends/opencl/backend.h
+++ b/include/genn/backends/opencl/backend.h
@@ -163,7 +163,7 @@ public:
     virtual void genDefinitionsPreamble(CodeStream &os, const ModelSpecMerged &modelMerged) const override;
     virtual void genDefinitionsInternalPreamble(CodeStream &os, const ModelSpecMerged &modelMerged) const override;
     virtual void genRunnerPreamble(CodeStream &os, const ModelSpecMerged &modelMerged) const override;
-    virtual void genAllocateMemPreamble(CodeStream &os, const ModelSpecMerged &modelMerged) const override;
+    virtual void genAllocateMemPreamble(CodeStream &os, const ModelSpecMerged &modelMerged, const MemAlloc &allocations) const override;
     virtual void genStepTimeFinalisePreamble(CodeStream &os, const ModelSpecMerged &modelMerged) const override;
 
     virtual void genVariableDefinition(CodeStream &definitions, CodeStream &definitionsInternal, const std::string &type, const std::string &name, VarLocation loc) const override;

--- a/include/genn/backends/opencl/backend.h
+++ b/include/genn/backends/opencl/backend.h
@@ -445,6 +445,10 @@ private:
         it would seem, doesn't support some functions e.g. inline PTAX */
     bool isChosenPlatformNVIDIA() const;
 
+    //! Should we make all allocations from sub-buffers?
+    /*! This is required for correct functioning on AMD devices */
+    bool shouldUseSubBufferAllocations() const;
+
     //--------------------------------------------------------------------------
     // Members
     //--------------------------------------------------------------------------

--- a/include/genn/backends/opencl/backend.h
+++ b/include/genn/backends/opencl/backend.h
@@ -168,7 +168,7 @@ public:
 
     virtual void genVariableDefinition(CodeStream &definitions, CodeStream &definitionsInternal, const std::string &type, const std::string &name, VarLocation loc) const override;
     virtual void genVariableImplementation(CodeStream &os, const std::string &type, const std::string &name, VarLocation loc) const override;
-    virtual MemAlloc genVariableAllocation(CodeStream &os, const std::string &type, const std::string &name, VarLocation loc, size_t count) const override;
+    virtual void genVariableAllocation(CodeStream &os, const std::string &type, const std::string &name, VarLocation loc, size_t count, MemAlloc &memAlloc) const override;
     virtual void genVariableFree(CodeStream &os, const std::string &name, VarLocation loc) const override;
 
     virtual void genExtraGlobalParamDefinition(CodeStream &definitions, CodeStream &definitionsInternal, const std::string &type, const std::string &name, VarLocation loc) const override;
@@ -216,9 +216,10 @@ public:
         genCurrentSpikePull(os, ng, batchSize, true);
     }
 
-    virtual MemAlloc genGlobalDeviceRNG(CodeStream &definitions, CodeStream &definitionsInternal, CodeStream &runner, CodeStream &allocations, CodeStream &free) const override;
-    virtual MemAlloc genPopulationRNG(CodeStream &definitions, CodeStream &definitionsInternal, CodeStream &runner,
-                                      CodeStream &allocations, CodeStream &free, const std::string &name, size_t count) const override;
+    virtual void genGlobalDeviceRNG(CodeStream &definitions, CodeStream &definitionsInternal, CodeStream &runner,
+                                    CodeStream &allocations, CodeStream &free, MemAlloc &memAlloc) const override;
+    virtual void genPopulationRNG(CodeStream &definitions, CodeStream &definitionsInternal, CodeStream &runner, CodeStream &allocations,
+                                  CodeStream &free, const std::string &name, size_t count, MemAlloc &memAlloc) const override;
     virtual void genTimer(CodeStream &definitions, CodeStream &definitionsInternal, CodeStream &runner,
                           CodeStream &allocations, CodeStream &free, CodeStream &stepTimeFinalise,
                           const std::string &name, bool updateInStepTime) const override;

--- a/include/genn/backends/single_threaded_cpu/backend.h
+++ b/include/genn/backends/single_threaded_cpu/backend.h
@@ -68,7 +68,7 @@ public:
     virtual void genDefinitionsPreamble(CodeStream &os, const ModelSpecMerged &modelMerged) const override;
     virtual void genDefinitionsInternalPreamble(CodeStream &os, const ModelSpecMerged &modelMerged) const override;
     virtual void genRunnerPreamble(CodeStream &os, const ModelSpecMerged &modelMerged) const override;
-    virtual void genAllocateMemPreamble(CodeStream &os, const ModelSpecMerged &modelMerged) const override;
+    virtual void genAllocateMemPreamble(CodeStream &os, const ModelSpecMerged &modelMerged, const MemAlloc &allocations) const override;
     virtual void genStepTimeFinalisePreamble(CodeStream &os, const ModelSpecMerged &modelMerged) const override;
 
     virtual void genVariableDefinition(CodeStream &definitions, CodeStream &definitionsInternal, const std::string &type, const std::string &name, VarLocation loc) const override;

--- a/include/genn/backends/single_threaded_cpu/backend.h
+++ b/include/genn/backends/single_threaded_cpu/backend.h
@@ -68,12 +68,12 @@ public:
     virtual void genDefinitionsPreamble(CodeStream &os, const ModelSpecMerged &modelMerged) const override;
     virtual void genDefinitionsInternalPreamble(CodeStream &os, const ModelSpecMerged &modelMerged) const override;
     virtual void genRunnerPreamble(CodeStream &os, const ModelSpecMerged &modelMerged) const override;
-    virtual void genAllocateMemPreamble(CodeStream &os, const ModelSpecMerged &modelMerged, const MemAlloc &allocations) const override;
+    virtual void genAllocateMemPreamble(CodeStream &os, const ModelSpecMerged &modelMerged, const MemAlloc &memAlloc) const override;
     virtual void genStepTimeFinalisePreamble(CodeStream &os, const ModelSpecMerged &modelMerged) const override;
 
     virtual void genVariableDefinition(CodeStream &definitions, CodeStream &definitionsInternal, const std::string &type, const std::string &name, VarLocation loc) const override;
     virtual void genVariableImplementation(CodeStream &os, const std::string &type, const std::string &name, VarLocation loc) const override;
-    virtual MemAlloc genVariableAllocation(CodeStream &os, const std::string &type, const std::string &name, VarLocation loc, size_t count) const override;
+    virtual void genVariableAllocation(CodeStream &os, const std::string &type, const std::string &name, VarLocation loc, size_t count, MemAlloc &memAlloc) const override;
     virtual void genVariableFree(CodeStream &os, const std::string &name, VarLocation loc) const override;
 
     virtual void genExtraGlobalParamDefinition(CodeStream &definitions, CodeStream &definitionsInternal, const std::string &type, const std::string &name, VarLocation loc) const override;
@@ -114,9 +114,11 @@ public:
     virtual void genCurrentSpikeLikeEventPush(CodeStream &os, const NeuronGroupInternal &ng, unsigned int batchSize) const override;
     virtual void genCurrentSpikeLikeEventPull(CodeStream &os, const NeuronGroupInternal &ng, unsigned int batchSize) const override;
 
-    virtual MemAlloc genGlobalDeviceRNG(CodeStream &definitions, CodeStream &definitionsInternal, CodeStream &runner, CodeStream &allocations, CodeStream &free) const override;
-    virtual MemAlloc genPopulationRNG(CodeStream &definitions, CodeStream &definitionsInternal, CodeStream &runner, CodeStream &allocations, CodeStream &free,
-                                      const std::string &name, size_t count) const override;
+    virtual void genGlobalDeviceRNG(CodeStream &definitions, CodeStream &definitionsInternal, CodeStream &runner, 
+                                    CodeStream &allocations, CodeStream &free, MemAlloc &memAlloc) const override;
+    virtual void genPopulationRNG(CodeStream &definitions, CodeStream &definitionsInternal, CodeStream &runner, 
+                                  CodeStream &allocations, CodeStream &free,
+                                  const std::string &name, size_t count, MemAlloc &memAlloc) const override;
     virtual void genTimer(CodeStream &definitions, CodeStream &definitionsInternal, CodeStream &runner, CodeStream &allocations, CodeStream &free,
                           CodeStream &stepTimeFinalise, const std::string &name, bool updateInStepTime) const override;
 

--- a/include/genn/backends/single_threaded_cpu/backend.h
+++ b/include/genn/backends/single_threaded_cpu/backend.h
@@ -67,7 +67,7 @@ public:
 
     virtual void genDefinitionsPreamble(CodeStream &os, const ModelSpecMerged &modelMerged) const override;
     virtual void genDefinitionsInternalPreamble(CodeStream &os, const ModelSpecMerged &modelMerged) const override;
-    virtual void genRunnerPreamble(CodeStream &os, const ModelSpecMerged &modelMerged) const override;
+    virtual void genRunnerPreamble(CodeStream &os, const ModelSpecMerged &modelMerged, const MemAlloc &memAlloc) const override;
     virtual void genAllocateMemPreamble(CodeStream &os, const ModelSpecMerged &modelMerged, const MemAlloc &memAlloc) const override;
     virtual void genStepTimeFinalisePreamble(CodeStream &os, const ModelSpecMerged &modelMerged) const override;
 

--- a/include/genn/genn/code_generator/backendBase.h
+++ b/include/genn/genn/code_generator/backendBase.h
@@ -268,7 +268,7 @@ public:
 
     //! Allocate memory is the first function in GeNN generated code called by usercode and it should only ever be called once.
     //! Therefore it's a good place for any global initialisation. This function generates a 'preamble' to this function.
-    virtual void genAllocateMemPreamble(CodeStream &os, const ModelSpecMerged &modelMerged) const = 0;
+    virtual void genAllocateMemPreamble(CodeStream &os, const ModelSpecMerged &modelMerged, const MemAlloc &allocations) const = 0;
 
     //! After all timestep logic is complete
     virtual void genStepTimeFinalisePreamble(CodeStream &os, const ModelSpecMerged &modelMerged) const = 0;

--- a/include/genn/genn/code_generator/backendBase.h
+++ b/include/genn/genn/code_generator/backendBase.h
@@ -268,7 +268,7 @@ public:
 
     //! Allocate memory is the first function in GeNN generated code called by usercode and it should only ever be called once.
     //! Therefore it's a good place for any global initialisation. This function generates a 'preamble' to this function.
-    virtual void genAllocateMemPreamble(CodeStream &os, const ModelSpecMerged &modelMerged, const MemAlloc &allocations) const = 0;
+    virtual void genAllocateMemPreamble(CodeStream &os, const ModelSpecMerged &modelMerged, const MemAlloc &memAlloc) const = 0;
 
     //! After all timestep logic is complete
     virtual void genStepTimeFinalisePreamble(CodeStream &os, const ModelSpecMerged &modelMerged) const = 0;

--- a/include/genn/genn/code_generator/backendBase.h
+++ b/include/genn/genn/code_generator/backendBase.h
@@ -264,7 +264,7 @@ public:
     /*! This will only be included by the platform-specific compiler used to build this backend so can include platform-specific types or headers*/
     virtual void genDefinitionsInternalPreamble(CodeStream &os, const ModelSpecMerged &modelMerged) const = 0;
 
-    virtual void genRunnerPreamble(CodeStream &os, const ModelSpecMerged &modelMerged) const = 0;
+    virtual void genRunnerPreamble(CodeStream &os, const ModelSpecMerged &modelMerged, const MemAlloc &memAlloc) const = 0;
 
     //! Allocate memory is the first function in GeNN generated code called by usercode and it should only ever be called once.
     //! Therefore it's a good place for any global initialisation. This function generates a 'preamble' to this function.

--- a/include/genn/genn/code_generator/backendBase.h
+++ b/include/genn/genn/code_generator/backendBase.h
@@ -275,7 +275,7 @@ public:
 
     virtual void genVariableDefinition(CodeStream &definitions, CodeStream &definitionsInternal, const std::string &type, const std::string &name, VarLocation loc) const = 0;
     virtual void genVariableImplementation(CodeStream &os, const std::string &type, const std::string &name, VarLocation loc) const = 0;
-    virtual MemAlloc genVariableAllocation(CodeStream &os, const std::string &type, const std::string &name, VarLocation loc, size_t count) const = 0;
+    virtual void genVariableAllocation(CodeStream &os, const std::string &type, const std::string &name, VarLocation loc, size_t count, MemAlloc &memAlloc) const = 0;
     virtual void genVariableFree(CodeStream &os, const std::string &name, VarLocation loc) const = 0;
 
     virtual void genExtraGlobalParamDefinition(CodeStream &definitions, CodeStream &definitionsInternal, const std::string &type, const std::string &name, VarLocation loc) const = 0;
@@ -332,11 +332,12 @@ public:
 
     //! Generate a single RNG instance
     /*! On single-threaded platforms this can be a standard RNG like M.T. but, on parallel platforms, it is likely to be a counter-based RNG */
-    virtual MemAlloc genGlobalDeviceRNG(CodeStream &definitions, CodeStream &definitionsInternal, CodeStream &runner, CodeStream &allocations, CodeStream &free) const = 0;
+    virtual void genGlobalDeviceRNG(CodeStream &definitions, CodeStream &definitionsInternal, CodeStream &runner,
+                                    CodeStream &allocations, CodeStream &free, MemAlloc &memAlloc) const = 0;
 
     //! Generate an RNG with a state per population member
-    virtual MemAlloc genPopulationRNG(CodeStream &definitions, CodeStream &definitionsInternal, CodeStream &runner, CodeStream &allocations, CodeStream &free,
-                                      const std::string &name, size_t count) const = 0;
+    virtual void genPopulationRNG(CodeStream &definitions, CodeStream &definitionsInternal, CodeStream &runner, CodeStream &allocations,
+                                  CodeStream &free, const std::string &name, size_t count, MemAlloc &memAlloc) const = 0;
 
     virtual void genTimer(CodeStream &definitions, CodeStream &definitionsInternal, CodeStream &runner, CodeStream &allocations, CodeStream &free,
                           CodeStream &stepTimeFinalise, const std::string &name, bool updateInStepTime) const = 0;
@@ -437,13 +438,13 @@ public:
     }
 
     //! Helper function to generate matching definition, declaration, allocation and free code for an array
-    MemAlloc genArray(CodeStream &definitions, CodeStream &definitionsInternal, CodeStream &runner, CodeStream &allocations, CodeStream &free,
-                      const std::string &type, const std::string &name, VarLocation loc, size_t count) const
+    void genArray(CodeStream &definitions, CodeStream &definitionsInternal, CodeStream &runner, CodeStream &allocations, CodeStream &free,
+                  const std::string &type, const std::string &name, VarLocation loc, size_t count, MemAlloc &memAlloc) const
     {
         genVariableDefinition(definitions, definitionsInternal, type + "*", name, loc);
         genVariableImplementation(runner, type + "*", name, loc);
         genVariableFree(free, name, loc);
-        return genVariableAllocation(allocations, type, name, loc, count);
+        genVariableAllocation(allocations, type, name, loc, count, memAlloc);
     }
 
     //! Get the size of the type

--- a/include/genn/genn/code_generator/modelSpecMerged.h
+++ b/include/genn/genn/code_generator/modelSpecMerged.h
@@ -178,6 +178,9 @@ public:
     const std::string &getPostsynapticUpdateSupportCodeNamespace(const std::string &code) const{ return m_PostsynapticUpdateSupportCode.getSupportCodeNamespace(code); }
     const std::string &getSynapseDynamicsSupportCodeNamespace(const std::string &code) const{ return m_SynapseDynamicsSupportCode.getSupportCodeNamespace(code); }
 
+    //! Does model have any EGPs?
+    bool anyPointerEGPs() const;
+
     //! Get the map of destinations within the merged data structures for a particular extra global parameter
     const MergedEGPDestinations &getMergedEGPDestinations(const std::string &name, const BackendBase &backend) const
     {

--- a/src/genn/backends/cuda/backend.cc
+++ b/src/genn/backends/cuda/backend.cc
@@ -1254,19 +1254,17 @@ void Backend::genVariableImplementation(CodeStream &os, const std::string &type,
     }
 }
 //--------------------------------------------------------------------------
-MemAlloc Backend::genVariableAllocation(CodeStream &os, const std::string &type, const std::string &name, VarLocation loc, size_t count) const
+void Backend::genVariableAllocation(CodeStream &os, const std::string &type, const std::string &name, VarLocation loc, size_t count, MemAlloc &memAlloc) const
 {
-    auto allocation = MemAlloc::zero();
-
     if(getPreferences().automaticCopy) {
         os << "CHECK_CUDA_ERRORS(cudaMallocManaged(&" << name << ", " << count << " * sizeof(" << type << ")));" << std::endl;
-        allocation += MemAlloc::device(count * getSize(type));
+        memAlloc += MemAlloc::device(count * getSize(type));
     }
     else {
         if(loc & VarLocation::HOST) {
             const char *flags = (loc & VarLocation::ZERO_COPY) ? "cudaHostAllocMapped" : "cudaHostAllocPortable";
             os << "CHECK_CUDA_ERRORS(cudaHostAlloc(&" << name << ", " << count << " * sizeof(" << type << "), " << flags << "));" << std::endl;
-            allocation += MemAlloc::host(count * getSize(type));
+            memAlloc += MemAlloc::host(count * getSize(type));
         }
 
         // If variable is present on device at all
@@ -1274,16 +1272,14 @@ MemAlloc Backend::genVariableAllocation(CodeStream &os, const std::string &type,
             // Insert call to correct helper depending on whether variable should be allocated in zero-copy mode or not
             if(loc & VarLocation::ZERO_COPY) {
                 os << "CHECK_CUDA_ERRORS(cudaHostGetDevicePointer((void **)&d_" << name << ", (void *)" << name << ", 0));" << std::endl;
-                allocation += MemAlloc::zeroCopy(count * getSize(type));
+                memAlloc += MemAlloc::zeroCopy(count * getSize(type));
             }
             else {
                 os << "CHECK_CUDA_ERRORS(cudaMalloc(&d_" << name << ", " << count << " * sizeof(" << type << ")));" << std::endl;
-                allocation += MemAlloc::device(count * getSize(type));
+                memAlloc += MemAlloc::device(count * getSize(type));
             }
         }
     }
-
-    return allocation;
 }
 //--------------------------------------------------------------------------
 void Backend::genVariableFree(CodeStream &os, const std::string &name, VarLocation loc) const
@@ -1507,7 +1503,7 @@ void Backend::genCurrentVariablePull(CodeStream &os, const NeuronGroupInternal &
     }
 }
 //--------------------------------------------------------------------------
-MemAlloc Backend::genGlobalDeviceRNG(CodeStream &, CodeStream &definitionsInternal, CodeStream &runner, CodeStream &, CodeStream &) const
+void Backend::genGlobalDeviceRNG(CodeStream &, CodeStream &definitionsInternal, CodeStream &runner, CodeStream &, CodeStream &, MemAlloc &memAlloc) const
 {
     // Define global Phillox RNG
     // **NOTE** this is actually accessed as a global so, unlike other variables, needs device global
@@ -1516,14 +1512,14 @@ MemAlloc Backend::genGlobalDeviceRNG(CodeStream &, CodeStream &definitionsIntern
     // Implement global Phillox RNG
     runner << "__device__ curandStatePhilox4_32_10_t d_rng;" << std::endl;
 
-    return MemAlloc::device(getSize("curandStatePhilox4_32_10_t"));
+    memAlloc += MemAlloc::device(getSize("curandStatePhilox4_32_10_t"));
 }
 //--------------------------------------------------------------------------
-MemAlloc Backend::genPopulationRNG(CodeStream &definitions, CodeStream &definitionsInternal, CodeStream &runner, CodeStream &allocations, CodeStream &free,
-                                   const std::string &name, size_t count) const
+void Backend::genPopulationRNG(CodeStream &definitions, CodeStream &definitionsInternal, CodeStream &runner, CodeStream &allocations, CodeStream &free,
+                                   const std::string &name, size_t count, MemAlloc &memAlloc) const
 {
     // Create an array or XORWOW RNGs
-    return genArray(definitions, definitionsInternal, runner, allocations, free, "curandState", name, VarLocation::DEVICE, count);
+    genArray(definitions, definitionsInternal, runner, allocations, free, "curandState", name, VarLocation::DEVICE, count, memAlloc);
 }
 //--------------------------------------------------------------------------
 void Backend::genTimer(CodeStream &, CodeStream &definitionsInternal, CodeStream &runner, CodeStream &allocations, CodeStream &free,

--- a/src/genn/backends/cuda/backend.cc
+++ b/src/genn/backends/cuda/backend.cc
@@ -1124,7 +1124,7 @@ void Backend::genDefinitionsInternalPreamble(CodeStream &os, const ModelSpecMerg
     os << std::endl;
 }
 //--------------------------------------------------------------------------
-void Backend::genRunnerPreamble(CodeStream &os, const ModelSpecMerged &) const
+void Backend::genRunnerPreamble(CodeStream &os, const ModelSpecMerged&, const MemAlloc&) const
 {
 #ifdef _WIN32
     // **YUCK** on Windows, disable "function assumed not to throw an exception but does" warning

--- a/src/genn/backends/cuda/backend.cc
+++ b/src/genn/backends/cuda/backend.cc
@@ -1111,7 +1111,7 @@ void Backend::genRunnerPreamble(CodeStream &os, const ModelSpecMerged &) const
 #endif
 }
 //--------------------------------------------------------------------------
-void Backend::genAllocateMemPreamble(CodeStream &os, const ModelSpecMerged &modelMerged) const
+void Backend::genAllocateMemPreamble(CodeStream &os, const ModelSpecMerged &modelMerged, const MemAlloc&) const
 {
     // If the model requires zero-copy
     if(modelMerged.getModel().zeroCopyInUse()) {

--- a/src/genn/backends/opencl/backend.cc
+++ b/src/genn/backends/opencl/backend.cc
@@ -2155,8 +2155,14 @@ void Backend::genTimer(CodeStream&, CodeStream &definitionsInternal, CodeStream 
 //--------------------------------------------------------------------------
 void Backend::genReturnFreeDeviceMemoryBytes(CodeStream &os) const
 {
-    // **NOTE** OpenCL does not have this functionality
-    os << "return 0;" << std::endl;
+    // If device is AMD, use extension to get free device memory
+    if(isChosenDeviceAMD()) {
+        return "return CHECK_OPENCL_ERRORS_POINTER(clDevice.getInfo<CL_DEVICE_GLOBAL_FREE_MEMORY_AMD>(&error));"
+    }
+    // Otherwise, return 0 as vanilla OpenCL doesn't have this functionality
+    else {
+        os << "return 0;" << std::endl;
+    }
 }
 //--------------------------------------------------------------------------
 void Backend::genMakefilePreamble(std::ostream &os) const

--- a/src/genn/backends/opencl/backend.cc
+++ b/src/genn/backends/opencl/backend.cc
@@ -2157,7 +2157,12 @@ void Backend::genReturnFreeDeviceMemoryBytes(CodeStream &os) const
 {
     // If device is AMD, use extension to get free device memory
     if(isChosenDeviceAMD()) {
-        return "return CHECK_OPENCL_ERRORS_POINTER(clDevice.getInfo<CL_DEVICE_GLOBAL_FREE_MEMORY_AMD>(&error));"
+        // CL_DEVICE_GLOBAL_FREE_MEMORY_AMD = 0x4039
+        // **NOTE** http://manpages.ubuntu.com/manpages/bionic/man1/clinfo.1.html and https://github.com/Oblomov/clinfo/blob/master/src/clinfo.c#L1406-L1411 suggest that, with newer drivers, you can also get maximum block size by requesting 128 bits of data here
+        // **YUCK** https://www.khronos.org/registry/OpenCL/extensions/amd/cl_amd_device_attribute_query.txt suggests this should be in KBytes but it doesn't seem to be in bytes
+        os << "cl_ulong freeMem;" << std::endl;
+        os << "CHECK_OPENCL_ERRORS(clDevice.getInfo(0x4039, &freeMem));" << std::endl;
+        os << "return freeMem;" << std::endl;
     }
     // Otherwise, return 0 as vanilla OpenCL doesn't have this functionality
     else {

--- a/src/genn/backends/opencl/backend.cc
+++ b/src/genn/backends/opencl/backend.cc
@@ -1479,7 +1479,7 @@ void Backend::genRunnerPreamble(CodeStream &os, const ModelSpecMerged &modelMerg
     os << std::endl;
 }
 //--------------------------------------------------------------------------
-void Backend::genAllocateMemPreamble(CodeStream &os, const ModelSpecMerged &modelMerged) const
+void Backend::genAllocateMemPreamble(CodeStream &os, const ModelSpecMerged &modelMerged, const MemAlloc &allocations) const
 {
     // Initializing OpenCL programs
     os << "// Get platforms" << std::endl;

--- a/src/genn/backends/opencl/backend.cc
+++ b/src/genn/backends/opencl/backend.cc
@@ -147,15 +147,19 @@ Backend::Backend(const KernelBlockSize &kernelBlockSizes, const Preferences &pre
     LOGI_BACKEND << "Using OpenCL device:" << m_ChosenDevice.getInfo<CL_DEVICE_NAME>();
     
     if(isChosenDeviceAMD()) {
-        LOGI_BACKEND << "Detected as an AMD device" << std::endl;
+        LOGI_BACKEND << "Detected as an AMD device";
     }
     else if(isChosenDeviceNVIDIA()) {
-        LOGI_BACKEND << "Detected as an NVIDIA device" << std::endl;
+        LOGI_BACKEND << "Detected as an NVIDIA device";
     }
     // Set pointer size
     const cl_int deviceAddressBytes = m_ChosenDevice.getInfo<CL_DEVICE_ADDRESS_BITS>() / 8;
     setPointerBytes(deviceAddressBytes);
     LOGI_BACKEND << "Device uses " << deviceAddressBytes * 8 << " bit pointers";
+
+    // Determine minimum alignement
+    m_AllocationAlignementBytes = m_ChosenDevice.getInfo<CL_DEVICE_MEM_BASE_ADDR_ALIGN>() / 8;
+    LOGI_BACKEND << "Device uses " << m_AllocationAlignementBytes << " byte alignement";
 
     // Add OpenCL-specific types
     addType("clrngLfsr113Stream", 16);

--- a/src/genn/backends/opencl/backend.cc
+++ b/src/genn/backends/opencl/backend.cc
@@ -1427,7 +1427,7 @@ void Backend::genDefinitionsInternalPreamble(CodeStream &os, const ModelSpecMerg
     os << std::endl;
 }
 //--------------------------------------------------------------------------
-void Backend::genRunnerPreamble(CodeStream &os, const ModelSpecMerged &modelMerged) const
+void Backend::genRunnerPreamble(CodeStream &os, const ModelSpecMerged &modelMerged, const MemAlloc &memAlloc) const
 {
 #ifdef _WIN32
     os << "#include <windows.h>" << std::endl;

--- a/src/genn/backends/opencl/backend.cc
+++ b/src/genn/backends/opencl/backend.cc
@@ -162,7 +162,7 @@ Backend::Backend(const KernelBlockSize &kernelBlockSizes, const Preferences &pre
     LOGI_BACKEND << "Device uses " << m_AllocationAlignementBytes << " byte alignement";
 
     // Add OpenCL-specific types
-    addType("clrngLfsr113Stream", 16);
+    addType("clrngLfsr113Stream", 48);
     addType("clrngPhilox432Stream", 132);
 }
 //--------------------------------------------------------------------------
@@ -1010,7 +1010,7 @@ void Backend::genCustomUpdate(CodeStream &os, const ModelSpecMerged &modelMerged
                     setMergedGroupKernelParams(os, KernelNames[KernelCustomUpdate] + g.first, modelMerged.getMergedCustomUpdateGroups(), start);
                     setMergedGroupKernelParams(os, KernelNames[KernelCustomUpdate] + g.first, modelMerged.getMergedCustomUpdateWUGroups(), start);
                     if(shouldUseSubBufferAllocations()) {
-                        os << "CHECK_OPENCL_ERRORS(" << KernelNames[KernelCustomUpdate] << ".setArg(" << (start + 1) << ", d_staticBuffer));" << std::endl;
+                        os << "CHECK_OPENCL_ERRORS(" << KernelNames[KernelCustomUpdate] << g.first << ".setArg(" << (start + 1) << ", d_staticBuffer));" << std::endl;
                     }
                 }
 
@@ -1019,7 +1019,7 @@ void Backend::genCustomUpdate(CodeStream &os, const ModelSpecMerged &modelMerged
 
                     setMergedGroupKernelParams(os, KernelNames[KernelCustomTransposeUpdate] + g.first, modelMerged.getMergedCustomUpdateTransposeWUGroups());
                     if(shouldUseSubBufferAllocations()) {
-                        os << "CHECK_OPENCL_ERRORS(" << KernelNames[KernelCustomTransposeUpdate] << ".setArg(" << (modelMerged.getMergedCustomUpdateTransposeWUGroups().size() + 1) << ", d_staticBuffer));" << std::endl;
+                        os << "CHECK_OPENCL_ERRORS(" << KernelNames[KernelCustomTransposeUpdate] << g.first << ".setArg(" << (modelMerged.getMergedCustomUpdateTransposeWUGroups().size() + 1) << ", d_staticBuffer));" << std::endl;
                     }
                 }
                 os << std::endl;

--- a/src/genn/backends/single_threaded_cpu/backend.cc
+++ b/src/genn/backends/single_threaded_cpu/backend.cc
@@ -1073,7 +1073,7 @@ void Backend::genDefinitionsInternalPreamble(CodeStream &os, const ModelSpecMerg
     os << std::endl;
 }
 //--------------------------------------------------------------------------
-void Backend::genRunnerPreamble(CodeStream &os, const ModelSpecMerged &modelMerged) const
+void Backend::genRunnerPreamble(CodeStream &os, const ModelSpecMerged &modelMerged, const MemAlloc&) const
 {
     const ModelSpecInternal &model = modelMerged.getModel();
 

--- a/src/genn/backends/single_threaded_cpu/backend.cc
+++ b/src/genn/backends/single_threaded_cpu/backend.cc
@@ -1075,7 +1075,7 @@ void Backend::genRunnerPreamble(CodeStream &os, const ModelSpecMerged &modelMerg
     os << std::endl;
 }
 //--------------------------------------------------------------------------
-void Backend::genAllocateMemPreamble(CodeStream&, const ModelSpecMerged&) const
+void Backend::genAllocateMemPreamble(CodeStream&, const ModelSpecMerged&, const MemAlloc&) const
 {
 }
 //--------------------------------------------------------------------------

--- a/src/genn/backends/single_threaded_cpu/backend.cc
+++ b/src/genn/backends/single_threaded_cpu/backend.cc
@@ -1105,11 +1105,11 @@ void Backend::genVariableImplementation(CodeStream &os, const std::string &type,
     os << type << " " << name << ";" << std::endl;
 }
 //--------------------------------------------------------------------------
-MemAlloc Backend::genVariableAllocation(CodeStream &os, const std::string &type, const std::string &name, VarLocation, size_t count) const
+void Backend::genVariableAllocation(CodeStream &os, const std::string &type, const std::string &name, VarLocation, size_t count, MemAlloc &memAlloc) const
 {
     os << name << " = new " << type << "[" << count << "];" << std::endl;
 
-    return MemAlloc::host(count * getSize(type));
+    memAlloc += MemAlloc::host(count * getSize(type));
 }
 //--------------------------------------------------------------------------
 void Backend::genVariableFree(CodeStream &os, const std::string &name, VarLocation) const
@@ -1256,17 +1256,14 @@ void Backend::genCurrentSpikeLikeEventPull(CodeStream&, const NeuronGroupInterna
     assert(!getPreferences().automaticCopy);
 }
 //--------------------------------------------------------------------------
-MemAlloc Backend::genGlobalDeviceRNG(CodeStream &, CodeStream &, CodeStream &, CodeStream &, CodeStream &) const
+void Backend::genGlobalDeviceRNG(CodeStream&, CodeStream&, CodeStream&, CodeStream&, CodeStream&, MemAlloc&) const
 {
     assert(false);
-    return MemAlloc::host(0);
 }
 //--------------------------------------------------------------------------
-MemAlloc Backend::genPopulationRNG(CodeStream &, CodeStream &, CodeStream &, CodeStream &, CodeStream &,
-                                   const std::string&, size_t) const
+void Backend::genPopulationRNG(CodeStream&, CodeStream&, CodeStream&, CodeStream&, CodeStream&,
+                                   const std::string&, size_t, MemAlloc&) const
 {
-    // No need for population RNGs for single-threaded CPU
-    return MemAlloc::zero();
 }
 //--------------------------------------------------------------------------
 void Backend::genTimer(CodeStream &, CodeStream &, CodeStream &, CodeStream &, CodeStream &, CodeStream &, const std::string &, bool) const

--- a/src/genn/genn/code_generator/generateRunner.cc
+++ b/src/genn/genn/code_generator/generateRunner.cc
@@ -79,20 +79,17 @@ void genHostScalar(CodeStream &definitionsVar, CodeStream &runnerVarDecl, const 
     runnerVarDecl << type << " " << name << " = " << value << ";" << std::endl;
 }
 //--------------------------------------------------------------------------
-MemAlloc genHostDeviceScalar(const BackendBase &backend, CodeStream &definitionsVar, CodeStream &definitionsInternalVar, 
+void genHostDeviceScalar(const BackendBase &backend, CodeStream &definitionsVar, CodeStream &definitionsInternalVar,
                          CodeStream &runnerVarDecl, CodeStream &runnerVarAlloc, CodeStream &runnerVarFree,
-                         const std::string &type, const std::string &name, const std::string &hostValue)
+                         const std::string &type, const std::string &name, const std::string &hostValue, MemAlloc &mem)
 {
     // Generate a host scalar
     genHostScalar(definitionsVar, runnerVarDecl, type, name, hostValue);
 
     // Generate a single-element array on device
     if(backend.isDeviceScalarRequired()) {
-        return backend.genArray(definitionsVar, definitionsInternalVar, runnerVarDecl, runnerVarAlloc, runnerVarFree,
-                                type, name, VarLocation::DEVICE, 1);
-    }
-    else {
-        return MemAlloc::zero();
+        backend.genArray(definitionsVar, definitionsInternalVar, runnerVarDecl, runnerVarAlloc, runnerVarFree,
+                                type, name, VarLocation::DEVICE, 1, mem);
     }
 }
 //--------------------------------------------------------------------------
@@ -204,7 +201,6 @@ void genSpikeGetters(CodeStream &definitionsFunc, CodeStream &runnerGetterFunc,
                               else {
                                   runnerGetterFunc << "batch";
                               }
-                              
                           }
                           runnerGetterFunc << "];" << std::endl;
                       });
@@ -240,10 +236,11 @@ void genStatePushPull(CodeStream &definitionsFunc, CodeStream &runnerPushFunc, C
     }
 }
 //-------------------------------------------------------------------------
-MemAlloc genVariable(const BackendBase &backend, CodeStream &definitionsVar, CodeStream &definitionsFunc,
+void genVariable(const BackendBase &backend, CodeStream &definitionsVar, CodeStream &definitionsFunc,
                      CodeStream &definitionsInternal, CodeStream &runner, CodeStream &allocations, CodeStream &free,
                      CodeStream &push, CodeStream &pull, const std::string &type, const std::string &name,
-                     VarLocation loc, bool autoInitialized, size_t count, std::vector<std::string> &statePushPullFunction)
+                     VarLocation loc, bool autoInitialized, size_t count, MemAlloc &mem,
+                     std::vector<std::string> &statePushPullFunction)
 {
     // Generate push and pull functions
     genVarPushPullScope(definitionsFunc, push, pull, loc, backend.getPreferences().automaticCopy, name, statePushPullFunction,
@@ -253,8 +250,8 @@ MemAlloc genVariable(const BackendBase &backend, CodeStream &definitionsVar, Cod
         });
 
     // Generate variables
-    return backend.genArray(definitionsVar, definitionsInternal, runner, allocations, free,
-                            type, name, loc, count);
+    backend.genArray(definitionsVar, definitionsInternal, runner, allocations, free,
+                     type, name, loc, count, mem);
 }
 //-------------------------------------------------------------------------
 void genExtraGlobalParam(const ModelSpecMerged &modelMerged, const BackendBase &backend, CodeStream &definitionsVar,
@@ -321,8 +318,8 @@ void genExtraGlobalParam(const ModelSpecMerged &modelMerged, const BackendBase &
     }
 }
 //-------------------------------------------------------------------------
-MemAlloc genGlobalHostRNG(CodeStream &definitionsVar, CodeStream &runnerVarDecl,
-                          CodeStream &runnerVarAlloc, unsigned int seed)
+void genGlobalHostRNG(CodeStream &definitionsVar, CodeStream &runnerVarDecl,
+                      CodeStream &runnerVarAlloc, unsigned int seed, MemAlloc &mem)
 {
     definitionsVar << "EXPORT_VAR " << "std::mt19937 hostRNG;" << std::endl;
     runnerVarDecl << "std::mt19937 hostRNG;" << std::endl;
@@ -349,7 +346,7 @@ MemAlloc genGlobalHostRNG(CodeStream &definitionsVar, CodeStream &runnerVarDecl,
     runnerVarAlloc << "hostRNG.seed(seeds);" << std::endl;
 
     // Add size of Mersenne Twister to memory tracker
-    return MemAlloc::host(sizeof(std::mt19937));
+    mem += MemAlloc::host(sizeof(std::mt19937));
 }
 //-------------------------------------------------------------------------
 void genSynapseConnectivityHostInit(const BackendBase &backend, CodeStream &os, 
@@ -437,9 +434,9 @@ void genCustomUpdate(const ModelSpecMerged &modelMerged, const BackendBase &back
             const auto *varInitSnippet = c.second.getVarInitialisers()[i].getSnippet();
             const unsigned int numCopies = c.second.isBatched() ? getNumCopies(cuVars[i].access, modelMerged.getModel().getBatchSize()) : 1;
             const bool autoInitialized = !varInitSnippet->getCode().empty();
-            mem += genVariable(backend, definitionsVar, definitionsFunc, definitionsInternalVar, runnerVarDecl, runnerVarAlloc, runnerVarFree,
-                                runnerPushFunc, runnerPullFunc, cuVars[i].type, cuVars[i].name + c.first, c.second.getVarLocation(i),
-                                autoInitialized, numCopies * getSizeFn(c.second), customUpdateStatePushPullFunctions);
+            genVariable(backend, definitionsVar, definitionsFunc, definitionsInternalVar, runnerVarDecl, runnerVarAlloc, runnerVarFree,
+                        runnerPushFunc, runnerPullFunc, cuVars[i].type, cuVars[i].name + c.first, c.second.getVarLocation(i),
+                        autoInitialized, numCopies * getSizeFn(c.second), mem, customUpdateStatePushPullFunctions);
 
             // Loop through EGPs required to initialize custom update variable
             const auto extraGlobalParams = varInitSnippet->getExtraGlobalParams();
@@ -577,11 +574,11 @@ MemAlloc CodeGenerator::generateRunner(CodeStream &definitions, CodeStream &defi
     }
     // If backend requires a global device RNG to simulate (or initialize) this model
     if(backend.isGlobalDeviceRNGRequired(modelMerged)) {
-        mem += backend.genGlobalDeviceRNG(definitionsVar, definitionsInternalVar, runnerVarDecl, runnerVarAlloc, runnerVarFree);
+        backend.genGlobalDeviceRNG(definitionsVar, definitionsInternalVar, runnerVarDecl, runnerVarAlloc, runnerVarFree, mem);
     }
     // If backend required a global host RNG to simulate (or initialize) this model, generate a standard Mersenne Twister
     if(backend.isGlobalHostRNGRequired(modelMerged)) {
-        mem += genGlobalHostRNG(definitionsVar, runnerVarDecl, runnerVarAlloc, model.getSeed());
+        genGlobalHostRNG(definitionsVar, runnerVarDecl, runnerVarAlloc, model.getSeed(), mem);
     }
     allVarStreams << std::endl;
 
@@ -803,10 +800,10 @@ MemAlloc CodeGenerator::generateRunner(CodeStream &definitions, CodeStream &defi
         const size_t numNeuronDelaySlots = batchSize * (size_t)n.second.getNumNeurons() * (size_t)n.second.getNumDelaySlots();
         const size_t numSpikeCounts = n.second.isTrueSpikeRequired() ? (batchSize * n.second.getNumDelaySlots()) : batchSize;
         const size_t numSpikes = n.second.isTrueSpikeRequired() ? numNeuronDelaySlots : (batchSize * n.second.getNumNeurons());
-        mem += backend.genArray(definitionsVar, definitionsInternalVar, runnerVarDecl, runnerVarAlloc, runnerVarFree,
-                                "unsigned int", "glbSpkCnt" + n.first, n.second.getSpikeLocation(), numSpikeCounts);
-        mem += backend.genArray(definitionsVar, definitionsInternalVar, runnerVarDecl, runnerVarAlloc, runnerVarFree,
-                                "unsigned int", "glbSpk" + n.first, n.second.getSpikeLocation(), numSpikes);
+        backend.genArray(definitionsVar, definitionsInternalVar, runnerVarDecl, runnerVarAlloc, runnerVarFree,
+                         "unsigned int", "glbSpkCnt" + n.first, n.second.getSpikeLocation(), numSpikeCounts, mem);
+        backend.genArray(definitionsVar, definitionsInternalVar, runnerVarDecl, runnerVarAlloc, runnerVarFree,
+                         "unsigned int", "glbSpk" + n.first, n.second.getSpikeLocation(), numSpikes, mem);
 
         // True spike push and pull functions
         genVarPushPullScope(definitionsFunc, runnerPushFunc, runnerPullFunc, n.second.getSpikeLocation(),
@@ -846,12 +843,12 @@ MemAlloc CodeGenerator::generateRunner(CodeStream &definitions, CodeStream &defi
             }
 
             // Spike-like event variables
-            mem += backend.genArray(definitionsVar, definitionsInternalVar, runnerVarDecl, runnerVarAlloc, runnerVarFree,
-                                    "unsigned int", "glbSpkCntEvnt" + n.first, n.second.getSpikeEventLocation(),
-                                    batchSize * n.second.getNumDelaySlots());
-            mem += backend.genArray(definitionsVar, definitionsInternalVar, runnerVarDecl, runnerVarAlloc, runnerVarFree,
-                                    "unsigned int", "glbSpkEvnt" + n.first, n.second.getSpikeEventLocation(),
-                                    numNeuronDelaySlots);
+            backend.genArray(definitionsVar, definitionsInternalVar, runnerVarDecl, runnerVarAlloc, runnerVarFree,
+                             "unsigned int", "glbSpkCntEvnt" + n.first, n.second.getSpikeEventLocation(),
+                             batchSize * n.second.getNumDelaySlots(), mem);
+            backend.genArray(definitionsVar, definitionsInternalVar, runnerVarDecl, runnerVarAlloc, runnerVarFree,
+                             "unsigned int", "glbSpkEvnt" + n.first, n.second.getSpikeEventLocation(),
+                              numNeuronDelaySlots, mem);
 
             // Spike-like event push and pull functions
             genVarPushPullScope(definitionsFunc, runnerPushFunc, runnerPullFunc, n.second.getSpikeEventLocation(),
@@ -886,15 +883,15 @@ MemAlloc CodeGenerator::generateRunner(CodeStream &definitions, CodeStream &defi
 
         // If neuron group has axonal delays
         if (n.second.isDelayRequired()) {
-            mem += genHostDeviceScalar(backend, definitionsVar, definitionsInternalVar, runnerVarDecl, runnerVarAlloc, runnerVarFree,
-                                       "unsigned int", "spkQuePtr" + n.first, "0");
+            genHostDeviceScalar(backend, definitionsVar, definitionsInternalVar, runnerVarDecl, runnerVarAlloc, runnerVarFree,
+                                "unsigned int", "spkQuePtr" + n.first, "0", mem);
         }
 
         // If neuron group needs to record its spike times
         if (n.second.isSpikeTimeRequired()) {
-            mem += backend.genArray(definitionsVar, definitionsInternalVar, runnerVarDecl, runnerVarAlloc, runnerVarFree,
-                                    model.getTimePrecision(), "sT" + n.first, n.second.getSpikeTimeLocation(),
-                                    numNeuronDelaySlots);
+            backend.genArray(definitionsVar, definitionsInternalVar, runnerVarDecl, runnerVarAlloc, runnerVarFree,
+                             model.getTimePrecision(), "sT" + n.first, n.second.getSpikeTimeLocation(),
+                             numNeuronDelaySlots, mem);
 
             // Generate push and pull functions
             genVarPushPullScope(definitionsFunc, runnerPushFunc, runnerPullFunc, n.second.getSpikeTimeLocation(),
@@ -909,9 +906,9 @@ MemAlloc CodeGenerator::generateRunner(CodeStream &definitions, CodeStream &defi
 
         // If neuron group needs to record its previous spike times
         if (n.second.isPrevSpikeTimeRequired()) {
-            mem += backend.genArray(definitionsVar, definitionsInternalVar, runnerVarDecl, runnerVarAlloc, runnerVarFree,
-                                    model.getTimePrecision(), "prevST" + n.first, n.second.getPrevSpikeTimeLocation(),
-                                    numNeuronDelaySlots);
+            backend.genArray(definitionsVar, definitionsInternalVar, runnerVarDecl, runnerVarAlloc, runnerVarFree,
+                             model.getTimePrecision(), "prevST" + n.first, n.second.getPrevSpikeTimeLocation(),
+                             numNeuronDelaySlots, mem);
 
             // Generate push and pull functions
             genVarPushPullScope(definitionsFunc, runnerPushFunc, runnerPullFunc, n.second.getPrevSpikeTimeLocation(),
@@ -926,9 +923,9 @@ MemAlloc CodeGenerator::generateRunner(CodeStream &definitions, CodeStream &defi
 
         // If neuron group needs to record its spike-like-event times
         if (n.second.isSpikeEventTimeRequired()) {
-            mem += backend.genArray(definitionsVar, definitionsInternalVar, runnerVarDecl, runnerVarAlloc, runnerVarFree,
-                                    model.getTimePrecision(), "seT" + n.first, n.second.getSpikeEventTimeLocation(),
-                                    numNeuronDelaySlots);
+            backend.genArray(definitionsVar, definitionsInternalVar, runnerVarDecl, runnerVarAlloc, runnerVarFree,
+                             model.getTimePrecision(), "seT" + n.first, n.second.getSpikeEventTimeLocation(),
+                             numNeuronDelaySlots, mem);
 
             // Generate push and pull functions
             genVarPushPullScope(definitionsFunc, runnerPushFunc, runnerPullFunc, n.second.getSpikeTimeLocation(),
@@ -943,9 +940,9 @@ MemAlloc CodeGenerator::generateRunner(CodeStream &definitions, CodeStream &defi
 
         // If neuron group needs to record its previous spike-like-event times
         if (n.second.isPrevSpikeEventTimeRequired()) {
-            mem += backend.genArray(definitionsVar, definitionsInternalVar, runnerVarDecl, runnerVarAlloc, runnerVarFree,
-                                    model.getTimePrecision(), "prevSET" + n.first, n.second.getPrevSpikeEventTimeLocation(),
-                                    numNeuronDelaySlots);
+            backend.genArray(definitionsVar, definitionsInternalVar, runnerVarDecl, runnerVarAlloc, runnerVarFree,
+                             model.getTimePrecision(), "prevSET" + n.first, n.second.getPrevSpikeEventTimeLocation(),
+                             numNeuronDelaySlots, mem);
 
             // Generate push and pull functions
             genVarPushPullScope(definitionsFunc, runnerPushFunc, runnerPullFunc, n.second.getPrevSpikeEventTimeLocation(),
@@ -960,8 +957,8 @@ MemAlloc CodeGenerator::generateRunner(CodeStream &definitions, CodeStream &defi
 
         // If neuron group needs per-neuron RNGs
         if(n.second.isSimRNGRequired()) {
-            mem += backend.genPopulationRNG(definitionsVar, definitionsInternalVar, runnerVarDecl, runnerVarAlloc, runnerVarFree, 
-                                            "rng" + n.first, batchSize * n.second.getNumNeurons());
+            backend.genPopulationRNG(definitionsVar, definitionsInternalVar, runnerVarDecl, runnerVarAlloc, runnerVarFree,
+                                     "rng" + n.first, batchSize * n.second.getNumNeurons(), mem);
         }
 
         // Neuron state variables
@@ -973,9 +970,9 @@ MemAlloc CodeGenerator::generateRunner(CodeStream &definitions, CodeStream &defi
             const unsigned int numCopies = getNumCopies(vars[i].access, batchSize);
             const size_t count = n.second.isVarQueueRequired(i) ? numCopies * n.second.getNumNeurons() * n.second.getNumDelaySlots() : numCopies * n.second.getNumNeurons();
             const bool autoInitialized = !varInitSnippet->getCode().empty();
-            mem += genVariable(backend, definitionsVar, definitionsFunc, definitionsInternalVar, runnerVarDecl, runnerVarAlloc, runnerVarFree,
-                               runnerPushFunc, runnerPullFunc, vars[i].type, vars[i].name + n.first,
-                               n.second.getVarLocation(i), autoInitialized, count, neuronStatePushPullFunctions);
+            genVariable(backend, definitionsVar, definitionsFunc, definitionsInternalVar, runnerVarDecl, runnerVarAlloc, runnerVarFree,
+                        runnerPushFunc, runnerPullFunc, vars[i].type, vars[i].name + n.first,
+                        n.second.getVarLocation(i), autoInitialized, count, mem, neuronStatePushPullFunctions);
 
             // Current variable push and pull functions
             genVarPushPullScope(definitionsFunc, runnerPushFunc, runnerPullFunc, n.second.getVarLocation(i),
@@ -1041,9 +1038,9 @@ MemAlloc CodeGenerator::generateRunner(CodeStream &definitions, CodeStream &defi
             for(size_t i = 0; i < csVars.size(); i++) {
                 const auto *varInitSnippet = cs->getVarInitialisers()[i].getSnippet();
                 const bool autoInitialized = !varInitSnippet->getCode().empty();
-                mem += genVariable(backend, definitionsVar, definitionsFunc, definitionsInternalVar, runnerVarDecl, runnerVarAlloc, runnerVarFree,
-                                   runnerPushFunc, runnerPullFunc, csVars[i].type, csVars[i].name + cs->getName(), cs->getVarLocation(i), 
-                                   autoInitialized, getNumCopies(csVars[i].access, batchSize) * n.second.getNumNeurons(), currentSourceStatePushPullFunctions);
+                genVariable(backend, definitionsVar, definitionsFunc, definitionsInternalVar, runnerVarDecl, runnerVarAlloc, runnerVarFree,
+                            runnerPushFunc, runnerPullFunc, csVars[i].type, csVars[i].name + cs->getName(), cs->getVarLocation(i),
+                            autoInitialized, getNumCopies(csVars[i].access, batchSize) * n.second.getNumNeurons(), mem, currentSourceStatePushPullFunctions);
 
                 // Loop through EGPs required to initialize current source variable
                 const auto extraGlobalParams = varInitSnippet->getExtraGlobalParams();
@@ -1100,24 +1097,24 @@ MemAlloc CodeGenerator::generateRunner(CodeStream &definitions, CodeStream &defi
         // Loop through merged incoming synaptic populations
         // **NOTE** because of merging we need to loop through postsynaptic models in this
         for(const auto *sg : n.second.getMergedInSyn()) {
-            mem += backend.genArray(definitionsVar, definitionsInternalVar, runnerVarDecl, runnerVarAlloc, runnerVarFree,
-                                    model.getPrecision(), "inSyn" + sg->getPSModelTargetName(), sg->getInSynLocation(),
-                                    sg->getTrgNeuronGroup()->getNumNeurons() * batchSize);
+            backend.genArray(definitionsVar, definitionsInternalVar, runnerVarDecl, runnerVarAlloc, runnerVarFree,
+                             model.getPrecision(), "inSyn" + sg->getPSModelTargetName(), sg->getInSynLocation(),
+                             sg->getTrgNeuronGroup()->getNumNeurons() * batchSize, mem);
 
             if (sg->isDendriticDelayRequired()) {
-                mem += backend.genArray(definitionsVar, definitionsInternalVar, runnerVarDecl, runnerVarAlloc, runnerVarFree,
-                                        model.getPrecision(), "denDelay" + sg->getPSModelTargetName(), sg->getDendriticDelayLocation(),
-                                        (size_t)sg->getMaxDendriticDelayTimesteps() * (size_t)sg->getTrgNeuronGroup()->getNumNeurons() * batchSize);
-                mem += genHostDeviceScalar(backend, definitionsVar, definitionsInternalVar, runnerVarDecl, runnerVarAlloc, runnerVarFree,
-                                           "unsigned int", "denDelayPtr" + sg->getPSModelTargetName(), "0");
+                backend.genArray(definitionsVar, definitionsInternalVar, runnerVarDecl, runnerVarAlloc, runnerVarFree,
+                                 model.getPrecision(), "denDelay" + sg->getPSModelTargetName(), sg->getDendriticDelayLocation(),
+                                 (size_t)sg->getMaxDendriticDelayTimesteps() * (size_t)sg->getTrgNeuronGroup()->getNumNeurons() * batchSize, mem);
+                genHostDeviceScalar(backend, definitionsVar, definitionsInternalVar, runnerVarDecl, runnerVarAlloc, runnerVarFree,
+                                    "unsigned int", "denDelayPtr" + sg->getPSModelTargetName(), "0", mem);
             }
 
             if (sg->getMatrixType() & SynapseMatrixWeight::INDIVIDUAL_PSM) {
                 const auto psmVars = sg->getPSModel()->getVars();
                 for(size_t v = 0; v < psmVars.size(); v++) {
-                    mem += backend.genArray(definitionsVar, definitionsInternalVar, runnerVarDecl, runnerVarAlloc, runnerVarFree,
-                                            psmVars[v].type, psmVars[v].name + sg->getPSModelTargetName(), sg->getPSVarLocation(v),
-                                            sg->getTrgNeuronGroup()->getNumNeurons() * getNumCopies(psmVars[v].access, batchSize));
+                    backend.genArray(definitionsVar, definitionsInternalVar, runnerVarDecl, runnerVarAlloc, runnerVarFree,
+                                     psmVars[v].type, psmVars[v].name + sg->getPSModelTargetName(), sg->getPSVarLocation(v),
+                                     sg->getTrgNeuronGroup()->getNumNeurons() * getNumCopies(psmVars[v].access, batchSize), mem);
 
                     // Loop through EGPs required to initialize PSM variable
                     const auto extraGlobalParams = sg->getPSVarInitialisers()[v].getSnippet()->getExtraGlobalParams();
@@ -1145,8 +1142,8 @@ MemAlloc CodeGenerator::generateRunner(CodeStream &definitions, CodeStream &defi
 
             if(s.second.getMatrixType() & SynapseMatrixConnectivity::BITMASK) {
                 const size_t gpSize = ceilDivide((size_t)s.second.getSrcNeuronGroup()->getNumNeurons() * backend.getSynapticMatrixRowStride(s.second), 32);
-                mem += backend.genArray(definitionsVar, definitionsInternalVar, runnerVarDecl, runnerVarAlloc, runnerVarFree,
-                                        "uint32_t", "gp" + s.second.getName(), s.second.getSparseConnectivityLocation(), gpSize);
+                backend.genArray(definitionsVar, definitionsInternalVar, runnerVarDecl, runnerVarAlloc, runnerVarFree,
+                                 "uint32_t", "gp" + s.second.getName(), s.second.getSparseConnectivityLocation(), gpSize, mem);
 
                 // Generate push and pull functions for bitmask
                 genVarPushPullScope(definitionsFunc, runnerPushFunc, runnerPullFunc, s.second.getSparseConnectivityLocation(),
@@ -1167,19 +1164,19 @@ MemAlloc CodeGenerator::generateRunner(CodeStream &definitions, CodeStream &defi
                 runnerVarDecl << "const unsigned int maxRowLength" << s.second.getName() << " = " << backend.getSynapticMatrixRowStride(s.second) << ";" << std::endl;
 
                 // Row lengths
-                mem += backend.genArray(definitionsVar, definitionsInternalVar, runnerVarDecl, runnerVarAlloc, runnerVarFree,
-                                        "unsigned int", "rowLength" + s.second.getName(), varLoc, s.second.getSrcNeuronGroup()->getNumNeurons());
+                backend.genArray(definitionsVar, definitionsInternalVar, runnerVarDecl, runnerVarAlloc, runnerVarFree,
+                                 "unsigned int", "rowLength" + s.second.getName(), varLoc, s.second.getSrcNeuronGroup()->getNumNeurons(), mem);
 
                 // Target indices
-                mem += backend.genArray(definitionsVar, definitionsInternalVar, runnerVarDecl, runnerVarAlloc, runnerVarFree,
-                                        s.second.getSparseIndType(), "ind" + s.second.getName(), varLoc, size);
+                backend.genArray(definitionsVar, definitionsInternalVar, runnerVarDecl, runnerVarAlloc, runnerVarFree,
+                                 s.second.getSparseIndType(), "ind" + s.second.getName(), varLoc, size, mem);
 
-                
+
                 // If synapse remap structure is required, allocate synRemap
                 // **THINK** this is over-allocating
                 if(backend.isSynRemapRequired(s.second)) {
-                    mem += backend.genArray(definitionsVar, definitionsInternalVar, runnerVarDecl, runnerVarAlloc, runnerVarFree,
-                                            "unsigned int", "synRemap" + s.second.getName(), VarLocation::DEVICE, size + 1);
+                    backend.genArray(definitionsVar, definitionsInternalVar, runnerVarDecl, runnerVarAlloc, runnerVarFree,
+                                     "unsigned int", "synRemap" + s.second.getName(), VarLocation::DEVICE, size + 1, mem);
                 }
 
                 // **TODO** remap is not always required
@@ -1187,12 +1184,12 @@ MemAlloc CodeGenerator::generateRunner(CodeStream &definitions, CodeStream &defi
                     const size_t postSize = (size_t)s.second.getTrgNeuronGroup()->getNumNeurons() * (size_t)s.second.getMaxSourceConnections();
 
                     // Allocate column lengths
-                    mem += backend.genArray(definitionsVar, definitionsInternalVar, runnerVarDecl, runnerVarAlloc, runnerVarFree,
-                                            "unsigned int", "colLength" + s.second.getName(), VarLocation::DEVICE, s.second.getTrgNeuronGroup()->getNumNeurons());
+                    backend.genArray(definitionsVar, definitionsInternalVar, runnerVarDecl, runnerVarAlloc, runnerVarFree,
+                                     "unsigned int", "colLength" + s.second.getName(), VarLocation::DEVICE, s.second.getTrgNeuronGroup()->getNumNeurons(), mem);
 
                     // Allocate remap
-                    mem += backend.genArray(definitionsVar, definitionsInternalVar, runnerVarDecl, runnerVarAlloc, runnerVarFree,
-                                            "unsigned int", "remap" + s.second.getName(), VarLocation::DEVICE, postSize);
+                    backend.genArray(definitionsVar, definitionsInternalVar, runnerVarDecl, runnerVarAlloc, runnerVarFree,
+                                     "unsigned int", "remap" + s.second.getName(), VarLocation::DEVICE, postSize, mem);
                 }
 
                 // Generate push and pull functions for sparse connectivity
@@ -1232,9 +1229,9 @@ MemAlloc CodeGenerator::generateRunner(CodeStream &definitions, CodeStream &defi
                 const auto *varInitSnippet = s.second.getWUVarInitialisers()[i].getSnippet();
                 if(individualWeights) {
                     const bool autoInitialized = !varInitSnippet->getCode().empty();
-                    mem += genVariable(backend, definitionsVar, definitionsFunc, definitionsInternalVar, runnerVarDecl, runnerVarAlloc, runnerVarFree,
-                                       runnerPushFunc, runnerPullFunc, wuVars[i].type, wuVars[i].name + s.second.getName(), s.second.getWUVarLocation(i),
-                                       autoInitialized, size * getNumCopies(wuVars[i].access, batchSize), synapseGroupStatePushPullFunctions);
+                    genVariable(backend, definitionsVar, definitionsFunc, definitionsInternalVar, runnerVarDecl, runnerVarAlloc, runnerVarFree,
+                                runnerPushFunc, runnerPullFunc, wuVars[i].type, wuVars[i].name + s.second.getName(), s.second.getWUVarLocation(i),
+                                autoInitialized, size * getNumCopies(wuVars[i].access, batchSize), mem, synapseGroupStatePushPullFunctions);
                 }
 
                 // Loop through EGPs required to initialize WUM variable
@@ -1256,9 +1253,9 @@ MemAlloc CodeGenerator::generateRunner(CodeStream &definitions, CodeStream &defi
         for(size_t i = 0; i < wuPreVars.size(); i++) {
             const auto *varInitSnippet = s.second.getWUPreVarInitialisers()[i].getSnippet();
             const bool autoInitialized = !varInitSnippet->getCode().empty();
-            mem += genVariable(backend, definitionsVar, definitionsFunc, definitionsInternalVar, runnerVarDecl, runnerVarAlloc, runnerVarFree,
-                               runnerPushFunc, runnerPullFunc, wuPreVars[i].type, wuPreVars[i].name + s.second.getName(),
-                               s.second.getWUPreVarLocation(i), autoInitialized, preSize * getNumCopies(wuPreVars[i].access, batchSize), synapseGroupStatePushPullFunctions);
+            genVariable(backend, definitionsVar, definitionsFunc, definitionsInternalVar, runnerVarDecl, runnerVarAlloc, runnerVarFree,
+                        runnerPushFunc, runnerPullFunc, wuPreVars[i].type, wuPreVars[i].name + s.second.getName(),
+                        s.second.getWUPreVarLocation(i), autoInitialized, preSize * getNumCopies(wuPreVars[i].access, batchSize), mem, synapseGroupStatePushPullFunctions);
 
             // Loop through EGPs required to initialize WUM variable
             const auto extraGlobalParams = varInitSnippet->getExtraGlobalParams();
@@ -1278,9 +1275,9 @@ MemAlloc CodeGenerator::generateRunner(CodeStream &definitions, CodeStream &defi
         for(size_t i = 0; i < wuPostVars.size(); i++) {
             const auto *varInitSnippet = s.second.getWUPostVarInitialisers()[i].getSnippet();
             const bool autoInitialized = !varInitSnippet->getCode().empty();
-            mem += genVariable(backend, definitionsVar, definitionsFunc, definitionsInternalVar, runnerVarDecl, runnerVarAlloc, runnerVarFree,
-                               runnerPushFunc, runnerPullFunc, wuPostVars[i].type, wuPostVars[i].name + s.second.getName(), s.second.getWUPostVarLocation(i),
-                               autoInitialized, postSize * getNumCopies(wuPostVars[i].access, batchSize), synapseGroupStatePushPullFunctions);
+            genVariable(backend, definitionsVar, definitionsFunc, definitionsInternalVar, runnerVarDecl, runnerVarAlloc, runnerVarFree,
+                        runnerPushFunc, runnerPullFunc, wuPostVars[i].type, wuPostVars[i].name + s.second.getName(), s.second.getWUPostVarLocation(i),
+                        autoInitialized, postSize * getNumCopies(wuPostVars[i].access, batchSize), mem, synapseGroupStatePushPullFunctions);
 
             // Loop through EGPs required to initialize WUM variable
             const auto extraGlobalParams = varInitSnippet->getExtraGlobalParams();

--- a/src/genn/genn/code_generator/generateRunner.cc
+++ b/src/genn/genn/code_generator/generateRunner.cc
@@ -1545,7 +1545,7 @@ MemAlloc CodeGenerator::generateRunner(CodeStream &definitions, CodeStream &defi
 
         // Generate preamble -this is the first bit of generated code called by user simulations
         // so global initialisation is often performed here
-        backend.genAllocateMemPreamble(runner, modelMerged);
+        backend.genAllocateMemPreamble(runner, modelMerged, mem);
 
         // Write variable allocations to runner
         runner << runnerVarAllocStream.str();

--- a/src/genn/genn/code_generator/generateRunner.cc
+++ b/src/genn/genn/code_generator/generateRunner.cc
@@ -521,7 +521,6 @@ MemAlloc CodeGenerator::generateRunner(CodeStream &definitions, CodeStream &defi
 
     // Write runner preamble
     runner << "#include \"definitionsInternal.h\"" << std::endl << std::endl;
-    backend.genRunnerPreamble(runner, modelMerged);
 
     // Create codestreams to generate different sections of runner and definitions
     std::stringstream runnerVarDeclStream;
@@ -1363,6 +1362,9 @@ MemAlloc CodeGenerator::generateRunner(CodeStream &definitions, CodeStream &defi
     // End extern C block around variable declarations
     runnerVarDecl << "}  // extern \"C\"" << std::endl;
  
+    // Write pre-amble to runner
+    backend.genRunnerPreamble(runner, modelMerged, mem);
+
     // Write variable declarations to runner
     runner << runnerVarDeclStream.str();
 

--- a/src/genn/genn/code_generator/modelSpecMerged.cc
+++ b/src/genn/genn/code_generator/modelSpecMerged.cc
@@ -12,7 +12,7 @@ using namespace CodeGenerator;
 //----------------------------------------------------------------------------
 // CodeGenerator::ModelSpecMerged
 //----------------------------------------------------------------------------
-CodeGenerator::ModelSpecMerged::ModelSpecMerged(const ModelSpecInternal &model, const BackendBase &backend)
+ModelSpecMerged::ModelSpecMerged(const ModelSpecInternal &model, const BackendBase &backend)
 :   m_Model(model), m_NeuronUpdateSupportCode("NeuronUpdateSupportCode"), m_PostsynapticDynamicsSupportCode("PostsynapticDynamicsSupportCode"),
     m_PresynapticUpdateSupportCode("PresynapticUpdateSupportCode"), m_PostsynapticUpdateSupportCode("PostsynapticUpdateSupportCode"),
     m_SynapseDynamicsSupportCode("SynapseDynamicsSupportCode")
@@ -170,4 +170,22 @@ CodeGenerator::ModelSpecMerged::ModelSpecMerged(const ModelSpecInternal &model, 
     for(const auto &sg : m_MergedSynapseDynamicsGroups) {
         m_SynapseDynamicsSupportCode.addSupportCode(sg.getArchetype().getWUModel()->getSynapseDynamicsSuppportCode());
     }
+}
+//----------------------------------------------------------------------------
+bool ModelSpecMerged::anyPointerEGPs() const
+{
+    // Loop through grouped merged EGPs
+    for(const auto &e : m_MergedEGPs) {
+        // If there's any pointer EGPs, return true
+        if(std::any_of(e.second.cbegin(), e.second.cend(),
+                       [](const MergedEGPDestinations::value_type &g) 
+                       {
+                           return Utils::isTypePointer(g.second.type); 
+                       }))
+        {
+            return true;
+        }
+    }
+
+    return false;
 }


### PR DESCRIPTION
As described in #390, AMD drivers do some magic in the background to try and overlap kernel execution etc if they can't detect any inter-dependencies based on buffers passed to each kernel (there are no global variables in OpenCL). However, due to kernel merging, GeNN doesn't pass all the buffers required to each kernel. Doing this would bring back many of the scaling problems kernel merging was trying to address so instead we do the following (as suggested by AMD support):
- Create a single ``cl::Buffer``, large enough to contain all static allocations (i.e. everything beside extra global parameters and recording data) padded to ``CL_​DEVICE_​MEM_​BASE_​ADDR_​ALIGN``
- When we allocate individual variables, the _device_ buffers need to be created as sub-buffers from this buffer using ``cl::Buffer::createSubBuffer``
- Pass the main ``cl::Buffer`` to **all** kernels to indicate that they need to be run in sequence.

We already track memory allocations in order to estimate device memory usage so this is actually pretty trivial to do. The only flies in the ointment are that, NVIDIA's OpenCL implementation doesn't like the resultant kernels so we can't entirely replace the old codepath. The second tricky issue is that, to handle dynamic allocations like pointer extra global parameters and recording buffers, we allocate as large a buffer as our device allows (on our modern AMD card this is almost all it's memory but, supposedly, on older devices this might be a limitation) and dish these out of that 'above' the static allocations.

**Note** the meaningful changes are all in the OpenCL backend.cc. The remainder involve updating the ``BackendBase`` methods which generate static allocations to take ``MemAccess`` objects by reference rather than returning ``MemAccess`` objects which then get added to the global total. As well as allowing the start point of allocations in the static buffer to be accessed when required this is arguably a more fool-proof API.

Fixes #390