### PR TITLE
Sync PyGeNN version to main GeNN version

### DIFF
--- a/pygenn/__init__.py
+++ b/pygenn/__init__.py
@@ -1,3 +1,13 @@
-# Import pygenn interface
+# python imports
+import sys
+
+# pygenn interface
 from .genn_groups import SynapseGroup, NeuronGroup, CurrentSource
 from .genn_model import GeNNModel
+
+if sys.version_info >= (3, 8):
+    from importlib import metadata
+else:
+    import importlib_metadata as metadata
+
+__version__ = metadata.version("pygenn")

--- a/setup.py
+++ b/setup.py
@@ -177,8 +177,12 @@ for filename, namespace, kwargs in backends:
     ext_modules.append(Extension("_" + namespace + "Backend", ["pygenn/genn_wrapper/generated/" + namespace + "Backend.i"],
                                  **backend_extension_kwargs))
 
+# Read version from txt file
+with open(os.path.join(genn_path, "version.txt")) as version_file:
+    version = version_file.read().strip()
+
 setup(name = "pygenn",
-      version = "0.4.6",
+      version = version,
       packages = find_packages(),
       package_data={"pygenn": package_data},
 
@@ -189,6 +193,7 @@ setup(name = "pygenn",
       ext_modules=ext_modules,
 
       # Requirements
-      install_requires=["numpy>=1.17", "six", "deprecated", "psutil"],
+      install_requires=["numpy>=1.17", "six", "deprecated", "psutil",
+                        "importlib-metadata>=1.0;python_version<'3.8'"],
       zip_safe=False,  # Partly for performance reasons
 )


### PR DESCRIPTION
By doing the following:
* Read version.txt to provide package version in setup.py
* Query package metadata to provide version at runtime (pygenn.__version__)

The PyGeNN version will be synchronised with the main GeNN version (PyGeNN versions were previously manually set to 0.X.Y)

Fixes #442