### PR TITLE
Fix multiple issues with sparse synapse index narrowing

### DIFF
--- a/include/genn/genn/synapseGroup.h
+++ b/include/genn/genn/synapseGroup.h
@@ -142,7 +142,13 @@ public:
     //! Is this synapse group a weight-sharing slave
     bool isWeightSharingSlave() const { return (getWeightSharingMaster() != nullptr); }
 
+    //! Has this synapse group's postsynaptic model been merged with others
+    /*! NOTE: this can only be called after model is finalized but needs to be public for PyGeNN */
     bool isPSModelMerged() const{ return m_PSModelTargetName != getName(); }
+
+    //! Get the type to use for sparse connectivity indices for synapse group
+    //! /*! NOTE: this can only be called after model is finalized but needs to be public for PyGeNN */
+    std::string getSparseIndType() const;
 
     const WeightUpdateModels::Base *getWUModel() const{ return m_WUModel; }
 
@@ -283,10 +289,7 @@ protected:
     /*! This is required when the pre-synaptic neuron population's outgoing synapse groups require different event threshold */
     bool isEventThresholdReTestRequired() const{ return m_EventThresholdReTestRequired; }
 
-    const std::string &getPSModelTargetName() const{ return m_PSModelTargetName; }    
-
-    //! Get the type to use for sparse connectivity indices for synapse group
-    std::string getSparseIndType() const;
+    const std::string &getPSModelTargetName() const{ return m_PSModelTargetName; }
 
     //! Are any of this synapse group's weight update model variables referenced by a custom update
     bool areWUVarReferencedByCustomUpdate() const { return m_WUVarReferencedByCustomUpdate;  }

--- a/pygenn/genn_groups.py
+++ b/pygenn/genn_groups.py
@@ -1050,7 +1050,7 @@ class SynapseGroup(Group):
                     # Get pointers to ragged data structure members
                     ind = self._assign_ext_ptr_array("ind",
                                                      self.weight_update_var_size,
-                                                     "unsigned int")
+                                                     self.pop.get_sparse_ind_type())
                     row_length = self._assign_ext_ptr_array("rowLength",
                                                             self.src.size,
                                                             "unsigned int")

--- a/src/genn/genn/code_generator/generateRunner.cc
+++ b/src/genn/genn/code_generator/generateRunner.cc
@@ -1228,7 +1228,7 @@ MemAlloc CodeGenerator::generateRunner(const filesystem::path &outputPath, const
                                                                     s.second.getSparseConnectivityLocation(), autoInitialized, s.second.getSrcNeuronGroup()->getNumNeurons());
 
                                         // Target indices
-                                        backend.genVariablePushPull(runnerPushFunc, runnerPullFunc, "unsigned int", "ind" + s.second.getName(), 
+                                        backend.genVariablePushPull(runnerPushFunc, runnerPullFunc,  s.second.getSparseIndType(), "ind" + s.second.getName(), 
                                                                     s.second.getSparseConnectivityLocation(), autoInitialized, size);
                                     });
             }

--- a/src/genn/genn/synapseGroup.cc
+++ b/src/genn/genn/synapseGroup.cc
@@ -238,6 +238,25 @@ bool SynapseGroup::isSpikeEventRequired() const
      return !getWUModel()->getEventCode().empty();
 }
 //----------------------------------------------------------------------------
+std::string SynapseGroup::getSparseIndType() const
+{
+    // If narrow sparse inds are enabled
+    if(m_NarrowSparseIndEnabled) {
+        // If number of target neurons can be represented using a uint8, use this type
+        const unsigned int numTrgNeurons = getTrgNeuronGroup()->getNumNeurons();
+        if(numTrgNeurons <= std::numeric_limits<uint8_t>::max()) {
+            return "uint8_t";
+        }
+        // Otherwise, if they can be represented as a uint16, use this type
+        else if(numTrgNeurons <= std::numeric_limits<uint16_t>::max()) {
+            return "uint16_t";
+        }
+    }
+
+    // Otherwise, use 32-bit int
+    return "uint32_t";
+}
+//----------------------------------------------------------------------------
 const std::vector<double> SynapseGroup::getWUConstInitVals() const
 {
     return getConstInitVals(m_WUVarInitialisers);
@@ -588,26 +607,6 @@ void SynapseGroup::initDerivedParams(double dt)
 
     // Initialise any derived connectivity initialiser parameters
     m_ConnectivityInitialiser.initDerivedParams(dt);
-}
-//----------------------------------------------------------------------------
-std::string SynapseGroup::getSparseIndType() const
-{
-    // If narrow sparse inds are enabled
-    if(m_NarrowSparseIndEnabled) {
-        // If number of target neurons can be represented using a uint8, use this type
-        const unsigned int numTrgNeurons = getTrgNeuronGroup()->getNumNeurons();
-        if(numTrgNeurons <= std::numeric_limits<uint8_t>::max()) {
-            return "uint8_t";
-        }
-        // Otherwise, if they can be represented as a uint16, use this type
-        else if(numTrgNeurons <= std::numeric_limits<uint16_t>::max()) {
-            return "uint16_t";
-        }
-    }
-
-    // Otherwise, use 32-bit int
-    return "uint32_t";
-
 }
 //----------------------------------------------------------------------------
 bool SynapseGroup::canPSBeLinearlyCombined() const

--- a/tests/features/connect_init/model.cc
+++ b/tests/features/connect_init/model.cc
@@ -23,6 +23,7 @@ void modelDefinition(ModelSpec &model)
 #endif
     model.setDT(0.1);
     model.setName("connect_init");
+    model.setDefaultNarrowSparseIndEnabled(true);
 
     NeuronModels::LIF::ParamValues lifParams(
                 0.25,   // 0 - C

--- a/tests/features/connect_init/test.cc
+++ b/tests/features/connect_init/test.cc
@@ -32,8 +32,8 @@ class SimTest : public SimulationTest
 {
 };
 
-template<size_t N>
-void calcHistogram(const unsigned int *rowLength, const uint32_t *ind,
+template<size_t N, typename I>
+void calcHistogram(const unsigned int *rowLength, const I *ind,
                    unsigned int maxRowLength, std::array<unsigned int, N> &histogram)
 {
     // Loop through rows


### PR DESCRIPTION
In #274 I implemented support for 'narrow' sparse synapse indices so, if the postsynaptic population was < 65536 neurons, ``uint16_t`` would be used and if < 256 neurons, ``uint8_t``. However:

1.  PyGeNN always tried to access  the sparse synapse indices as ``uint32_t`` - it now calls``SynapseGroup::getSparseIndType`` to get correct type
2. In the generated code for ``pushXXConnectivityToDevice`` and ``pullXXConnectivityToDevice``, ``unsigned int`` was always being used - this also now uses the correct type.