### PR TITLE
Alt binomial

### DIFF
--- a/include/genn/genn/initSparseConnectivitySnippet.h
+++ b/include/genn/genn/initSparseConnectivitySnippet.h
@@ -375,7 +375,7 @@ public:
     SET_CALC_MAX_ROW_LENGTH_FUNC(
         [](unsigned int numPre, unsigned int numPost, const std::vector<double> &pars)
         {
-            // Calculate suitable quantile for 0.9999 change when drawing numPre times
+            // Calculate suitable quantile for 0.9999 chance when drawing numPre times
             const double quantile = pow(0.9999, 1.0 / (double)numPre);
 
             // In each column the number of connections that end up in a row are distributed

--- a/src/genn/genn/binomial.cc
+++ b/src/genn/genn/binomial.cc
@@ -124,7 +124,9 @@ unsigned int binomialInverseCDF(double cdf, unsigned int n, double p)
 }
 
 
-// evaluates inverse CDF of binomial distribution directly from definition
+// evaluates inverse CDF of binomial distribution directly from the definition
+// The calculation is doen mostly in the log domain except for teh final
+// accumulation of the probabilities
 unsigned int directBinomialInverseCDF(double cdf, unsigned int n, double p)
 {
     if(cdf < 0.0 || 1.0 < cdf) {
@@ -138,8 +140,6 @@ unsigned int directBinomialInverseCDF(double cdf, unsigned int n, double p)
       if (ptot >= cdf) return k;
       bp+= log(n-k)-log(k+1)+pfac;
       ptot+= expl(bp);
-      //      std::cerr << bp << std::endl;
-      //      std::cerr << ptot << std::endl;
     }
     return n;
 }

--- a/src/genn/genn/binomial.cc
+++ b/src/genn/genn/binomial.cc
@@ -4,142 +4,61 @@
 #include <stdexcept>
 
 // Standard C includes
-#include <cassert>
 #include <cmath>
-#include <cstdint>
-#include <iostream>
 
-// Anonymous namespace
-namespace
-{
-// Evaluates continued fraction for incomplete beta function by modified Lentz's method
-// Adopted from numerical recipes in C p227
-double betacf(double a, double b, double x)
-{
-    const int maxIterations = 200;
-    const double epsilon = 3.0E-7;
-    const double fpMin = 1.0E-30;
-
-    const double qab = a + b;
-    const double qap = a + 1.0;
-    const double  qam = a - 1.0;
-    double c = 1.0;
-
-    // First step of Lentz’s method.
-    double d = 1.0 - qab * x / qap;
-    if (fabs(d) < fpMin) {
-        d = fpMin;
-    }
-    d = 1.0 / d;
-    double h = d;
-    int m;
-    for(m = 1; m <= maxIterations; m++) {
-        const double m2 = 2.0 * m;
-        const double aa1 = m * (b - m) * x / ((qam + m2) * (a + m2));
-        d = 1.0 + aa1 * d;
-
-        // One step (the even one) of the recurrence.
-        if(fabs(d) < fpMin)  {
-            d = fpMin;
-        }
-        c = 1.0 + aa1 / c;
-        if(fabs(c) < fpMin) {
-            c=fpMin;
-        }
-        d = 1.0 / d;
-        h *= d * c;
-        const double aa2 = -(a + m) * (qab + m) * x / ((a + m2) * (qap + m2));
-        d = 1.0 + aa2 * d;
-
-        // Next step of the recurrence (the odd one).
-        if (fabs(d) < fpMin) {
-            d = fpMin;
-        }
-        c = 1.0 + aa2 / c;
-        if (fabs(c) < fpMin)  {
-            c = fpMin;
-        }
-        d = 1.0 / d;
-        const double del = d * c;
-        h *= del;
-
-        // Are we done?
-        if (fabs(del - 1.0) < epsilon) {
-            break;
-        }
-    }
-    if (m > maxIterations) {
-        throw std::runtime_error("a or b too big, or MAXIT too small in betacf");
-    }
-    return h;
-}
-//----------------------------------------------------------------------------
-// Returns the incomplete beta function Ix(a, b)
-// Adopted from numerical recipes in C p227
-double betai(double a, double b, double x)
-{
-    if (x < 0.0 || x > 1.0) {
-        throw std::runtime_error("Bad x in routine betai");
-    }
-
-    // Factors in front of the continued fraction.
-    double bt;
-    if (x == 0.0 || x == 1.0) {
-        bt = 0.0;
-    }
-    else {
-        bt = exp(lgamma(a + b) - lgamma(a) - lgamma(b) + a * log(x) + b * log(1.0 - x));
-    }
-
-    // Use continued fraction directly.
-    if (x < ((a + 1.0) / (a + b + 2.0))) {
-        return bt * betacf(a, b, x) / a;
-    }
-    // Otherwise, use continued fraction after making the 
-    // symmetry transformation.
-    else {
-        return 1.0 - (bt * betacf(b, a, 1.0 - x) / b);
-    }
-}
-}   // Anonymous namespace
-
-// Evaluates inverse CDF of binomial distribution
+// Evaluates the inverse CDF of the binomial distribution directly from the definition
+// The calculation is done mostly in the log domain except for the final
+// accumulation of the probabilities
 unsigned int binomialInverseCDF(double cdf, unsigned int n, double p)
 {
     if(cdf < 0.0 || 1.0 < cdf) {
         throw std::runtime_error("binomialInverseCDF error - CDF < 0 or 1 < CDF");
     }
 
-    // Loop through ks <= n
-    for (unsigned int k = 0; k <= n; k++)
-    {
-        // Use incomplete beta function to evalauate CDF, if it's greater than desired CDF value, return k
-        if (betai(n - k, 1 + k, 1.0 - p) > cdf) {
-            return k;
-	}
+    // While you can calculate the CDF directly using the incomplete beta function, because we need to loop through
+    // k anyway, it's more efficient to calculate the PMF iteratively for each k and sum them to get the CDF.
+ 
+    // First of all we start with the definition of the PMF:
+    //                   k         n - k
+    // (1) PMF(k) = |n| p   (1 - p)
+    //              |k|
 
-    }
+    // However, various aspects of this will quickly overflow so we will move this to the log domain
+    // (2) log(PMF(k)) = log|n| + klog(p) - klog(1 - p) + nlog(1 - p)
+    //                      |k|
 
-    throw std::runtime_error("Invalid CDF parameters");
-}
+    // The logarithms in the middle two terms can be pre-calculated and then added on for every k:
+    const long double logProbRatio = log(p) - log(1.0 - p);
 
+    // The final term is a constant so we can again calculate it once at the start of our sum:
+    long double logPMF = (double)n * log(1.0 - p);
+ 
+    // Because the first three terms of (2) will be zero for k=0,
+    // we can can calculate the CDF by taking the exponent of the constant term
+    long double cdfTotal = exp(logPMF);
 
-// Evaluates the inverse CDF of the binomial distribution directly from the definition
-// The calculation is done mostly in the log domain except for the final
-// accumulation of the probabilities
-unsigned int directBinomialInverseCDF(double cdf, unsigned int n, double p)
-{
-    if(cdf < 0.0 || 1.0 < cdf) {
-        throw std::runtime_error("binomialInverseCDF error - CDF < 0 or 1 < CDF");
-    }
-    long double bp = n*log(1.0-p);
-    long double pfac= log(p)-log(1.0-p);
-    long double ptot= expl(bp);
     // Loop through ks <= n 
     for (unsigned int k = 0; k < n; k++) {
-      if (ptot >= cdf) return k;
-      bp+= log(n-k)-log(k+1)+pfac;
-      ptot+= expl(bp);
+        // If we have reached the CDF value we're looking for, return k
+        if(cdfTotal >= cdf) {
+            return k;
+        }
+
+        // Binomiral coefficients can be calculated iteratively (for k from 0 to n) with:
+        // |  n  | =  n - k  |n|
+        // |k + 1|   ------- |k|
+        //            k + 1
+
+        // This can, again, be moved to the log domain:
+        // log|  n  | = log(n - k) - log(k + 1) + log| n |
+        //    |k + 1|                                | k |
+
+        // So we can update our log PMF for the next k by adding 
+        // these log terms as well as the one pre-calculated earlier
+        logPMF += log(n - k) - log(k + 1) + logProbRatio;
+
+        // Add the exponent of the updated PMF to the CDF total
+        cdfTotal += exp(logPMF);
     }
     return n;
 }

--- a/src/genn/genn/binomial.cc
+++ b/src/genn/genn/binomial.cc
@@ -124,8 +124,8 @@ unsigned int binomialInverseCDF(double cdf, unsigned int n, double p)
 }
 
 
