### PR TITLE
Detect WSL when linking CUDA and add additional wsl linker path

### DIFF
--- a/src/genn/MakefileCommon
+++ b/src/genn/MakefileCommon
@@ -1,7 +1,9 @@
 # Determine whether OS is Darwin i.e. Mac OS X and whether the kernel is 32 or 64 bit
 OS_SIZE				:=$(shell getconf LONG_BIT)
 OS_UPPER			:=$(shell uname -s 2>/dev/null | tr [:lower:] [:upper:])
+OS_RELEASE_UPPER		:=$(shell uname -r 2>/dev/null | tr [:lower:] [:upper:])
 DARWIN				:=$(strip $(findstring DARWIN,$(OS_UPPER)))
+MICROSOFT			:=$(strip $(findstring MICROSOFT,$(OS_RELEASE_UPPER)))
 
 # Get directory of this makefile i.e. GeNN directory (means make can be invoked else where)
 GENN_DIR			:= $(abspath $(dir $(lastword $(MAKEFILE_LIST)))../../)
@@ -25,7 +27,7 @@ endif
 
 ifdef COVERAGE
     GENN_PREFIX			:=$(GENN_PREFIX)_coverage
-    
+
     # Use clang's source-based coverage on OS X
     ifeq ($(DARWIN),DARWIN)
         CXXFLAGS		+=-O0 -fprofile-instr-generate -fcoverage-mapping

--- a/src/genn/generator/MakefileCUDA
+++ b/src/genn/generator/MakefileCUDA
@@ -15,6 +15,9 @@ CXXFLAGS		+= -I"$(CUDA_PATH)/include"
 ifeq ($(DARWIN),DARWIN)
     LDFLAGS		+=-rpath $(CUDA_PATH)/lib -L"$(CUDA_PATH)/lib" -lcuda -lcudart -pthread
 else
+    ifeq ($(MICROSOFT),MICROSOFT)
+        LDFLAGS		+=-L"/usr/lib/wsl/lib"
+    endif
     ifeq ($(OS_SIZE),32)
         LDFLAGS		+=-L"$(CUDA_PATH)/lib" -lcuda -lcudart -pthread 
     else

--- a/src/spineml/generator/MakefileCUDA
+++ b/src/spineml/generator/MakefileCUDA
@@ -16,6 +16,9 @@ CXXFLAGS		+= -I"$(CUDA_PATH)/include"
 ifeq ($(DARWIN),DARWIN)
     LDFLAGS		+=-rpath $(CUDA_PATH)/lib -L"$(CUDA_PATH)/lib" -lcuda -lcudart -pthread
 else
+    ifeq ($(MICROSOFT),MICROSOFT)
+        LDFLAGS         +=-L"/usr/lib/wsl/lib"
+    endif
     ifeq ($(OS_SIZE),32)
         LDFLAGS		+=-L"$(CUDA_PATH)/lib" -lcuda -lcudart -pthread
     else


### PR DESCRIPTION
I've been playing with the updated version of Windows Subsystem for Linux which provides support for CUDA (and x-forwarding) in the Linux image. Because GeNN links to the CUDA driver as well as the runtime, a small change is required as the CUDA driver is in a weird location (essentially it's mounted from the Windows driver installation)

Overall, it seems to perform pretty well - only a marginal increase in overhead compared to running natively on Windows