### PR TITLE
Missing PyGenn toeplitz

### DIFF
--- a/src/genn/genn/code_generator/presynapticUpdateStrategySIMT.cc
+++ b/src/genn/genn/code_generator/presynapticUpdateStrategySIMT.cc
@@ -945,9 +945,8 @@ void PostSpanToeplitz::genUpdate(CodeStream &os, const ModelSpecMerged &modelMer
                 // Otherwise
                 else {
                     // If we should use shared memory, add to shared memory
-                    // **THINK** this is only correct if there are no multapses i.e. there is only one synapse between any pair of pre and postsynaptic neurons
                     if(isSmallSharedMemoryPop(sg, backend)) {
-                        presynapticUpdateSubs.addFuncSubstitution("addToInSyn", 1, "shLg[" + presynapticUpdateSubs["id_post"] + "] += $(0)");
+                        presynapticUpdateSubs.addFuncSubstitution("addToInSyn", 1, "shLg[$(id_post)] += $(0)");
                     }
                     // Otherwise, use global memory atomic
                     else {


### PR DESCRIPTION
Yet another branch, left behind after the pre-Christmas flurry of ANN conversation...This fixes two issues:
- Totally forgot to expose defining custom Toeplitz models to PyGeNN
- With pooling, you can easily hit the code path where the target population is small enough to fit in shared memory and...this was  broken