### PR TITLE
Include model name in DLL name on Windows

### DIFF
--- a/generate_swig_interfaces.py
+++ b/generate_swig_interfaces.py
@@ -601,7 +601,7 @@ def generateConfigs(gennPath, backends):
             #ifdef _WIN32
                 // Create MSBuild project to compile and link all generated modules
                 std::ofstream makefile((outputPath / "runner.vcxproj").str());
-                CodeGenerator::generateMSBuild(makefile, backend, "", output.first);
+                CodeGenerator::generateMSBuild(makefile, model, backend, "", output.first);
             #else
                 // Create makefile to compile and link all generated modules
                 std::ofstream makefile((outputPath / "Makefile").str());

--- a/include/genn/genn/code_generator/backendBase.h
+++ b/include/genn/genn/code_generator/backendBase.h
@@ -75,6 +75,10 @@ struct PreferencesBase
     //! Should GeNN generate pull functions for extra global parameters? These are very rarely used
     bool generateExtraGlobalParamPull = true;
 
+    //! On Windows, should the model name be included in the name of the DLL 
+    //! i.e. runner_test_model_Release.dll rather than runner_Release.dll
+    bool includeModelNameInDLL = false;
+
     //! C++ compiler options to be used for building all host side code (used for unix based platforms)
     std::string userCxxFlagsGNU = "";
 

--- a/include/genn/genn/code_generator/generateMSBuild.h
+++ b/include/genn/genn/code_generator/generateMSBuild.h
@@ -18,6 +18,6 @@ class BackendBase;
 //--------------------------------------------------------------------------
 namespace CodeGenerator
 {
-GENN_EXPORT void generateMSBuild(std::ostream &os, const BackendBase &backend, const std::string &projectGUID,
-                                 const std::vector<std::string> &moduleNames);
+GENN_EXPORT void generateMSBuild(std::ostream &os, const ModelSpecInternal &model, const BackendBase &backend, 
+                                 const std::string &projectGUID, const std::vector<std::string> &moduleNames);
 }

--- a/pygenn/genn_model.py
+++ b/pygenn/genn_model.py
@@ -571,7 +571,10 @@ class GeNNModel(object):
         for k, v in iteritems(self._preferences):
             if hasattr(preferences, k):
                 setattr(preferences, k, v)
