### PR TITLE
Fixed a small problem with the MBody1 example. 

### DIFF
--- a/userproject/MBody1_project/generate_run.cc
+++ b/userproject/MBody1_project/generate_run.cc
@@ -53,7 +53,6 @@ protected:
         // <nAL> <# classes> <# pattern/ input class> <prob. to be active> <perturbation prob. in class>
         // <'on' rate> <baseline rate>
         cmd +=  std::to_string(m_NumAL);
-        cerr << "<outfile> 
         cmd += " 10 10 0.1 0.1 1000.0 0.2 ";   // p_perturb only sensible if >= 1/n_act (where n_act=p_act*nAL); this assumes nAL >= 100
         cmd += getOutDir() + "/" + getExperimentName() + ".inpat 2>&1 ";
 #ifndef _WIN32


### PR DESCRIPTION
The previous choice of p_perturb meant that literally all patterns in the same class were identical as n_perturb == (int) (0.05*10) == 0 active neurons were changed.
I have added a couple of comments that hopefully help newcomers to understand the code better around this issue.
Credit to Jinwoo Kim who spotted the problem.