### PR TITLE
Variable references to custom update variables

### DIFF
--- a/include/genn/genn/modelSpec.h
+++ b/include/genn/genn/modelSpec.h
@@ -121,6 +121,12 @@ inline Models::VarReference createVarRef(const CurrentSource *cs, const std::str
     return Models::VarReference::createVarRef(cs, varName);
 }
 
+//! Creates a reference to a custom update variable
+inline Models::VarReference createVarRef(const CustomUpdate *cu, const std::string &varName)
+{
+    return Models::VarReference::createVarRef(cu, varName);
+}
+
 //! Creates a reference to a postsynaptic model variable
 inline Models::VarReference createPSMVarRef(const SynapseGroup *sg, const std::string &varName)
 {

--- a/include/genn/genn/modelSpec.h
+++ b/include/genn/genn/modelSpec.h
@@ -152,6 +152,12 @@ inline Models::WUVarReference createWUVarRef(const SynapseGroup *sg, const std::
     return Models::WUVarReference(sg, varName, transposeSG, transposeVarName);
 }
 
+//! Creates a reference to a custom weight update variable
+inline Models::WUVarReference createWUVarRef(const CustomUpdateWU *cu, const std::string &varName)
+{
+    return Models::WUVarReference(cu, varName);
+}
+
 //----------------------------------------------------------------------------
 // ModelSpec
 //----------------------------------------------------------------------------

--- a/include/genn/genn/models.h
+++ b/include/genn/genn/models.h
@@ -12,6 +12,8 @@
 #include "varAccess.h"
 
 // Forward declarations
+class CustomUpdate;
+class CustomUpdateWU;
 class NeuronGroup;
 class SynapseGroup;
 class CurrentSource;
@@ -195,6 +197,7 @@ public:
     //------------------------------------------------------------------------
     static VarReference createVarRef(const NeuronGroup *ng, const std::string &varName);
     static VarReference createVarRef(const CurrentSource *cs, const std::string &varName);
+    static VarReference createVarRef(const CustomUpdate *su, const std::string &varName);
     static VarReference createPSMVarRef(const SynapseGroup *sg, const std::string &varName);
     static VarReference createWUPreVarRef(const SynapseGroup *sg, const std::string &varName);
     static VarReference createWUPostVarRef(const SynapseGroup *sg, const std::string &varName);
@@ -207,6 +210,7 @@ private:
 
     VarReference(const NeuronGroupInternal *ng, const std::string &varName);
     VarReference(const CurrentSourceInternal *cs, const std::string &varName);
+    VarReference(const CustomUpdate *cu, const std::string &varName);
     VarReference(unsigned int size, GetDelayNeuronGroupFn getDelayNeuronGroup,
                  size_t varIndex, const Models::Base::VarVec &varVec, GetTargetNameFn getTargetNameFn);
 

--- a/include/genn/genn/models.h
+++ b/include/genn/genn/models.h
@@ -235,6 +235,7 @@ class GENN_EXPORT WUVarReference : public VarReferenceBase
 public:
     WUVarReference(const SynapseGroup *sg, const std::string &varName,
                    const SynapseGroup *transposeSG = nullptr, const std::string &transposeVarName = "");
+    WUVarReference(const CustomUpdateWU *cu, const std::string &varName);
 
     //------------------------------------------------------------------------
     // Public API

--- a/src/genn/genn/models.cc
+++ b/src/genn/genn/models.cc
@@ -2,6 +2,7 @@
 
 
 // GeNN includes
+#include "customUpdateInternal.h"
 #include "currentSourceInternal.h"
 #include "neuronGroupInternal.h"
 #include "synapseGroupInternal.h"
@@ -29,6 +30,11 @@ VarReference VarReference::createVarRef(const NeuronGroup *ng, const std::string
 VarReference VarReference::createVarRef(const CurrentSource *cs, const std::string &varName)
 {
     return VarReference(static_cast<const CurrentSourceInternal *>(cs), varName);
+}
+//----------------------------------------------------------------------------
+VarReference VarReference::createVarRef(const CustomUpdate *cu, const std::string &varName)
+{
+    return VarReference(static_cast<const CustomUpdateInternal *>(cu), varName);
 }
 //----------------------------------------------------------------------------
 VarReference VarReference::createPSMVarRef(const SynapseGroup *sg, const std::string &varName)
@@ -74,6 +80,13 @@ VarReference::VarReference(const NeuronGroupInternal *ng, const std::string &var
 VarReference::VarReference(const CurrentSourceInternal *cs, const std::string &varName)
 :   VarReferenceBase(cs->getCurrentSourceModel()->getVarIndex(varName), cs->getCurrentSourceModel()->getVars(), [cs]() { return cs->getName(); }),
     m_Size(cs->getTrgNeuronGroup()->getNumNeurons()), m_GetDelayNeuronGroup([]() { return nullptr; })
+{
+
+}
+//----------------------------------------------------------------------------
+VarReference::VarReference(const CustomUpdate *cu, const std::string &varName)
+:   VarReferenceBase(cu->getCustomUpdateModel()->getVarIndex(varName), cu->getCustomUpdateModel()->getVars(), [cu]() { return cu->getName(); }),
+    m_Size(cu->getSize()), m_GetDelayNeuronGroup([]() { return nullptr; })
 {
 
 }

--- a/src/genn/genn/models.cc
+++ b/src/genn/genn/models.cc
@@ -1,6 +1,5 @@
 #include "models.h"
 
-
 // GeNN includes
 #include "customUpdateInternal.h"
 #include "currentSourceInternal.h"
@@ -145,9 +144,17 @@ WUVarReference::WUVarReference(const SynapseGroup *sg, const std::string &varNam
     }
 }
 //----------------------------------------------------------------------------
-const SynapseGroup *WUVarReference::getSynapseGroup() const 
-{ 
-    return m_SG; 
+WUVarReference::WUVarReference(const CustomUpdateWU *cu, const std::string &varName)
+:   VarReferenceBase(cu->getCustomUpdateModel()->getVarIndex(varName), cu->getCustomUpdateModel()->getVars(), [cu]() { return cu->getName(); }),
+    m_SG(static_cast<const CustomUpdateWUInternal*>(cu)->getSynapseGroup()), m_TransposeSG(nullptr),
+    m_TransposeVarIndex(0)
+{
+
+}
+//----------------------------------------------------------------------------
+const SynapseGroup *WUVarReference::getSynapseGroup() const
+{
+    return m_SG;
 }
 //----------------------------------------------------------------------------
 const SynapseGroup *WUVarReference::getTransposeSynapseGroup() const 

--- a/tests/features/custom_update/model.cc
+++ b/tests/features/custom_update/model.cc
@@ -103,6 +103,9 @@ void modelDefinition(ModelSpec &model)
     TestCU::VarReferences cuTestVarReferences(createVarRef(ng, "V"));
     auto *cu = model.addCustomUpdate<TestCU>("CustomUpdate", "Test2", {}, {0.0}, cuTestVarReferences);
     
+    TestCU::WUVarReferences cuTestWUVarReferences(createWUVarRef(denseSG, "g"));
+    auto *cuWU = model.addCustomUpdate<TestCU>("CustomWUUpdate", "Test2", {}, {0.0}, cuTestWUVarReferences);
+    
     //---------------------------------------------------------------------------
     // Custom updates
     //---------------------------------------------------------------------------
@@ -137,4 +140,8 @@ void modelDefinition(ModelSpec &model)
     SetTime::WUVarReferences wuSparseVarReferences(createWUVarRef(sparseSG, "g")); // R
     model.addCustomUpdate<SetTime>("WUSparseSetTime", "Test",
                                    {}, {0.0}, wuSparseVarReferences);
+    
+    SetTime::WUVarReferences wuCUVarReferences(createWUVarRef(cuWU, "C")); // R
+    model.addCustomUpdate<SetTime>("CustomWUUpdateSetTime", "Test",
+                                   {}, {0.0}, wuCUVarReferences);
 }

--- a/tests/features/custom_update/model.cc
+++ b/tests/features/custom_update/model.cc
@@ -48,6 +48,16 @@ public:
 };
 IMPLEMENT_MODEL(TestWUM);
 
+class TestCU : public CustomUpdateModels::Base
+{
+public:
+    DECLARE_CUSTOM_UPDATE_MODEL(TestCU, 0, 1, 1);
+
+    SET_VARS({{"C", "scalar"}});
+    SET_VAR_REFS({{"R", "scalar"}})
+};
+IMPLEMENT_MODEL(TestCU);
+
 class SetTime : public CustomUpdateModels::Base
 {
 public:
@@ -90,6 +100,8 @@ void modelDefinition(ModelSpec &model)
         {}, {0}, {0.0}, {0.0},
         {}, {0},
         initConnectivity<InitSparseConnectivitySnippet::FixedProbability>({0.1}));
+    TestCU::VarReferences cuTestVarReferences(createVarRef(ng, "V"));
+    auto *cu = model.addCustomUpdate<TestCU>("CustomUpdate", "Test2", {}, {0.0}, cuTestVarReferences);
     
     //---------------------------------------------------------------------------
     // Custom updates
@@ -101,7 +113,11 @@ void modelDefinition(ModelSpec &model)
     SetTime::VarReferences csVarReferences(createVarRef(cs, "C")); // R
     model.addCustomUpdate<SetTime>("CurrentSourceSetTime", "Test",
                                    {}, {0.0}, csVarReferences);
-                                   
+   
+    SetTime::VarReferences cuVarReferences(createVarRef(cu, "C")); // R
+    model.addCustomUpdate<SetTime>("CustomUpdateSetTime", "Test",
+                                   {}, {0.0}, cuVarReferences);
+
     SetTime::VarReferences psmVarReferences(createPSMVarRef(denseSG, "P")); // R
     model.addCustomUpdate<SetTime>("PSMSetTime", "Test",
                                    {}, {0.0}, psmVarReferences);

--- a/tests/features/custom_update/test.cc
+++ b/tests/features/custom_update/test.cc
@@ -53,6 +53,8 @@ TEST_F(SimTest, CustomUpdate)
             pullVWUSparseSetTimeFromDevice();
             pullgSparseFromDevice();
             pullSparseConnectivityFromDevice();
+            pullVCustomWUUpdateSetTimeFromDevice();
+            pullCCustomWUUpdateFromDevice();
 
             // Check all values match time of update
             EXPECT_TRUE(std::all_of(&VNeuron[0], &VNeuron[100],
@@ -93,6 +95,11 @@ TEST_F(SimTest, CustomUpdate)
             EXPECT_TRUE(std::all_of(&VWUDenseSetTime[0], &VWUDenseSetTime[100 * 100],
                         [](scalar v) { return v == t; }));
             EXPECT_TRUE(std::all_of(&gDense[0], &gDense[100 * 100],
+                        [](scalar v) { return v == t; }));
+
+            EXPECT_TRUE(std::all_of(&VCustomWUUpdateSetTime[0], &VCustomWUUpdateSetTime[100 * 100],
+                        [](scalar v) { return v == t; }));
+            EXPECT_TRUE(std::all_of(&CCustomWUUpdate[0], &CCustomWUUpdate[100 * 100],
                         [](scalar v) { return v == t; }));
 
             for(unsigned int i = 0; i < 100; i++) {

--- a/tests/features/custom_update/test.cc
+++ b/tests/features/custom_update/test.cc
@@ -40,6 +40,8 @@ TEST_F(SimTest, CustomUpdate)
             pullVNeuronFromDevice();
             pullVCurrentSourceSetTimeFromDevice();
             pullCCurrentSourceFromDevice();
+            pullVCustomUpdateSetTimeFromDevice();
+            pullCCustomUpdateFromDevice();
             pullVPSMSetTimeFromDevice();
             pullPDenseFromDevice();
             pullVWUPreSetTimeFromDevice();
@@ -62,7 +64,12 @@ TEST_F(SimTest, CustomUpdate)
                         [](scalar v) { return v == t; }));
             EXPECT_TRUE(std::all_of(&CCurrentSource[0], &CCurrentSource[100],
                         [](scalar v) { return v == t; }));
-
+            
+            EXPECT_TRUE(std::all_of(&VCustomUpdateSetTime[0], &VCustomUpdateSetTime[100],
+                        [](scalar v) { return v == t; }));
+            EXPECT_TRUE(std::all_of(&CCustomUpdate[0], &CCustomUpdate[100],
+                        [](scalar v) { return v == t; }));
+                        
             EXPECT_TRUE(std::all_of(&VPSMSetTime[0], &VPSMSetTime[100],
                         [](scalar v) { return v == t; }));
             EXPECT_TRUE(std::all_of(&PDense[0], &PDense[100],


### PR DESCRIPTION
This basically lets you 'chain' custom updates so they can process each other's results. This is used for implementing batch reductions, the results of which are used to update weights in next PR :smile: