### PR TITLE
Workaround for Windows fatal error C1090: PDB API call failed, error code '3' 

### DIFF
--- a/include/genn/genn/code_generator/backendBase.h
+++ b/include/genn/genn/code_generator/backendBase.h
@@ -73,6 +73,11 @@ struct PreferencesBase
     //! Should GeNN generate pull functions for extra global parameters? These are very rarely used
     bool generateExtraGlobalParamPull = true;
 
+    //! On some Windows systems, for reasons yet to be identified, 
+    //! you get Fatal error C1090: PDB API call failed, error code '3' when building generated code.
+    //! Setting this flag should fix these errors
+    bool synchronizePDBWrites = false;
+
     //! C++ compiler options to be used for building all host side code (used for unix based platforms)
     std::string userCxxFlagsGNU = "";
 

--- a/src/genn/backends/cuda/backend.cc
+++ b/src/genn/backends/cuda/backend.cc
@@ -1612,11 +1612,15 @@ void Backend::genMSBuildItemDefinitions(std::ostream &os) const
     os << "\t\t\t<IntrinsicFunctions Condition=\"'$(Configuration)'=='Release'\">true</IntrinsicFunctions>" << std::endl;
     os << "\t\t\t<PreprocessorDefinitions Condition=\"'$(Configuration)'=='Release'\">WIN32;WIN64;NDEBUG;_CONSOLE;BUILDING_GENERATED_CODE;%(PreprocessorDefinitions)</PreprocessorDefinitions>" << std::endl;
     os << "\t\t\t<PreprocessorDefinitions Condition=\"'$(Configuration)'=='Debug'\">WIN32;WIN64;_DEBUG;_CONSOLE;BUILDING_GENERATED_CODE;%(PreprocessorDefinitions)</PreprocessorDefinitions>" << std::endl;
+    if(getPreferences().synchronizePDBWrites) {
+        os << "\t\t\t<AdditionalOptions>/FS</AdditionalOptions>" << std::endl;
+    }
     os << "\t\t</ClCompile>" << std::endl;
 
     // Add item definition for linking
     os << "\t\t<Link>" << std::endl;
-    os << "\t\t\t<GenerateDebugInformation>true</GenerateDebugInformation>" << std::endl;
+    os << "\t\t\t<GenerateDebugInformation Condition=\"'$(Configuration)'=='Debug'\">true</GenerateDebugInformation>" << std::endl;
+    os << "\t\t\t<GenerateDebugInformation Condition=\"'$(Configuration)'=='Release'\">false</GenerateDebugInformation>" << std::endl;
     os << "\t\t\t<EnableCOMDATFolding Condition=\"'$(Configuration)'=='Release'\">true</EnableCOMDATFolding>" << std::endl;
     os << "\t\t\t<OptimizeReferences Condition=\"'$(Configuration)'=='Release'\">true</OptimizeReferences>" << std::endl;
     os << "\t\t\t<SubSystem>Console</SubSystem>" << std::endl;

--- a/src/genn/backends/opencl/backend.cc
+++ b/src/genn/backends/opencl/backend.cc
@@ -2229,11 +2229,15 @@ void Backend::genMSBuildItemDefinitions(std::ostream &os) const
     os << "\t\t\t<PreprocessorDefinitions Condition=\"'$(Configuration)'=='Release'\">_CRT_SECURE_NO_WARNINGS;WIN32;WIN64;NDEBUG;_CONSOLE;BUILDING_GENERATED_CODE;CLRNG_SINGLE_PRECISION;CL_HPP_TARGET_OPENCL_VERSION=120;CL_HPP_MINIMUM_OPENCL_VERSION=120;%(PreprocessorDefinitions)</PreprocessorDefinitions>" << std::endl;
     os << "\t\t\t<PreprocessorDefinitions Condition=\"'$(Configuration)'=='Debug'\">_CRT_SECURE_NO_WARNINGS;WIN32;WIN64;_DEBUG;_CONSOLE;BUILDING_GENERATED_CODE;CLRNG_SINGLE_PRECISION;CL_HPP_TARGET_OPENCL_VERSION=120;CL_HPP_MINIMUM_OPENCL_VERSION=120;%(PreprocessorDefinitions)</PreprocessorDefinitions>" << std::endl;
     os << "\t\t\t<AdditionalIncludeDirectories>opencl\\clRNG\\include;$(OPENCL_PATH)\\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>" << std::endl;
