### PR TITLE
std::function wrapping

### DIFF
--- a/generate_swig_interfaces.py
+++ b/generate_swig_interfaces.py
@@ -456,7 +456,7 @@ def generateBackend(swigPath, folder, namespace):
         mg.addSwigModuleHeadline()
         mg.addSwigEnableUnderCaseConvert()
         mg.addSwigInclude('<exception.i>')
-
+        mg.addSwigInclude('<std_string.i>')
         # Add exception handler
         mg.addStandardExceptionHandler()
 

--- a/generate_swig_interfaces.py
+++ b/generate_swig_interfaces.py
@@ -39,7 +39,6 @@ import os  # to work with paths nicely
 from itertools import product
 from string import Template # for better text substitutions
 from argparse import ArgumentParser # to parse command line args
-from six import iteritems
 from textwrap import dedent
 
 # module attributes
@@ -374,7 +373,7 @@ def generateStlContainersInterface( swigPath ):
         functionTypes = {'DP': 'function<double(const std::vector<double> &, double)>',
                          'CKS': 'function<std::vector<unsigned int>(const std::vector<double>&)>',
                          'CML': 'function<unsigned int( unsigned int, unsigned int, const std::vector<double> &)>'}
-        for name, spec in iteritems(functionTypes):
+        for name, spec in functionTypes.items():
             # Find brackets defining function arguments
             firstBracketIdx = spec.find('(')
             lastBracketIdx = spec.rfind(')')

--- a/generate_swig_interfaces.py
+++ b/generate_swig_interfaces.py
@@ -39,6 +39,7 @@ import os  # to work with paths nicely
 from itertools import product
 from string import Template # for better text substitutions
 from argparse import ArgumentParser # to parse command line args
+from six import iteritems
 from textwrap import dedent
 
 # module attributes
@@ -369,25 +370,38 @@ def generateStlContainersInterface( swigPath ):
         mg.addSwigInclude( '<std_string.i>' )
         mg.addSwigInclude( '<std_pair.i>' )
         mg.addSwigInclude( '<std_vector.i>' )
-
-        dpfunc_template_spec = 'function<double( const std::vector<double> &, double )>'
-        mg.write( '\n// wrap std::function in a callable struct with the same name\n' )
-        mg.write( '// and enable directors feature for it, so that a new class can\n' )
-        mg.write( '// be derived from it in python. swig magic.\n')
-        mg.addSwigRename( 'std::' + dpfunc_template_spec,
-                'STD_DPFunc' )
-        mg.addSwigRename(
-                'std::' + dpfunc_template_spec + '::operator()',
-                '__call__',
-                '// rename operator() as __call__ so that it works correctly in python' )
-        mg.addSwigFeatureDirector( 'std::' + dpfunc_template_spec )
-        mg.write('namespace std{\n'
-                 '    struct ' + dpfunc_template_spec + ' {\n'
-                 '        // copy ctor\n' +
-                 '        {0}( const std::{0}&);\n'.format( dpfunc_template_spec ) +
-                 '        double operator()( const std::vector<double> &, double ) const;\n'
-                 '    };\n'
-                 '}\n' )
+    
+        functionTypes = {'DP': 'function<double(const std::vector<double> &, double)>',
+                         'CKS': 'function<std::vector<unsigned int>(const std::vector<double>&)>',
+                         'CML': 'function<unsigned int( unsigned int, unsigned int, const std::vector<double> &)>'}
+        for name, spec in iteritems(functionTypes):
+            # Find brackets defining function arguments
+            firstBracketIdx = spec.find('(')
+            lastBracketIdx = spec.rfind(')')
+            assert firstBracketIdx != -1
+            assert lastBracketIdx != -1
+            assert firstBracketIdx < lastBracketIdx
+            
+            # Use to extract function arguments and return type
+            functionArgs = spec[firstBracketIdx + 1:lastBracketIdx]
+            functionRet = spec[9:firstBracketIdx]
+            
+            # Rename this std::function specialisation
+            mg.addSwigRename('std::' + spec, name + 'Function')
+            
+            mg.addSwigRename(
+                    'std::' + spec + '::operator()',
+                    '__call__',
+                    '// rename operator() as __call__ so that it works correctly in python' )
+                    
+            # Write SWIG-parsable version of std::function specialisation
+            mg.write('namespace std{\n'
+                     '    struct ' + spec + ' {\n'
+                     '        // copy ctor\n' +
+                     '        {0}( const std::{0}&);\n'.format( spec ) +
+                     '        ' + functionRet + ' operator()(' + functionArgs + ') const;\n'
+                     '    };\n'
+                     '}\n' )
 
         mg.write( '\n// add template specifications for various STL containers\n' )
         mg.addSwigTemplate( 'std::vector<std::string>', 'StringVector' )


### PR DESCRIPTION
When wrapping row length and kernel size calculation functions in PyGeNN we missed one step which lead to large numbers of irritating warnings. This PR rectifies this and, additionally, I spotted that setting backend preferences which were strings (e.g. ``userCxxFlagsGNU="-march=native"``) didn't work from PyGeNN - this simply required the SWIG ``<std_string.i>`` interface to be included in all backend SWIG interface files.