-// evaluates inverse CDF of binomial distribution directly from the definition
-// The calculation is doen mostly in the log domain except for teh final
+// Evaluates the inverse CDF of the binomial distribution directly from the definition
+// The calculation is done mostly in the log domain except for the final
 // accumulation of the probabilities
 unsigned int directBinomialInverseCDF(double cdf, unsigned int n, double p)
 {

--- a/src/genn/genn/binomial.cc
+++ b/src/genn/genn/binomial.cc
@@ -42,10 +42,10 @@ unsigned int binomialInverseCDF(double cdf, unsigned int n, double p)
         for (unsigned int k = 0; k < n; k++) {
             // If we have reached the CDF value we're looking for, return k
             if(cdfTotal >= cdf) {
-                    return k;
+                return k;
             }
 
-            // Binomiral coefficients can be calculated iteratively (for k from 0 to n) with:
+            // Binomial coefficients can be calculated iteratively (for k from 0 to n) with:
             // |  n  | =  n - k  |n|
             // |k + 1|   ------- |k|
             //            k + 1
@@ -64,8 +64,8 @@ unsigned int binomialInverseCDF(double cdf, unsigned int n, double p)
         return n;
     }
     else {
-        // same approach as above but counting down from high k
-        cdf= 1.0-cdf;
+        // Same approach as above but counting down from high k
+        cdf= 1.0 - cdf;
         long double logPMF = (long double)n * log((long double)p);
 
         // Because the first three terms of (2) will be zero for k=0,
@@ -73,13 +73,13 @@ unsigned int binomialInverseCDF(double cdf, unsigned int n, double p)
         long double cdfTotal = exp(logPMF);
 
         // Loop through ks >= 0
-        for (unsigned int k = n-1; k >= 0; k--) {
+        for (unsigned int k = (n - 1); k >= 0; k--) {
             // If we have reached the CDF value we're looking for, return k
             if(cdfTotal > cdf) {
-                return k+1;
+                return k + 1;
             }
 
-            // Binomiral coefficients can be calculated iteratively (for k from n-1 down to 0) with:
+            // Binomiral coefficients can be calculated iteratively (for k from n - 1 down to 0) with:
             // | n | =  k + 1  |   n  |
             // | k |   ------- | k + 1|
             //          n - k

--- a/src/genn/genn/binomial.cc
+++ b/src/genn/genn/binomial.cc
@@ -140,6 +140,6 @@ unsigned int directBinomialInverseCDF(double cdf, unsigned int n, double p)
         bp*= (n-k)*pfac/(k+1.0);
         ptot+= bp;
     }
-    return n
+    return n;
 }
    

--- a/src/genn/genn/binomial.cc
+++ b/src/genn/genn/binomial.cc
@@ -31,7 +31,7 @@ unsigned int binomialInverseCDF(double cdf, unsigned int n, double p)
     const long double logProbRatio = log(p) - log(1.0 - p);
 
     // The final term is a constant so we can again calculate it once at the start of our sum:
-    long double logPMF = (double)n * log(1.0 - p);
+    long double logPMF = (long double)n * log((long double)(1.0 - p));
  
     // Because the first three terms of (2) will be zero for k=0,
     // we can can calculate the CDF by taking the exponent of the constant term
@@ -55,7 +55,7 @@ unsigned int binomialInverseCDF(double cdf, unsigned int n, double p)
 
         // So we can update our log PMF for the next k by adding 
         // these log terms as well as the one pre-calculated earlier
-        logPMF += log(n - k) - log(k + 1) + logProbRatio;
+        logPMF += log((long double)(n - k)) - log((long double)(k + 1)) + logProbRatio;
 
         // Add the exponent of the updated PMF to the CDF total
         cdfTotal += exp(logPMF);

--- a/src/genn/genn/binomial.cc
+++ b/src/genn/genn/binomial.cc
@@ -28,38 +28,74 @@ unsigned int binomialInverseCDF(double cdf, unsigned int n, double p)
     //                      |k|
 
     // The logarithms in the middle two terms can be pre-calculated and then added on for every k:
-    const long double logProbRatio = log(p) - log(1.0 - p);
+    const long double logProbRatio = log((long double)p) - log((long double)(1.0 - p));
 
-    // The final term is a constant so we can again calculate it once at the start of our sum:
-    long double logPMF = (long double)n * log((long double)(1.0 - p));
- 
-    // Because the first three terms of (2) will be zero for k=0,
-    // we can can calculate the CDF by taking the exponent of the constant term
-    long double cdfTotal = exp(logPMF);
+    if (cdf < p) {
+        // The final term is a constant so we can again calculate it once at the start of our sum:
+        long double logPMF = (long double)n * log((long double)(1.0 - p));
+      
+        // Because the first three terms of (2) will be zero for k=0,
+        // we can can calculate the CDF by taking the exponent of the constant term
+        long double cdfTotal = exp(logPMF);
 
-    // Loop through ks <= n 
-    for (unsigned int k = 0; k < n; k++) {
-        // If we have reached the CDF value we're looking for, return k
-        if(cdfTotal >= cdf) {
-            return k;
-        }
+	// Loop through ks <= n 
+	for (unsigned int k = 0; k < n; k++) {
+            // If we have reached the CDF value we're looking for, return k
+	    if(cdfTotal >= cdf) {
+                return k;
+	    }
 
-        // Binomiral coefficients can be calculated iteratively (for k from 0 to n) with:
-        // |  n  | =  n - k  |n|
-        // |k + 1|   ------- |k|
-        //            k + 1
+	    // Binomiral coefficients can be calculated iteratively (for k from 0 to n) with:
+	    // |  n  | =  n - k  |n|
+	    // |k + 1|   ------- |k|
+	    //            k + 1
+	    
+	    // This can, again, be moved to the log domain:
+	    // log|  n  | = log(n - k) - log(k + 1) + log| n |
+	    //    |k + 1|                                | k |
 
-        // This can, again, be moved to the log domain:
-        // log|  n  | = log(n - k) - log(k + 1) + log| n |
-        //    |k + 1|                                | k |
-
-        // So we can update our log PMF for the next k by adding 
-        // these log terms as well as the one pre-calculated earlier
-        logPMF += log((long double)(n - k)) - log((long double)(k + 1)) + logProbRatio;
-
-        // Add the exponent of the updated PMF to the CDF total
-        cdfTotal += exp(logPMF);
+	    // So we can update our log PMF for the next k by adding 
+	    // these log terms as well as the one pre-calculated earlier
+	    logPMF += log((long double)(n - k)) - log((long double)(k + 1)) + logProbRatio;
+	    
+	    // Add the exponent of the updated PMF to the CDF total
+	    cdfTotal += exp(logPMF);
+	}
+	return n;
     }
-    return n;
+    else {
+        // same approach as above but counting down from high k
+        cdf= 1.0-cdf;
+        long double logPMF = (long double)n * log((long double)p);
+	
+        // Because the first three terms of (2) will be zero for k=0,
+        // we can can calculate the CDF by taking the exponent of the constant term
+	long double cdfTotal = exp(logPMF);
+	
+        // Loop through ks >= 0 
+        for (unsigned int k = n-1; k >= 0; k--) {
+            // If we have reached the CDF value we're looking for, return k
+            if(cdfTotal > cdf) {
+                return k+1;
+	    }
+
+            // Binomiral coefficients can be calculated iteratively (for k from n-1 down to 0) with:
+            // | n | =  k + 1  |   n  |
+	    // | k |   ------- | k + 1|
+	    //          n - k
+	    
+	    // This can, again, be moved to the log domain:
+	    // log| n | = log(k + 1) - log(n - k) + log|   n   |
+	    //    | k |                                | k + 1 |
+	    
+	    // So we can update our log PMF for the previous k by adding 
+	    // these log terms as well as the one pre-calculated earlier
+	    logPMF += log((long double)(k + 1)) - log((long double)(n - k)) - logProbRatio;
+
+	    // Add the exponent of the updated PMF to the CDF total
+	    cdfTotal += exp(logPMF);
+	}
+	return 0;
+    }
 }
    

--- a/src/genn/genn/binomial.cc
+++ b/src/genn/genn/binomial.cc
@@ -30,7 +30,7 @@ unsigned int binomialInverseCDF(double cdf, unsigned int n, double p)
     // The logarithms in the middle two terms can be pre-calculated and then added on for every k:
     const long double logProbRatio = log((long double)p) - log((long double)(1.0 - p));
 
-    if (cdf < p) {
+    if (cdf < 0.5) {
         // The final term is a constant so we can again calculate it once at the start of our sum:
         long double logPMF = (long double)n * log((long double)(1.0 - p));
       

--- a/src/genn/genn/binomial.cc
+++ b/src/genn/genn/binomial.cc
@@ -33,69 +33,69 @@ unsigned int binomialInverseCDF(double cdf, unsigned int n, double p)
     if (cdf < 0.5) {
         // The final term is a constant so we can again calculate it once at the start of our sum:
         long double logPMF = (long double)n * log((long double)(1.0 - p));
-      
+
         // Because the first three terms of (2) will be zero for k=0,
         // we can can calculate the CDF by taking the exponent of the constant term
         long double cdfTotal = exp(logPMF);
 
-	// Loop through ks <= n 
-	for (unsigned int k = 0; k < n; k++) {
+        // Loop through ks <= n
+        for (unsigned int k = 0; k < n; k++) {
             // If we have reached the CDF value we're looking for, return k
-	    if(cdfTotal >= cdf) {
-                return k;
-	    }
+            if(cdfTotal >= cdf) {
+                    return k;
+            }
 
-	    // Binomiral coefficients can be calculated iteratively (for k from 0 to n) with:
-	    // |  n  | =  n - k  |n|
-	    // |k + 1|   ------- |k|
-	    //            k + 1
-	    
-	    // This can, again, be moved to the log domain:
-	    // log|  n  | = log(n - k) - log(k + 1) + log| n |
-	    //    |k + 1|                                | k |
+            // Binomiral coefficients can be calculated iteratively (for k from 0 to n) with:
+            // |  n  | =  n - k  |n|
+            // |k + 1|   ------- |k|
+            //            k + 1
 
-	    // So we can update our log PMF for the next k by adding 
-	    // these log terms as well as the one pre-calculated earlier
-	    logPMF += log((long double)(n - k)) - log((long double)(k + 1)) + logProbRatio;
-	    
-	    // Add the exponent of the updated PMF to the CDF total
-	    cdfTotal += exp(logPMF);
-	}
-	return n;
+            // This can, again, be moved to the log domain:
+            // log|  n  | = log(n - k) - log(k + 1) + log| n |
+            //    |k + 1|                                | k |
+
+            // So we can update our log PMF for the next k by adding
+            // these log terms as well as the one pre-calculated earlier
+            logPMF += log((long double)(n - k)) - log((long double)(k + 1)) + logProbRatio;
+
+            // Add the exponent of the updated PMF to the CDF total
+            cdfTotal += exp(logPMF);
+        }
+        return n;
     }
     else {
         // same approach as above but counting down from high k
         cdf= 1.0-cdf;
         long double logPMF = (long double)n * log((long double)p);
-	
+
         // Because the first three terms of (2) will be zero for k=0,
         // we can can calculate the CDF by taking the exponent of the constant term
-	long double cdfTotal = exp(logPMF);
-	
-        // Loop through ks >= 0 
+        long double cdfTotal = exp(logPMF);
+
+        // Loop through ks >= 0
         for (unsigned int k = n-1; k >= 0; k--) {
             // If we have reached the CDF value we're looking for, return k
             if(cdfTotal > cdf) {
                 return k+1;
-	    }
+            }
 
             // Binomiral coefficients can be calculated iteratively (for k from n-1 down to 0) with:
             // | n | =  k + 1  |   n  |
-	    // | k |   ------- | k + 1|
-	    //          n - k
-	    
-	    // This can, again, be moved to the log domain:
-	    // log| n | = log(k + 1) - log(n - k) + log|   n   |
-	    //    | k |                                | k + 1 |
-	    
-	    // So we can update our log PMF for the previous k by adding 
-	    // these log terms as well as the one pre-calculated earlier
-	    logPMF += log((long double)(k + 1)) - log((long double)(n - k)) - logProbRatio;
+            // | k |   ------- | k + 1|
+            //          n - k
 
-	    // Add the exponent of the updated PMF to the CDF total
-	    cdfTotal += exp(logPMF);
-	}
-	return 0;
+            // This can, again, be moved to the log domain:
+            // log| n | = log(k + 1) - log(n - k) + log|   n   |
+            //    | k |                                | k + 1 |
+
+            // So we can update our log PMF for the previous k by adding
+            // these log terms as well as the one pre-calculated earlier
+            logPMF += log((long double)(k + 1)) - log((long double)(n - k)) - logProbRatio;
+
+            // Add the exponent of the updated PMF to the CDF total
+            cdfTotal += exp(logPMF);
+        }
+        return 0;
     }
 }
    

--- a/src/genn/genn/binomial.cc
+++ b/src/genn/genn/binomial.cc
@@ -7,6 +7,7 @@
 #include <cassert>
 #include <cmath>
 #include <cstdint>
+#include <iostream>
 
 // Anonymous namespace
 namespace
@@ -115,9 +116,30 @@ unsigned int binomialInverseCDF(double cdf, unsigned int n, double p)
         // Use incomplete beta function to evalauate CDF, if it's greater than desired CDF value, return k
         if (betai(n - k, 1 + k, 1.0 - p) > cdf) {
             return k;
-        }
+	}
 
     }
 
