### PR TITLE
Include versions in hash

### DIFF
--- a/src/genn/MakefileCommon
+++ b/src/genn/MakefileCommon
@@ -4,10 +4,14 @@ OS_UPPER			:=$(shell uname -s 2>/dev/null | tr [:lower:] [:upper:])
 DARWIN				:=$(strip $(findstring DARWIN,$(OS_UPPER)))
 
 # Get directory of this makefile i.e. GeNN directory (means make can be invoked else where)
-GENN_DIR 			:= $(abspath $(dir $(lastword $(MAKEFILE_LIST)))../../)
+GENN_DIR			:= $(abspath $(dir $(lastword $(MAKEFILE_LIST)))../../)
+
+# Read GeNN version and git hash
+GENN_VERSION		:= $(shell cat "$(GENN_DIR)/version.txt")
+GIT_HASH			:= $(shell git -C "$(GENN_DIR)" rev-parse HEAD 2>/dev/null)
 
 # Set standard compiler and archiver flags
-CXXFLAGS 			+=-Wall -Wpedantic -Wextra -MMD -MP -I$(GENN_DIR)/include/genn/genn -I$(GENN_DIR)/include/genn/third_party
+CXXFLAGS			+=-Wall -Wpedantic -Wextra -MMD -MP -I$(GENN_DIR)/include/genn/genn -I$(GENN_DIR)/include/genn/third_party -DGENN_VERSION=\"$(GENN_VERSION)\" -DGIT_HASH=\"$(GIT_HASH)\"
 ARFLAGS				:=-rcs
 
 # On Mac OS X, use Clang++ rather than GC++
@@ -41,7 +45,7 @@ ifdef DYNAMIC
     ifeq ($(DARWIN),DARWIN)
         LIBRARY_EXTENSION	:=dylib
     else
-	LIBRARY_EXTENSION	:=so
+    LIBRARY_EXTENSION	:=so
     endif
 else
     LIBRARY_EXTENSION		:=a
@@ -55,4 +59,4 @@ endif
 # Add prefix to object directory and library name
 OBJECT_DIRECTORY		?=$(GENN_DIR)/obj$(GENN_PREFIX)
 LIBRARY_DIRECTORY		?=$(GENN_DIR)/lib
-LIBGENN				:=$(LIBRARY_DIRECTORY)/libgenn$(GENN_PREFIX).$(LIBRARY_EXTENSION)
+LIBGENN					:=$(LIBRARY_DIRECTORY)/libgenn$(GENN_PREFIX).$(LIBRARY_EXTENSION)

--- a/src/genn/MakefileCommon
+++ b/src/genn/MakefileCommon
@@ -6,12 +6,8 @@ DARWIN				:=$(strip $(findstring DARWIN,$(OS_UPPER)))
 # Get directory of this makefile i.e. GeNN directory (means make can be invoked else where)
 GENN_DIR			:= $(abspath $(dir $(lastword $(MAKEFILE_LIST)))../../)
 
-# Read GeNN version and git hash
-GENN_VERSION		:= $(shell cat "$(GENN_DIR)/version.txt")
-GIT_HASH			:= $(shell git -C "$(GENN_DIR)" rev-parse HEAD 2>/dev/null)
-
 # Set standard compiler and archiver flags
-CXXFLAGS			+=-Wall -Wpedantic -Wextra -MMD -MP -I$(GENN_DIR)/include/genn/genn -I$(GENN_DIR)/include/genn/third_party -DGENN_VERSION=\"$(GENN_VERSION)\" -DGIT_HASH=\"$(GIT_HASH)\"
+CXXFLAGS			+=-Wall -Wpedantic -Wextra -MMD -MP -I$(GENN_DIR)/include/genn/genn -I$(GENN_DIR)/include/genn/third_party
 ARFLAGS				:=-rcs
 
 # On Mac OS X, use Clang++ rather than GC++

--- a/src/genn/genn/Makefile
+++ b/src/genn/genn/Makefile
@@ -13,6 +13,13 @@ OBJECT_DIRECTORY	:=$(OBJECT_DIRECTORY)/genn/genn
 OBJECTS			:=$(SOURCES:%.cc=$(OBJECT_DIRECTORY)/%.o)
 DEPS			:=$(OBJECTS:.o=.d)
 