+    if(getPreferences().synchronizePDBWrites) {
+        os << "\t\t\t<AdditionalOptions>/FS</AdditionalOptions>" << std::endl;
+    }
     os << "\t\t</ClCompile>" << std::endl;
 
     // Add item definition for linking
     os << "\t\t<Link>" << std::endl;
-    os << "\t\t\t<GenerateDebugInformation>true</GenerateDebugInformation>" << std::endl;
+    os << "\t\t\t<GenerateDebugInformation Condition=\"'$(Configuration)'=='Debug'\">true</GenerateDebugInformation>" << std::endl;
+    os << "\t\t\t<GenerateDebugInformation Condition=\"'$(Configuration)'=='Release'\">false</GenerateDebugInformation>" << std::endl;
     os << "\t\t\t<EnableCOMDATFolding Condition=\"'$(Configuration)'=='Release'\">true</EnableCOMDATFolding>" << std::endl;
     os << "\t\t\t<OptimizeReferences Condition=\"'$(Configuration)'=='Release'\">true</OptimizeReferences>" << std::endl;
     os << "\t\t\t<SubSystem>Console</SubSystem>" << std::endl;

--- a/src/genn/backends/single_threaded_cpu/backend.cc
+++ b/src/genn/backends/single_threaded_cpu/backend.cc
@@ -1331,11 +1331,15 @@ void Backend::genMSBuildItemDefinitions(std::ostream &os) const
     os << "\t\t\t<PreprocessorDefinitions Condition=\"'$(Configuration)'=='Release'\">WIN32;WIN64;NDEBUG;_CONSOLE;BUILDING_GENERATED_CODE;%(PreprocessorDefinitions)</PreprocessorDefinitions>" << std::endl;
     os << "\t\t\t<PreprocessorDefinitions Condition=\"'$(Configuration)'=='Debug'\">WIN32;WIN64;_DEBUG;_CONSOLE;BUILDING_GENERATED_CODE;%(PreprocessorDefinitions)</PreprocessorDefinitions>" << std::endl;
     os << "\t\t\t<FloatingPointModel>" << (getPreferences().optimizeCode ? "Fast" : "Precise") << "</FloatingPointModel>" << std::endl;
+    if(getPreferences().synchronizePDBWrites) {
+        os << "\t\t\t<AdditionalOptions>/FS</AdditionalOptions>" << std::endl;
+    }
     os << "\t\t</ClCompile>" << std::endl;
 
     // Add item definition for linking
     os << "\t\t<Link>" << std::endl;
-    os << "\t\t\t<GenerateDebugInformation>true</GenerateDebugInformation>" << std::endl;
+    os << "\t\t\t<GenerateDebugInformation Condition=\"'$(Configuration)'=='Debug'\">true</GenerateDebugInformation>" << std::endl;
+    os << "\t\t\t<GenerateDebugInformation Condition=\"'$(Configuration)'=='Release'\">false</GenerateDebugInformation>" << std::endl;
     os << "\t\t\t<EnableCOMDATFolding Condition=\"'$(Configuration)'=='Release'\">true</EnableCOMDATFolding>" << std::endl;
     os << "\t\t\t<OptimizeReferences Condition=\"'$(Configuration)'=='Release'\">true</OptimizeReferences>" << std::endl;
     os << "\t\t\t<SubSystem>Console</SubSystem>" << std::endl;


### PR DESCRIPTION
In Windows, debug information is added to a Program DataBase file (rather than being stored in the individual object files like on Linux). There can be issues with parallel accesses to this/other processes (virus scanners/orphan debuggers) trying to mess with it so this PR adds the following functionality to the MSBuild code generator:
* Added ``synchronizePDBWrites`` preferences flag which  turns on the /FS compiler flag (https://docs.microsoft.com/en-us/cpp/build/reference/fs-force-synchronous-pdb-writes) which seems to prevent these 
* Turned off generation of debug information in Release builds (doesn't seem to prevent PDB being created or solve C1090 errors but maybe speeds things up)