-    throw std::runtime_error("Invalid CDF parameterse");
+    throw std::runtime_error("Invalid CDF parameters");
 }
+
+
+// evaluates inverse CDF of binomial distribution directly from definition
+unsigned int directBinomialInverseCDF(double cdf, unsigned int n, double p)
+{
+    if(cdf < 0.0 || 1.0 < cdf) {
+        throw std::runtime_error("binomialInverseCDF error - CDF < 0 or 1 < CDF");
+    }
+
+    double bp = pow(1.0-p,n);
+    double pfac= p/(1.0-p);
+    double ptot= bp;
+    // Loop through ks <= n 
+    for (unsigned int k = 0; k < n; k++) {
+        if (ptot > cdf) return k;
+        bp*= (n-k)*pfac/(k+1.0);
+        ptot+= bp;
+    }
+    return n
+}
+   

--- a/src/genn/genn/binomial.cc
+++ b/src/genn/genn/binomial.cc
@@ -130,15 +130,16 @@ unsigned int directBinomialInverseCDF(double cdf, unsigned int n, double p)
     if(cdf < 0.0 || 1.0 < cdf) {
         throw std::runtime_error("binomialInverseCDF error - CDF < 0 or 1 < CDF");
     }
-
-    double bp = pow(1.0-p,n);
-    double pfac= p/(1.0-p);
-    double ptot= bp;
+    long double bp = n*log(1.0-p);
+    long double pfac= log(p)-log(1.0-p);
+    long double ptot= expl(bp);
     // Loop through ks <= n 
     for (unsigned int k = 0; k < n; k++) {
-        if (ptot > cdf) return k;
-        bp*= (n-k)*pfac/(k+1.0);
-        ptot+= bp;
+      if (ptot >= cdf) return k;
+      bp+= log(n-k)-log(k+1)+pfac;
+      ptot+= expl(bp);
+      //      std::cerr << bp << std::endl;
+      //      std::cerr << ptot << std::endl;
     }
     return n;
 }