+# Read GeNN version and git hash
+GENN_VERSION		:= $(shell cat "$(GENN_DIR)/version.txt")
+GIT_HASH			:= $(shell git -C "$(GENN_DIR)" rev-parse HEAD 2>/dev/null)
+
+# Add version and hash to compiler flags
+CXXFLAGS		+= -DGENN_VERSION=\"$(GENN_VERSION)\" -DGIT_HASH=\"$(GIT_HASH)\"
+
 .PHONY: all clean
 
 all: $(LIBGENN)

--- a/src/genn/genn/code_generator/modelSpecMerged.cc
+++ b/src/genn/genn/code_generator/modelSpecMerged.cc
@@ -320,6 +320,13 @@ boost::uuids::detail::sha1::digest_type ModelSpecMerged::getNeuronUpdateArchetyp
     // Add hash of model batch size
     Utils::updateHash(getModel().getBatchSize(), hash);
 
+    // Concatenate hash digest of GeNN version
+    Utils::updateHash(GENN_VERSION, hash);
+
+    // Concatenate hash digest of git hash
+    // **NOTE** it would be nicer to actually treat git hash as a hash but not really important
+    Utils::updateHash(GIT_HASH, hash);
+
     // Concatenate hash digest of archetype neuron update group
     for(const auto &g : m_MergedNeuronUpdateGroups) {
         Utils::updateHash(g.getArchetype().getHashDigest(), hash);
@@ -337,6 +344,13 @@ boost::uuids::detail::sha1::digest_type ModelSpecMerged::getSynapseUpdateArchety
 
     // Add hash of model batch size
     Utils::updateHash(getModel().getBatchSize(), hash);
+
+    // Concatenate hash digest of GeNN version
+    Utils::updateHash(GENN_VERSION, hash);
+
+    // Concatenate hash digest of git hash
+    // **NOTE** it would be nicer to actually treat git hash as a hash but not really important
+    Utils::updateHash(GIT_HASH, hash);
 
     // Concatenate hash digest of archetype presynaptic update group
     for(const auto &g : m_MergedPresynapticUpdateGroups) {
@@ -367,6 +381,13 @@ boost::uuids::detail::sha1::digest_type ModelSpecMerged::getCustomUpdateArchetyp
     // Add hash of model batch size
     Utils::updateHash(getModel().getBatchSize(), hash);
     
+    // Concatenate hash digest of GeNN version
+    Utils::updateHash(GENN_VERSION, hash);
+
+    // Concatenate hash digest of git hash
+    // **NOTE** it would be nicer to actually treat git hash as a hash but not really important
+    Utils::updateHash(GIT_HASH, hash);
+
     // Concatenate hash digest of archetype custom update group
     for(const auto &g : m_MergedCustomUpdateGroups) {
         Utils::updateHash(g.getArchetype().getHashDigest(), hash);
@@ -392,6 +413,13 @@ boost::uuids::detail::sha1::digest_type ModelSpecMerged::getInitArchetypeHashDig
     // Add hash of model batch size
     Utils::updateHash(getModel().getBatchSize(), hash);
     
+    // Concatenate hash digest of GeNN version
+    Utils::updateHash(GENN_VERSION, hash);
+
+    // Concatenate hash digest of git hash
+    // **NOTE** it would be nicer to actually treat git hash as a hash but not really important
+    Utils::updateHash(GIT_HASH, hash);
+
     // Concatenate hash digest of archetype neuron init group
     for(const auto &g : m_MergedNeuronInitGroups) {
         Utils::updateHash(g.getArchetype().getInitHashDigest(), hash);

--- a/src/genn/genn/code_generator/modelSpecMerged.cc
+++ b/src/genn/genn/code_generator/modelSpecMerged.cc
@@ -211,6 +211,13 @@ boost::uuids::detail::sha1::digest_type ModelSpecMerged::getHashDigest(const Bac
     // Concatenate hash digest of backend properties
     Utils::updateHash(backend.getHashDigest(), hash);
 
+    // Concatenate hash digest of GeNN version
+    Utils::updateHash(GENN_VERSION, hash);
+
+    // Concatenate hash digest of git hash
+    // **NOTE** it would be nicer to actually treat git hash as a hash but not really important
+    Utils::updateHash(GIT_HASH, hash);
+
     // Concatenate hash digest of neuron update groups
     for(const auto &g : m_MergedNeuronUpdateGroups) {
         Utils::updateHash(g.getHashDigest(), hash);

--- a/src/genn/genn/genn.vcxproj
+++ b/src/genn/genn/genn.vcxproj
@@ -152,4 +152,14 @@
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <ImportGroup Label="ExtensionTargets">
   </ImportGroup>
+  <Target Name="ReadGitHash" BeforeTargets="PrepareForBuild">
+    <Exec Command="git -C $(MSBuildThisFileDirectory) rev-parse HEAD" ConsoleToMsBuild="true">
+      <Output TaskParameter="ConsoleOutput" PropertyName="GitHash" />
+    </Exec>
+    <ItemGroup>
+      <ClCompile>
+       <PreprocessorDefinitions>%(PreprocessorDefinitions);GIT_HASH="$(GitHash)"</PreprocessorDefinitions>
+      </ClCompile>
+    </ItemGroup>
+  </Target>
 </Project>

--- a/src/genn/genn/genn.vcxproj
+++ b/src/genn/genn/genn.vcxproj
@@ -152,13 +152,16 @@
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <ImportGroup Label="ExtensionTargets">
   </ImportGroup>
-  <Target Name="ReadGitHash" BeforeTargets="PrepareForBuild">
+  <Target Name="ReadGitHashAndVersion" BeforeTargets="PrepareForBuild">
     <Exec Command="git -C $(MSBuildThisFileDirectory) rev-parse HEAD" ConsoleToMsBuild="true">
       <Output TaskParameter="ConsoleOutput" PropertyName="GitHash" />
     </Exec>
+    <ReadLinesFromFile File="..\..\..\version.txt">
+        <Output TaskParameter="Lines" PropertyName="GeNNVersion" />
+    </ReadLinesFromFile>
     <ItemGroup>
       <ClCompile>
-       <PreprocessorDefinitions>%(PreprocessorDefinitions);GIT_HASH="$(GitHash)"</PreprocessorDefinitions>
+       <PreprocessorDefinitions>%(PreprocessorDefinitions);GIT_HASH="$(GitHash)";GENN_VERSION="$(GeNNVersion)"</PreprocessorDefinitions>
       </ClCompile>
     </ItemGroup>
   </Target>

--- a/src/genn/genn/genn.vcxproj
+++ b/src/genn/genn/genn.vcxproj
@@ -153,7 +153,7 @@
   <ImportGroup Label="ExtensionTargets">
   </ImportGroup>
   <Target Name="ReadGitHashAndVersion" BeforeTargets="PrepareForBuild">
-    <Exec Command="git -C $(MSBuildThisFileDirectory) rev-parse HEAD" ConsoleToMsBuild="true">
+    <Exec Command="git -C $(MSBuildThisFileDirectory) rev-parse HEAD 2> NUL" ConsoleToMsBuild="true" EchoOff="true" IgnoreExitCode="true">
       <Output TaskParameter="ConsoleOutput" PropertyName="GitHash" />
     </Exec>
     <ReadLinesFromFile File="..\..\..\version.txt">


### PR DESCRIPTION
I had the realisation over the weekend that, models should be rebuilt if the GeNN version or the model changes. There's basically two use cases here:

1. Downloading zip files
2. Checking out of git

In the case of 1, it's reasonably safe to assume that it's a release version of GeNN so including the hash of the version string is fine. When GeNN's been checked out of git, we can use the git head revision hash. This is pretty simple using both make (aside from that the ``$(file)`` function is only supported on super-bleeding edge versions) and MSBuild - the only tricky bits are handling the error cases (we don't want the build failing if there's no git or git/shell stderr messages making their way into ``GIT_HASH``)
