### PR TITLE
Postsynaptic model target

### DIFF
--- a/include/genn/genn/synapseGroup.h
+++ b/include/genn/genn/synapseGroup.h
@@ -66,7 +66,7 @@ public:
 
     //! Set name of neuron input variable postsynaptic model will target
     /*! This should either be 'Isyn' or the name of one of the postsynaptic neuron's additional input variables. */
-    void setPSOutputVar(const std::string &varName);
+    void setPSTargetVar(const std::string &varName);
     
     //! Set location of sparse connectivity initialiser extra global parameter
     /*! This is ignored for simulations on hardware with a single memory space
@@ -204,7 +204,7 @@ public:
 
     //! Get name of neuron input variable postsynaptic model will target
     /*! This will either be 'Isyn' or the name of one of the postsynaptic neuron's additional input variables. */
-    const std::string &getPSOutputVar() const{ return m_PSOutputVar; }
+    const std::string &getPSTargetVar() const{ return m_PSTargetVar; }
     
     //! Get location of sparse connectivity initialiser extra global parameter by name
     /*! This is only used by extra global parameters which are pointers*/
@@ -465,5 +465,5 @@ private:
     
     //! Name of neuron input variable postsynaptic model will target
     /*! This should either be 'Isyn' or the name of one of the postsynaptic neuron's additional input variables. */
-    std::string m_PSOutputVar;
+    std::string m_PSTargetVar;
 };

--- a/include/genn/genn/synapseGroup.h
+++ b/include/genn/genn/synapseGroup.h
@@ -64,6 +64,10 @@ public:
         and only applies to extra global parameters which are pointers. */
     void setPSExtraGlobalParamLocation(const std::string &paramName, VarLocation loc);
 
+    //! Set name of neuron input variable postsynaptic model will target
+    /*! This should either be 'Isyn' or the name of one of the postsynaptic neuron's additional input variables. */
+    void setPSOutputVar(const std::string &varName);
+    
     //! Set location of sparse connectivity initialiser extra global parameter
     /*! This is ignored for simulations on hardware with a single memory space
         and only applies to extra global parameters which are pointers. */
@@ -198,6 +202,10 @@ public:
     /*! This is only used by extra global parameters which are pointers*/
     VarLocation getPSExtraGlobalParamLocation(size_t index) const{ return m_PSExtraGlobalParamLocation.at(index); }
 
+    //! Get name of neuron input variable postsynaptic model will target
+    /*! This will either be 'Isyn' or the name of one of the postsynaptic neuron's additional input variables. */
+    const std::string &getPSOutputVar() const{ return m_PSOutputVar; }
+    
     //! Get location of sparse connectivity initialiser extra global parameter by name
     /*! This is only used by extra global parameters which are pointers*/
     VarLocation getSparseConnectivityExtraGlobalParamLocation(const std::string &paramName) const;
@@ -454,4 +462,8 @@ private:
     //! Name of the synapse group in which postsynaptic model is located
     /*! This may not be the name of this group if it has been merged*/
     std::string m_PSModelTargetName;
+    
+    //! Name of neuron input variable postsynaptic model will target
+    /*! This should either be 'Isyn' or the name of one of the postsynaptic neuron's additional input variables. */
+    std::string m_PSOutputVar;
 };

--- a/pygenn/genn_groups.py
+++ b/pygenn/genn_groups.py
@@ -819,14 +819,14 @@ class SynapseGroup(Group):
         return (self.matrix_type & SynapseMatrixWeight_INDIVIDUAL_PSM) != 0
     
     @property
-    def ps_output_var(self):
+    def ps_target_var(self):
         """Gets name of neuron input variable postsynaptic model will target"""
-        return self.pop.get_psoutput_var()
+        return self.pop.get_pstarget_var()
 
     @ps_output_var.setter
-    def ps_output_var(self, var):
+    def ps_target_var(self, var):
         """Sets name of neuron input variable postsynaptic model will target"""
