### PR TITLE
PyGeNN helpers for accessing model internals

### DIFF
--- a/include/genn/genn/synapseGroup.h
+++ b/include/genn/genn/synapseGroup.h
@@ -138,6 +138,8 @@ public:
     //! Is this synapse group a weight-sharing slave
     bool isWeightSharingSlave() const { return (getWeightSharingMaster() != nullptr); }
 
+    bool isPSModelMerged() const{ return m_PSModelTargetName != getName(); }
+
     const WeightUpdateModels::Base *getWUModel() const{ return m_WUModel; }
 
     const std::vector<double> &getWUParams() const{ return m_WUParams; }
@@ -273,8 +275,7 @@ protected:
     /*! This is required when the pre-synaptic neuron population's outgoing synapse groups require different event threshold */
     bool isEventThresholdReTestRequired() const{ return m_EventThresholdReTestRequired; }
 
-    const std::string &getPSModelTargetName() const{ return m_PSModelTargetName; }
-    bool isPSModelMerged() const{ return m_PSModelTargetName != getName(); }
+    const std::string &getPSModelTargetName() const{ return m_PSModelTargetName; }    
 
     //! Get the type to use for sparse connectivity indices for synapse group
     std::string getSparseIndType() const;

--- a/include/genn/genn/synapseGroupInternal.h
+++ b/include/genn/genn/synapseGroupInternal.h
@@ -38,7 +38,6 @@ public:
     using SynapseGroup::isEventThresholdReTestRequired;
     using SynapseGroup::areWUVarReferencedByCustomUpdate;
     using SynapseGroup::getPSModelTargetName;
-    using SynapseGroup::isPSModelMerged;
     using SynapseGroup::getSparseIndType;
     using SynapseGroup::canPSBeLinearlyCombined;
     using SynapseGroup::getWUHashDigest;

--- a/pygenn/genn_groups.py
+++ b/pygenn/genn_groups.py
@@ -506,28 +506,28 @@ class NeuronGroup(Group):
         if (self.pop.is_spike_time_required() and
             (self.pop.get_spike_time_location() & VarLocation_HOST) != 0):
             
-            self.spike_times = self.get_event_time_view("sT")
+            self.spike_times = self._get_event_time_view("sT")
         
         # If this neuron group generates spike event times 
         # and they are accesible on the host
         if (self.pop.is_spike_event_time_required() and
             (self.pop.get_spike_event_time_location() & VarLocation_HOST) != 0):
             
-            self.spike_event_times = self.get_event_time_view("seT")
+            self.spike_event_times = self._get_event_time_view("seT")
         
         # If this neuron group generates previous spike times 
         # and they are accesible on the host
         if (self.pop.is_prev_spike_time_required() and
             (self.pop.get_prev_spike_time_location() & VarLocation_HOST) != 0):
             
-            self.prev_spike_times = self.get_event_time_view("prevST")
+            self.prev_spike_times = self._get_event_time_view("prevST")
         
         # If this neuron group generates previous spike event times 
         # and they are accesible on the host
         if (self.pop.is_prev_spike_event_time_required() and
             (self.pop.get_prev_spike_event_time_location() & VarLocation_HOST) != 0):
             
-            self.prev_spike_event_times = self.get_event_time_view("prevSET")
+            self.prev_spike_event_times = self._get_event_time_view("prevSET")
 
         # If spike recording is enabled
         if self.spike_recording_enabled:
@@ -563,8 +563,9 @@ class NeuronGroup(Group):
     def _spike_recording_words(self):
         return ((self.size + 31) // 32)
         
-    def get_event_time_view(name, self):
+    def _get_event_time_view(self, name):
         # Get view
+        batch_size = self._model.batch_size
         view = self._assign_ext_ptr_array(
             name, self.size * self.delay_slots * batch_size,
             self._model._time_precision)
@@ -967,7 +968,15 @@ class SynapseGroup(Group):
     def push_connectivity_to_device(self):
         """Wrapper around GeNNModel.push_connectivity_to_device"""
         self._model.push_connectivity_to_device(self.name)
+    
+    def pull_in_syn_from_device(self):
+        """Pull synaptic input current from device"""
+        self.pull_var_from_device("inSyn")
 
+    def push_in_syn_to_device(self):
+        """Push synaptic input current to device"""
+        self.push_var_to_device("inSyn")
+        
     def pull_psm_extra_global_param_from_device(self, egp_name):
         """Wrapper around GeNNModel.pull_extra_global_param_from_device
 

--- a/pygenn/genn_groups.py
+++ b/pygenn/genn_groups.py
@@ -442,22 +442,26 @@ class NeuronGroup(Group):
     def pull_current_spikes_from_device(self):
         """Wrapper around GeNNModel.pull_current_spikes_from_device"""
         self._model.pull_current_spikes_from_device(self.name)
-    
+
     def pull_spike_times_from_device(self):
         """Helper to pull spike times from device"""
-        self.pull_var_from_device("SpikeTimes")
-    
+        # **YUCK** these variables are named inconsistently
+        self._model.pull_var_from_device("SpikeTimes", self.name)
+
     def pull_spike_event_times_from_device(self):
         """Helper to pull spike event times from device"""
-        self.pull_var_from_device("SpikeEventTimes")
-    
+        # **YUCK** these variables are named inconsistently
+        self._model.pull_var_from_device("SpikeEventTimes", self.name)
+
     def pull_prev_spike_times_from_device(self):
         """Helper to pull previous spike times from device"""
-        self.pull_var_from_device("PreviousSpikeTimes")
-    
+        # **YUCK** these variables are named inconsistently
+        self._model.pull_var_from_device("PreviousSpikeTimes", self.name)
+
     def pull_prev_spike_event_times_from_device(self):
         """Helper to pull previous spike event times from device"""
-        self.pull_var_from_device("PreviousSpikeEventTimes")
+        # **YUCK** these variables are named inconsistently
+        self._model.pull_var_from_device("PreviousSpikeEventTimes", self.name)
 
     def push_spikes_to_device(self):
         """Wrapper around GeNNModel.push_spikes_to_device"""
@@ -469,20 +473,24 @@ class NeuronGroup(Group):
 
     def push_spike_times_to_device(self):
         """Helper to push spike times to device"""
-        self.push_var_to_device("SpikeTimes")
-    
+        # **YUCK** these variables are named inconsistently
+        self._model.push_var_to_device("SpikeTimes", self.name)
+
     def push_spike_event_times_to_device(self):
         """Helper to push spike event times to device"""
-        self.push_var_to_device("SpikeEventTimes")
-    
+        # **YUCK** these variables are named inconsistently
+        self._model.push_var_to_device("SpikeEventTimes", self.name)
+
     def push_prev_spike_times_to_device(self):
         """Helper to push previous spike times to device"""
-        self.push_var_to_device("PreviousSpikeTimes")
-    
+        # **YUCK** these variables are named inconsistently
+        self._model.push_var_to_device("PreviousSpikeTimes", self.name)
+
     def push_prev_spike_event_times_to_device(self):
         """Helper to push previous spike event times to device"""
-        self.push_var_to_device("PreviousSpikeEventTimes")
-    
+        # **YUCK** these variables are named inconsistently
+        self._model.push_var_to_device("PreviousSpikeEventTimes", self.name)
+
     def load(self, num_recording_timesteps):
         """Loads neuron group"""
         # If spike data is present on the host

--- a/pygenn/genn_groups.py
+++ b/pygenn/genn_groups.py
@@ -1079,15 +1079,17 @@ class SynapseGroup(Group):
                                 self.psm_vars, self.pop.get_psvar_location)
         
         # If this synapse group's inSyn is accessible on the host
-        if (self.pop.get_in_syn_location() & VarLocation_HOST) != 0:
+        if (not self.pop.is_psmodel_merged() and
+            (self.pop.get_in_syn_location() & VarLocation_HOST) != 0):
             # Get view
             self.in_syn = self._assign_ext_ptr_array(
                 "inSyn", self.trg.size * self._model.batch_size,
                 "scalar")
 
             # Reshape to expose batches
-            self.in_syn = np.reshape(view, (batch_size, self.trg.size))
-        
+            self.in_syn = np.reshape(self.in_syn, (self._model.batch_size,
+                                                   self.trg.size))
+
         # Load extra global parameters
         self._load_egp()
         self._load_egp(self.psm_extra_global_params)

--- a/pygenn/genn_model.py
+++ b/pygenn/genn_model.py
@@ -114,17 +114,17 @@ class GeNNModel(object):
         # Based on time precision, create correct type 
         # of SLM class and determine GeNN time type 
         # **NOTE** all SLM uses its template parameter for is time variable
-        time_precision = precision if time_precision is None else time_precision
-        if time_precision == "float":
+        self._time_precision = precision if time_precision is None else time_precision
+        if self._time_precision == "float":
             self._slm = slm.SharedLibraryModelNumpy_f()
             genn_time_type = "TimePrecision_FLOAT"
-        elif time_precision == "double":
+        elif self._time_precision == "double":
             self._slm = slm.SharedLibraryModelNumpy_d()
             genn_time_type = "TimePrecision_DOUBLE"
         else:
             raise ValueError(
                 "Supported time precisions are float and double, "
-                "but '{1}' was given".format(time_precision))
+                "but '{1}' was given".format(self._time_precision))
 
         # Store precision in class and determine GeNN scalar type
         self._scalar = precision


### PR DESCRIPTION
Namely:
- Spike times (and all the thrilling variants)
- inSyn (this will also be a useful building block for https://github.com/genn-team/pynn_genn/issues/16)

All of these things are accessible already if you know the right thing to hack at, but the names are inconsistent etc. The only nuance is making ``SynapseGroup::isPSModelMerged`` public rather than only accessible in the code generator. This is less than idea as it's value is meaningless at the point the non-PyGeNN user is likely to call it (merging only happens during ``ModelSpec::finalize`` but the only alternative would just be to rely on catching the exception raised when you try and access a merged-away inSyn which #359 means isn't possible