### PR TITLE
Fixed for strided convolutions

### DIFF
--- a/include/genn/genn/initSparseConnectivitySnippet.h
+++ b/include/genn/genn/initSparseConnectivitySnippet.h
@@ -415,9 +415,9 @@ public:
     SET_ROW_BUILD_STATE_VARS({{"inRow", "int", "($(id_pre) / (int)$(conv_ic)) / (int)$(conv_iw)"},
                               {"inCol", "int", "($(id_pre) / (int)$(conv_ic)) % (int)$(conv_iw)"},
                               {"inChan", "int", "$(id_pre) % (int)$(conv_ic)"},
-                              {"outRow", "int", "min((int)$(conv_oh), max(0, 1 + ((inRow + (int)$(conv_padh) - (int)$(conv_kh)) / (int)$(conv_sh))))"},
+                              {"outRow", "int", "min((int)$(conv_oh), max(0, 1 + (int)floor((inRow + $(conv_padh) - $(conv_kh)) / $(conv_sh))))"},
                               {"maxOutRow", "int", "min((int)$(conv_oh), max(0, 1 + ((inRow + (int)$(conv_padh)) / (int)$(conv_sh))))"},
-                              {"minOutCol", "int", "min((int)$(conv_ow), max(0, 1 + ((inCol + (int)$(conv_padw) - (int)$(conv_kw)) / (int)$(conv_sw))))"},
+                              {"minOutCol", "int", "min((int)$(conv_ow), max(0, 1 + (int)floor((inCol + $(conv_padw) - $(conv_kw)) / $(conv_sw))))"},
                               {"maxOutCol", "int", "min((int)$(conv_ow), max(0, 1 + ((inCol + (int)$(conv_padw)) / (int)$(conv_sw))))"}});
 
     SET_ROW_BUILD_CODE(

--- a/src/genn/genn/code_generator/initGroupMerged.cc
+++ b/src/genn/genn/code_generator/initGroupMerged.cc
@@ -695,6 +695,7 @@ void SynapseConnectivityInitGroupMerged::genInitConnectivity(CodeStream &os, Sub
         // Apply substitutions to value
         std::string value = a.value;
         popSubs.applyCheckUnreplaced(value, "initSparseConnectivity state var : merged" + std::to_string(getIndex()));
+        value = ensureFtype(value, ftype);
 
         os << a.type << " " << a.name << " = " << value << ";" << std::endl;
     }

--- a/src/genn/genn/code_generator/neuronUpdateGroupMerged.cc
+++ b/src/genn/genn/code_generator/neuronUpdateGroupMerged.cc
@@ -247,6 +247,7 @@ void NeuronUpdateGroupMerged::generateNeuronUpdate(const BackendBase &backend, C
         // Apply substitutions to value
         std::string value = a.value;
         neuronSubs.applyCheckUnreplaced(value, "neuron additional input var : merged" + std::to_string(getIndex()));
+        value = ensureFtype(value, modelMerged.getModel().getPrecision());
 
         os << a.type << " " << a.name << " = " << value << ";" << std::endl;
     }

--- a/src/genn/genn/code_generator/synapseUpdateGroupMerged.cc
+++ b/src/genn/genn/code_generator/synapseUpdateGroupMerged.cc
@@ -249,7 +249,7 @@ void PresynapticUpdateGroupMerged::generateProceduralConnectivity(const BackendB
         // Apply substitutions to value
         std::string value = a.value;
         popSubs.applyCheckUnreplaced(value, "proceduralSparseConnectivity row build state var : merged" + std::to_string(getIndex()));
-
+        value = ensureFtype(value, modelMerged.getModel().getPrecision());
         os << a.type << " " << a.name << " = " << value << ";" << std::endl;
     }
 


### PR DESCRIPTION
Two fixes here:
* We weren't calling ``ensureFtype`` on code used to initialise state variables e.g. the row-build state variables for procedural connectivity. In cases where all calculation couldn't be optimised out, this could lead to double-precision maths happening.
* When calculating convolutions with stride, you perform a calculation like ``1 + ((inRow - kernelSize) / stride)`` to obtain the lower bound of output rows to loop through. That division **should** be rounding towards -infinity rather than towards zero to handle cases like ``inRow=1``, ``kernelSize=3``, ``stride=2`` where you want to be starting at row 0 but the code was incorrectly giving 1. I have fixed by moving the calculation to floating point and using floor.

This is cherry-picked from the toeplitz_kernelg branch as it's not really related