### PR TITLE
Another convolution fix

### DIFF
--- a/include/genn/genn/initSparseConnectivitySnippet.h
+++ b/include/genn/genn/initSparseConnectivitySnippet.h
@@ -441,12 +441,12 @@ public:
     SET_CALC_MAX_ROW_LENGTH_FUNC(
         [](unsigned int, unsigned int, const std::vector<double> &pars)
         {
-            const unsigned int conv_kh = (unsigned int)pars[0];
-            const unsigned int conv_kw = (unsigned int)pars[1];
-            const unsigned int conv_sh = (unsigned int)pars[2];
-            const unsigned int conv_sw = (unsigned int)pars[3];
+            const double conv_kh = pars[0];
+            const double conv_kw = pars[1];
+            const double conv_sh = pars[2];
+            const double conv_sw = pars[3];
             const unsigned int conv_oc = (unsigned int)pars[11];
-            return (conv_kh / conv_sh) * (conv_kw / conv_sw) * conv_oc;
+            return (unsigned int)std::ceil(conv_kh / conv_sh) * (unsigned int)std::ceil(conv_kw / conv_sw) * conv_oc;
         });
 
     SET_CALC_KERNEL_SIZE_FUNC(


### PR DESCRIPTION
We have been calculating max row length for building sparse matrices from Conv2D connectivity by multiplying the number of output channels by ones of these terms for each dimension (where X is unknown):
```
floor((X + pad) / stride) - floor((X + pad - kern_size) / stride)
```
Previously I had simplified this to:
```
floor(kern_size / stride)
```
But, I think this is correct:
```
ceil(kern_size / stride)
```
The cases that were crashing now don't but I'm not quite sure what the floor/ceiling function relation 'proves' it.....