-        self.pop.set_psoutput_var(var)
+        self.pop.set_pstarget_var(var)
 
 
     def set_sparse_connections(self, pre_indices, post_indices):

--- a/pygenn/genn_groups.py
+++ b/pygenn/genn_groups.py
@@ -817,6 +817,17 @@ class SynapseGroup(Group):
         """Tests whether synaptic connectivity has
         individual postsynaptic model variables"""
         return (self.matrix_type & SynapseMatrixWeight_INDIVIDUAL_PSM) != 0
+    
+    @property
+    def ps_output_var(self):
+        """Gets name of neuron input variable postsynaptic model will target"""
+        return self.pop.get_psoutput_var()
+
+    @ps_output_var.setter
+    def ps_output_var(self, var):
+        """Sets name of neuron input variable postsynaptic model will target"""
+        self.pop.set_psoutput_var(var)
+
 
     def set_sparse_connections(self, pre_indices, post_indices):
         """Set ragged format connections between two groups of neurons

--- a/src/genn/genn/code_generator/generateNeuronUpdate.cc
+++ b/src/genn/genn/code_generator/generateNeuronUpdate.cc
@@ -256,6 +256,9 @@ void CodeGenerator::generateNeuronUpdate(const filesystem::path &outputPath, con
 
                 Substitutions inSynSubs(&neuronSubs);
                 inSynSubs.addVarSubstitution("inSyn", "linSyn");
+                
+                // Allow synapse group's PS output var to override what Isyn points to
+                inSynSubs.addVarSubstitution("Isyn", sg->getPSOutputVar(), true);
 
                 if (sg->getMatrixType() & SynapseMatrixWeight::INDIVIDUAL_PSM) {
                     inSynSubs.addVarNameSubstitution(psm->getVars(), "", "lps");

--- a/src/genn/genn/code_generator/generateNeuronUpdate.cc
+++ b/src/genn/genn/code_generator/generateNeuronUpdate.cc
@@ -258,7 +258,7 @@ void CodeGenerator::generateNeuronUpdate(const filesystem::path &outputPath, con
                 inSynSubs.addVarSubstitution("inSyn", "linSyn");
                 
                 // Allow synapse group's PS output var to override what Isyn points to
-                inSynSubs.addVarSubstitution("Isyn", sg->getPSOutputVar(), true);
+                inSynSubs.addVarSubstitution("Isyn", sg->getPSTargetVar(), true);
 
                 if (sg->getMatrixType() & SynapseMatrixWeight::INDIVIDUAL_PSM) {
                     inSynSubs.addVarNameSubstitution(psm->getVars(), "", "lps");

--- a/src/genn/genn/synapseGroup.cc
+++ b/src/genn/genn/synapseGroup.cc
@@ -75,6 +75,21 @@ void SynapseGroup::setPSVarLocation(const std::string &varName, VarLocation loc)
     m_PSVarLocation[getPSModel()->getVarIndex(varName)] = loc;
 }
 //----------------------------------------------------------------------------
+void SynapseGroup::setPSOutputVar(const std::string &varName)
+{
+    // If varname is either 'ISyn' or name of target neuron group additional input variable, store
+    const auto additionalInputVars = getTrgNeuronGroup()->getNeuronModel()->getAdditionalInputVars();
+    if(varName == "Isyn" || 
+       std::find_if(additionalInputVars.cbegin(), additionalInputVars.cend(), 
+                    [&varName](const Models::Base::ParamVal &v){ return (v.name == varName); }) != additionalInputVars.cend())
+    {
+        m_PSOutputVar = varName;
+    }
+    else {
+        throw std::runtime_error("Target neuron group has no input variable '" + varName + "'");
+    }
+}
+//----------------------------------------------------------------------------
 void SynapseGroup::setPSExtraGlobalParamLocation(const std::string &paramName, VarLocation loc)
 {
     const size_t extraGlobalParamIndex = getPSModel()->getExtraGlobalParamIndex(paramName);
@@ -437,7 +452,8 @@ SynapseGroup::SynapseGroup(const std::string &name, SynapseMatrixType matrixType
         m_WUPostVarLocation(wuPostVarInitialisers.size(), defaultVarLocation), m_WUExtraGlobalParamLocation(wu->getExtraGlobalParams().size(), defaultExtraGlobalParamLocation),
         m_PSVarLocation(psVarInitialisers.size(), defaultVarLocation), m_PSExtraGlobalParamLocation(ps->getExtraGlobalParams().size(), defaultExtraGlobalParamLocation),
         m_ConnectivityInitialiser(connectivityInitialiser), m_SparseConnectivityLocation(defaultSparseConnectivityLocation),
-        m_ConnectivityExtraGlobalParamLocation(connectivityInitialiser.getSnippet()->getExtraGlobalParams().size(), defaultExtraGlobalParamLocation), m_PSModelTargetName(name)
+        m_ConnectivityExtraGlobalParamLocation(connectivityInitialiser.getSnippet()->getExtraGlobalParams().size(), defaultExtraGlobalParamLocation), m_PSModelTargetName(name),
+        m_PSOutputVar("Isyn")
 {
     // Validate names
     Utils::validatePopName(name, "Synapse group");
@@ -655,6 +671,7 @@ boost::uuids::detail::sha1::digest_type SynapseGroup::getPSHashDigest() const
     Utils::updateHash(getPSModel()->getHashDigest(), hash);
     Utils::updateHash(getMaxDendriticDelayTimesteps(), hash);
     Utils::updateHash((getMatrixType() & SynapseMatrixWeight::INDIVIDUAL_PSM), hash);
+    Utils::updateHash(getPSOutputVar(), hash);
     return hash.get_digest();
 }
 //----------------------------------------------------------------------------
@@ -664,6 +681,7 @@ boost::uuids::detail::sha1::digest_type SynapseGroup::getPSLinearCombineHashDige
     Utils::updateHash(getPSModel()->getHashDigest(), hash);
     Utils::updateHash(getMaxDendriticDelayTimesteps(), hash);
     Utils::updateHash((getMatrixType() & SynapseMatrixWeight::INDIVIDUAL_PSM), hash);
+    Utils::updateHash(getPSOutputVar(), hash);
     Utils::updateHash(getPSParams(), hash);
     Utils::updateHash(getPSDerivedParams(), hash);
     return hash.get_digest();

--- a/src/genn/genn/synapseGroup.cc
+++ b/src/genn/genn/synapseGroup.cc
@@ -75,7 +75,7 @@ void SynapseGroup::setPSVarLocation(const std::string &varName, VarLocation loc)
     m_PSVarLocation[getPSModel()->getVarIndex(varName)] = loc;
 }
 //----------------------------------------------------------------------------
-void SynapseGroup::setPSOutputVar(const std::string &varName)
+void SynapseGroup::setPSTargetVar(const std::string &varName)
 {
     // If varname is either 'ISyn' or name of target neuron group additional input variable, store
     const auto additionalInputVars = getTrgNeuronGroup()->getNeuronModel()->getAdditionalInputVars();
@@ -83,7 +83,7 @@ void SynapseGroup::setPSOutputVar(const std::string &varName)
        std::find_if(additionalInputVars.cbegin(), additionalInputVars.cend(), 
                     [&varName](const Models::Base::ParamVal &v){ return (v.name == varName); }) != additionalInputVars.cend())
     {
-        m_PSOutputVar = varName;
+        m_PSTargetVar = varName;
     }
     else {
         throw std::runtime_error("Target neuron group has no input variable '" + varName + "'");
@@ -453,7 +453,7 @@ SynapseGroup::SynapseGroup(const std::string &name, SynapseMatrixType matrixType
         m_PSVarLocation(psVarInitialisers.size(), defaultVarLocation), m_PSExtraGlobalParamLocation(ps->getExtraGlobalParams().size(), defaultExtraGlobalParamLocation),
         m_ConnectivityInitialiser(connectivityInitialiser), m_SparseConnectivityLocation(defaultSparseConnectivityLocation),
         m_ConnectivityExtraGlobalParamLocation(connectivityInitialiser.getSnippet()->getExtraGlobalParams().size(), defaultExtraGlobalParamLocation), m_PSModelTargetName(name),
-        m_PSOutputVar("Isyn")
+        m_PSTargetVar("Isyn")
 {
     // Validate names
     Utils::validatePopName(name, "Synapse group");
@@ -671,7 +671,7 @@ boost::uuids::detail::sha1::digest_type SynapseGroup::getPSHashDigest() const
     Utils::updateHash(getPSModel()->getHashDigest(), hash);
     Utils::updateHash(getMaxDendriticDelayTimesteps(), hash);
     Utils::updateHash((getMatrixType() & SynapseMatrixWeight::INDIVIDUAL_PSM), hash);
-    Utils::updateHash(getPSOutputVar(), hash);
+    Utils::updateHash(getPSTargetVar(), hash);
     return hash.get_digest();
 }
 //----------------------------------------------------------------------------
@@ -681,7 +681,7 @@ boost::uuids::detail::sha1::digest_type SynapseGroup::getPSLinearCombineHashDige
     Utils::updateHash(getPSModel()->getHashDigest(), hash);
     Utils::updateHash(getMaxDendriticDelayTimesteps(), hash);
     Utils::updateHash((getMatrixType() & SynapseMatrixWeight::INDIVIDUAL_PSM), hash);
-    Utils::updateHash(getPSOutputVar(), hash);
+    Utils::updateHash(getPSTargetVar(), hash);
     Utils::updateHash(getPSParams(), hash);
     Utils::updateHash(getPSDerivedParams(), hash);
     return hash.get_digest();

--- a/tests/unit/synapseGroup.cc
+++ b/tests/unit/synapseGroup.cc
@@ -822,10 +822,10 @@ TEST(SynapseGroup, InvalidPSOutputVar)
         {}, { 1.0 },
         {}, {});
 
-    prePost->setPSOutputVar("Isyn");
-    prePost->setPSOutputVar("Isyn2");
+    prePost->setPSTargetVar("Isyn");
+    prePost->setPSTargetVar("Isyn2");
     try {
-        prePost->setPSOutputVar("NonExistent");
+        prePost->setPSTargetVar("NonExistent");
         FAIL();
     }
     catch (const std::runtime_error &) {

--- a/tests/unit/synapseGroup.cc
+++ b/tests/unit/synapseGroup.cc
@@ -105,6 +105,47 @@ class Sum : public CustomUpdateModels::Base
                   {"b", "scalar", VarAccessMode::READ_ONLY}});
 };
 IMPLEMENT_MODEL(Sum);
+
+class LIFAdditional : public NeuronModels::Base
+{
+public:
+    DECLARE_MODEL(LIFAdditional, 7, 2);
+
+    SET_ADDITIONAL_INPUT_VARS({{"Isyn2", "scalar", "$(Ioffset)"}});
+    SET_SIM_CODE(
+        "if ($(RefracTime) <= 0.0) {\n"
+        "  scalar alpha = ($(Isyn2) * $(Rmembrane)) + $(Vrest);\n"
+        "  $(V) = alpha - ($(ExpTC) * (alpha - $(V)));\n"
+        "}\n"
+        "else {\n"
+        "  $(RefracTime) -= DT;\n"
+        "}\n"
+    );
+
+    SET_THRESHOLD_CONDITION_CODE("$(RefracTime) <= 0.0 && $(V) >= $(Vthresh)");
+
+    SET_RESET_CODE(
+        "$(V) = $(Vreset);\n"
+        "$(RefracTime) = $(TauRefrac);\n");
+
+    SET_PARAM_NAMES({
+        "C",          // Membrane capacitance
+        "TauM",       // Membrane time constant [ms]
+        "Vrest",      // Resting membrane potential [mV]
+        "Vreset",     // Reset voltage [mV]
+        "Vthresh",    // Spiking threshold [mV]
+        "Ioffset",    // Offset current
+        "TauRefrac"});
+
+    SET_DERIVED_PARAMS({
+        {"ExpTC", [](const std::vector<double> &pars, double dt) { return std::exp(-dt / pars[1]); }},
+        {"Rmembrane", [](const std::vector<double> &pars, double) { return  pars[1] / pars[0]; }}});
+
+    SET_VARS({{"V", "scalar"}, {"RefracTime", "scalar"}});
+
+    SET_NEEDS_AUTO_REFRACTORY(false);
+};
+IMPLEMENT_MODEL(LIFAdditional);
 }   // Anonymous namespace
 
 //--------------------------------------------------------------------------
@@ -765,4 +806,28 @@ TEST(SynapseGroup, SharedWeightSlaveInvalidMethods)
     }
     //setSparseConnectivityExtraGlobalParamLocation
     //setMaxSourceConnections
+}
+
+TEST(SynapseGroup, InvalidPSOutputVar)
+{
+    LIFAdditional::ParamValues paramVals(0.25, 10.0, 0.0, 0.0, 20.0, 0.0, 5.0);
+    LIFAdditional::VarValues varVals(0.0, 0.0);
+
+    ModelSpec model;
+    model.addNeuronPopulation<NeuronModels::SpikeSource>("Pre", 10, {}, {});
+    model.addNeuronPopulation<LIFAdditional>("Post", 10, paramVals, varVals);
+    auto *prePost = model.addSynapsePopulation<WeightUpdateModels::StaticPulse, PostsynapticModels::DeltaCurr>(
+        "PrePost", SynapseMatrixType::SPARSE_INDIVIDUALG, NO_DELAY,
+        "Pre", "Post",
+        {}, { 1.0 },
+        {}, {});
+
+    prePost->setPSOutputVar("Isyn");
+    prePost->setPSOutputVar("Isyn2");
+    try {
+        prePost->setPSOutputVar("NonExistent");
+        FAIL();
+    }
+    catch (const std::runtime_error &) {
+    }
 }


### PR DESCRIPTION
As described in #451, previously, you needed to define a new postsynaptic model for each additional input variable you might want to connect synapses to e.g. you should be able to use a standard ``DeltaCurr`` rather than having to define:
```python
feedback_psm_model = genn_model.create_custom_postsynaptic_class(
    "feedback_psm",
    apply_input_code="""
    $(ISynFeedback) += $(inSyn);
    $(inSyn) = 0;
    """)
```
just to connect synapses to a neuron's ``ISynFeedback`` additional input variable. This PR instead allows you to do this in C++:
```c++
auto *syn= model.addSynapsePopulation<WeightUpdateModels::StaticPulse, PostsynapticModels::DeltaCurr>(
    "Syn", SynapseMatrixType::DENSE_INDIVIDUALG, NO_DELAY,
    "Pre", "Post",
    {}, { 1.0 },
    {}, {});
syn->setPSOutputVar("ISynFeedback");
```
or in Python
```python
syn = model.add_synapse_population("Syn", "DENSE_INDIVIDUALG", NO_DELAY,
    pre_pop, post_pop,
    "StaticPulse", {}, {"g": 1.0}, {}, {},
    "DeltaCurr", {}, {})
syn.ps_output_var = "ISynFeedback"
```

The implementation is trivial, my only question is whether "PS output variable" is a good names for these things rather than, for instance, "Target input variable" or "Postsynaptic input variable". Any thoughts much appreciated!

Fixes #451 