--- a/tests/unit/binomial.cc
+++ b/tests/unit/binomial.cc
@@ -1,0 +1,29 @@
+// Google test includes
+#include "gtest/gtest.h"
+
+// GeNN code generator includes
+#include "binomial.h"
+
+//--------------------------------------------------------------------------
+// Tests
+//--------------------------------------------------------------------------
+TEST(Binomial, FixedProbabilityRange)
+{
+    const double probs[] = {0.02, 0.1, 1.0};
+    const unsigned int popSizes[] = {1, 1000, 1000000};
+    constexpr size_t numProbs = sizeof(probs) / sizeof(probs[0]);
+    constexpr size_t numPopSizes = sizeof(popSizes) / sizeof(popSizes[0]);
+    const unsigned int scipyPPF[numProbs][numPopSizes] = {
+        // popSizes[0], popSizes[1], popSizes[2]
+        {1,             47,         20897},     // probs[0] 
+        {1,             153,        101914},    // probs[1]
+        {1,             1000,       1000000}};  // probs[2]
+    
+    for(size_t i = 0; i < numProbs; i++) {
+        for(size_t j = 0; j < numPopSizes; j++) {
+            const double quantile = pow(0.9999, 1.0 / (double)popSizes[j]);
+            const double ppf = binomialInverseCDF(quantile, popSizes[j], probs[i]);
+            EXPECT_EQ(scipyPPF[i][j], ppf);
+        }
+    }
+}