-
+        
+        # When using PyGeNN, always include model name in DLL
+        preferences.includeModelNameInDLL = True
+        
         # Create backend
         backend = self._backend_module.create_backend(self._model, output_path,
                                                       self.backend_log_level,
@@ -600,7 +603,7 @@ class GeNNModel(object):
             raise Exception("GeNN model already loaded")
         self._path_to_model = path_to_model
 
-        self._slm.open(self._path_to_model, self.model_name)
+        self._slm.open(self._path_to_model, self.model_name, True)
 
         self._slm.allocate_mem()
 

--- a/src/genn/generator/generator.cc
+++ b/src/genn/generator/generator.cc
@@ -110,7 +110,7 @@ int main(int argc,     //!< number of arguments; expected to be 3
         }
         // Create MSBuild project to compile and link all generated modules
         std::ofstream makefile((outputPath / "runner.vcxproj").str());
-        CodeGenerator::generateMSBuild(makefile, backend, projectGUIDString, moduleNames);
+        CodeGenerator::generateMSBuild(makefile, model, backend, projectGUIDString, moduleNames);
 #else
         // Create makefile to compile and link all generated modules
         std::ofstream makefile((outputPath / "Makefile").str());

--- a/src/genn/genn/code_generator/generateMSBuild.cc
+++ b/src/genn/genn/code_generator/generateMSBuild.cc
@@ -3,14 +3,17 @@
 // Standard C++ includes
 #include <string>
 
+// GeNN includes
+#include "modelSpecInternal.h"
+
 // GeNN code generator includes
 #include "code_generator/backendBase.h"
 
 //--------------------------------------------------------------------------
 // CodeGenerator
 //--------------------------------------------------------------------------
-void CodeGenerator::generateMSBuild(std::ostream &os, const BackendBase &backend, const std::string &projectGUID,
-    const std::vector<std::string> &moduleNames)
+void CodeGenerator::generateMSBuild(std::ostream &os, const ModelSpecInternal &model, const BackendBase &backend, 
+                                    const std::string &projectGUID, const std::vector<std::string> &moduleNames)
 {
     // Generate header and targets for release and debug builds
     os << "<?xml version=\"1.0\" encoding=\"utf-8\"?>" << std::endl;
@@ -59,7 +62,12 @@ void CodeGenerator::generateMSBuild(std::ostream &os, const BackendBase &backend
     os << "\t<PropertyGroup>" << std::endl;
     os << "\t\t<LinkIncremental Condition=\"'$(Configuration)'=='Debug'\">true</LinkIncremental>" << std::endl;
     os << "\t\t<OutDir>../</OutDir>" << std::endl;
-    os << "\t\t<TargetName>$(ProjectName)_$(Configuration)</TargetName>" << std::endl;
+    if(backend.getPreferences().includeModelNameInDLL) {
+        os << "\t\t<TargetName>runner_" << model.getName() << "_$(Configuration)</TargetName>" << std::endl;
+    }
+    else {
+        os << "\t\t<TargetName>runner_$(Configuration)</TargetName>" << std::endl;
+    }
     os << "\t\t<TargetExt>.dll</TargetExt>" << std::endl;
     os << "\t</PropertyGroup>" << std::endl;
 

--- a/src/spineml/generator/main.cc
+++ b/src/spineml/generator/main.cc
@@ -630,7 +630,7 @@ int main(int argc, char *argv[])
         // **NOTE** scope requiredso it gets closed before being built
         {
             std::ofstream makefile((codePath / "runner.vcxproj").str());
-            CodeGenerator::generateMSBuild(makefile, backend, "", moduleNames);
+            CodeGenerator::generateMSBuild(makefile, model, backend, "", moduleNames);
         }
 
         // Generate command to build using msbuild

--- a/userproject/include/sharedLibraryModel.h
+++ b/userproject/include/sharedLibraryModel.h
@@ -40,9 +40,10 @@ public:
     {
     }
 
-    SharedLibraryModel(const std::string &pathToModel, const std::string &modelName)
+    SharedLibraryModel(const std::string &pathToModel, const std::string &modelName,
+                       bool includeModelNameInDLL = false)
     {
-        if(!open(pathToModel, modelName)) {
+        if(!open(pathToModel, modelName, includeModelNameInDLL)) {
             throw std::runtime_error("Unable to open library");
         }
     }
@@ -63,13 +64,15 @@ public:
     //----------------------------------------------------------------------------
     // Public API
     //----------------------------------------------------------------------------
-    bool open(const std::string &pathToModel, const std::string &modelName)
+    bool open(const std::string &pathToModel, const std::string &modelName,
+              bool includeModelNameInDLL = false)
     {
 #ifdef _WIN32
+        const std::string runnerName = includeModelNameInDLL ? ("runner_" + modelName) : "runner";
 #ifdef _DEBUG
-        const std::string libraryName = pathToModel + "\\runner_Debug.dll";
+        const std::string libraryName = pathToModel + "\\" + runnerName + "_Debug.dll";
 #else
-        const std::string libraryName = pathToModel + "\\runner_Release.dll";
+        const std::string libraryName = pathToModel + "\\" + runnerName + "_Release.dll";
 #endif
         m_Library = LoadLibrary(libraryName.c_str());
 #else


### PR DESCRIPTION
Due to the inflexibility of Windows DLLfinding, ``runner_Release.dll`` (or ``runner_Debug.dll``) is created in the same directory as the script (rather than in the ``***_CODE`` sub-directory with everything else). Previously this was only a minor annoyance but, now the caching system (#430)  means that models don't always get rebuilt, it can lead to an issue where, if you have multiple models in one directory, a DLL for the wrong model will get loaded.

This PR solves this by adding a flag which includes the model name in the DLL name (for backward compatibility, for now, this is not the default). In PyGeNN, as we're in control of both building and loading the DLL, this is now the default.