### PR TITLE
Allow no self conns all to all

### DIFF
--- a/pygenn/genn_groups.py
+++ b/pygenn/genn_groups.py
@@ -1014,6 +1014,8 @@ class SynapseGroup(Group):
             # copy variables  directly into view
             # **NOTE** we assume order is row-major
             if self.is_dense:
+                # when an AllToAll connection states that "self" connections
+                # are not allowed, we need to pass weights in the right place
                 if var_data.values.size < var_data.view.size:
                     size = var_data.view.size
                     rs = size - var_data.values.size

--- a/pygenn/genn_groups.py
+++ b/pygenn/genn_groups.py
@@ -1017,10 +1017,9 @@ class SynapseGroup(Group):
                 # when an AllToAll connection states that "self" connections
                 # are not allowed, we need to pass weights in the right place
                 if var_data.values.size < var_data.view.size:
-                    size = var_data.view.size
-                    rs = size - var_data.values.size
-                    cs = size // rs
-                    ids = [i for i in range(size) if (i // cs) != (i % cs)]
+                    wsize = var_data.view.size
+                    n_cols = self.trg.size
+                    ids = [i for i in range(wsize) if (i // n_cols) != (i % n_cols)]
                     var_data.view[ids] = var_data.values
                 else:
                     var_data.view[:] = var_data.values

--- a/pygenn/genn_groups.py
+++ b/pygenn/genn_groups.py
@@ -1014,7 +1014,14 @@ class SynapseGroup(Group):
             # copy variables  directly into view
             # **NOTE** we assume order is row-major
             if self.is_dense:
-                var_data.view[:] = var_data.values
+                if var_data.values.size < var_data.view.size:
+                    size = var_data.view.size
+                    rs = size - var_data.values.size
+                    cs = size // rs
+                    ids = [i for i in range(size) if (i // cs) != (i % cs)]
+                    var_data.view[ids] = var_data.values
+                else:
+                    var_data.view[:] = var_data.values
             elif self.is_ragged:
                 # Sort variable to match GeNN order
                 sorted_var = var_data.values[self.synapse_order]


### PR DESCRIPTION
When All-to-All connections from PyNN GeNN disable self-connections (autapses?) there's a discrepancy between the size of variable values and the size of the variable view. Instead of just assigning the values to the view, I generate appropriate indices to set the values. 