### PR TITLE
Check event code for den delay

### DIFF
--- a/src/genn/genn/synapseGroup.cc
+++ b/src/genn/genn/synapseGroup.cc
@@ -404,6 +404,11 @@ bool SynapseGroup::isDendriticDelayRequired() const
         return true;
     }
 
+    // If addToInSynDelay function is used in event code, return true
+    if(getWUModel()->getEventCode().find("$(addToInSynDelay") != std::string::npos) {
+        return true;
+    }
+
     // If addToInSynDelay function is used in synapse dynamics, return true
     if(getWUModel()->getSynapseDynamicsCode().find("$(addToInSynDelay") != std::string::npos) {
         return true;


### PR DESCRIPTION
Until Anindya tried, clearly no one has tried using heterogeneous delays and spike-like events - the event code was never getting searched for ``addToInSynDelay`` so code wasn't compiling. Also added a unit test