### PR TITLE
Missing include breaks compilation on Visual C++ 2017

### DIFF
--- a/src/genn/genn/gennUtils.cc
+++ b/src/genn/genn/gennUtils.cc
@@ -3,6 +3,9 @@
 // Standard C++ includes
 #include <algorithm>
 
+// Standard C includes
+#include <cctype>
+
 // GeNN includes
 #include "models.h"
 


### PR DESCRIPTION
Hadn't tested on Visual C++ 2017 for a while and, as is always the way, standard library header files are subtly different so an additional include was required