--- a/tests/unit/binomial.cc
+++ b/tests/unit/binomial.cc
@@ -16,17 +16,42 @@ TEST(Binomial, FixedProbabilityRange)
     const unsigned int popSizes[] = {1, 1000, 1000000};
     constexpr size_t numProbs = sizeof(probs) / sizeof(probs[0]);
     constexpr size_t numPopSizes = sizeof(popSizes) / sizeof(popSizes[0]);
+
     const unsigned int scipyPPF[numProbs][numPopSizes] = {
         // popSizes[0], popSizes[1], popSizes[2]
         {1,             47,         20897},     // probs[0] 
         {1,             153,        101914},    // probs[1]
         {1,             1000,       1000000}};  // probs[2]
-    
+
     for(size_t i = 0; i < numProbs; i++) {
         for(size_t j = 0; j < numPopSizes; j++) {
             const double quantile = pow(0.9999, 1.0 / (double)popSizes[j]);
             const double ppf = binomialInverseCDF(quantile, popSizes[j], probs[i]);
             EXPECT_EQ(scipyPPF[i][j], ppf);
+        }
+    }
+}
+
+TEST(Binomial, FixedNumberPrePost)
+{
+    const unsigned int fixedNumbers[] = {1, 10, 100};
+    const unsigned int popSizes[] = {1, 1000, 1000000};
+    constexpr size_t numFixedNumbers = sizeof(fixedNumbers) / sizeof(fixedNumbers[0]);
+    constexpr size_t numPopSizes = sizeof(popSizes) / sizeof(popSizes[0]);
+
+    const unsigned int scipyPPF[numFixedNumbers][numPopSizes] = {
+        // popSizes[0], popSizes[1], popSizes[2]
+        {1,             10,         12},     // fixedNumbers[0]
+        {10,            30,         36},     // fixedNumbers[1]
+        {100,           156,        170}};   // fixedNumbers[2]
+
+    for(size_t i = 0; i < numFixedNumbers; i++) {
+        for(size_t j = 0; j < numPopSizes; j++) {
+            if(fixedNumbers[i] < popSizes[j]) {
+                const double quantile = pow(0.9999, 1.0 / (double)popSizes[j]);
+                const double ppf = binomialInverseCDF(quantile, fixedNumbers[i] * popSizes[j], 1.0 / (double)popSizes[j]);
+                EXPECT_EQ(scipyPPF[i][j], ppf);
+            }
         }
     }
 }

--- a/tests/unit/binomial.cc
+++ b/tests/unit/binomial.cc
@@ -1,3 +1,6 @@
+// Standard C includes
+#include <cmath>
+
 // Google test includes
 #include "gtest/gtest.h"
 

--- a/tests/unit/unit.vcxproj
+++ b/tests/unit/unit.vcxproj
@@ -14,6 +14,7 @@
     <ProjectGuid>{A202469A-9380-4F7E-B2A9-6FD1B52F2F91}</ProjectGuid>
   </PropertyGroup>
   <ItemGroup>
+    <ClCompile Include="binomial.cc" />
     <ClCompile Include="codeGenUtils.cc" />
     <ClCompile Include="currentSource.cc" />
     <ClCompile Include="currentSourceModels.cc" />


### PR DESCRIPTION
The ```binomialInverseCDF``` is failing for large n, observed for instance, at n=5e8 with p approximately 1e-3. Here I suggest an alternative direct calculation of an inverse binomial CDF that appears to hold up longer and seems to give values similar to those provided by SciPy with different methods (only a spot test).
Probably we don't want to merge it like this but change the code that is using ```binomialInverseCDF``` to use the new function ``` directBinomialInverseCDF```. Feel free to push appropriate changes into this branch before merging.