### PR TITLE
Lookup data structures not taking batching into account

### DIFF
--- a/include/genn/genn/code_generator/backendSIMT.h
+++ b/include/genn/genn/code_generator/backendSIMT.h
@@ -155,6 +155,7 @@ public:
 
     size_t getKernelBlockSize(Kernel kernel) const { return m_KernelBlockSizes.at(kernel); }
 
+    size_t getPaddedNumCustomUpdateThreads(const CustomUpdateInternal &cg, unsigned int batchSize) const;
     size_t getPaddedNumCustomUpdateWUThreads(const CustomUpdateWUInternal &cg, unsigned int batchSize) const;
     size_t getPaddedNumCustomUpdateTransposeWUThreads(const CustomUpdateWUInternal &cg, unsigned int batchSize) const;
     

--- a/src/genn/backends/cuda/backend.cc
+++ b/src/genn/backends/cuda/backend.cc
@@ -729,7 +729,7 @@ void Backend::genCustomUpdate(CodeStream &os, const ModelSpecMerged &modelMerged
         {
             genFilteredMergedKernelDataStructures(os, totalConstMem,
                                                   modelMerged.getMergedCustomUpdateGroups(),
-                                                  [this](const CustomUpdateInternal &cg){ return padKernelSize(cg.getSize(), KernelCustomUpdate); },
+                                                  [&model, this](const CustomUpdateInternal &cg){ return getPaddedNumCustomUpdateThreads(cg, model.getBatchSize()); },
                                                   [g](const CustomUpdateGroupMerged &cg){ return cg.getArchetype().getUpdateGroupName() == g; },
 
                                                   modelMerged.getMergedCustomUpdateWUGroups(),

--- a/src/genn/backends/opencl/backend.cc
+++ b/src/genn/backends/opencl/backend.cc
@@ -892,7 +892,7 @@ void Backend::genCustomUpdate(CodeStream &os, const ModelSpecMerged &modelMerged
             genFilteredMergedKernelDataStructures(
                 customUpdateKernels,
                 modelMerged.getMergedCustomUpdateGroups(),
-                [this](const CustomUpdateInternal &cg) { return padKernelSize(cg.getSize(), KernelCustomUpdate); },
+                [&model, this](const CustomUpdateInternal &cg) { return getPaddedNumCustomUpdateThreads(cg, model.getBatchSize()); },
                 [g](const CustomUpdateGroupMerged &c){ return (c.getArchetype().getUpdateGroupName() == g.first); },
 
                 modelMerged.getMergedCustomUpdateWUGroups(),

--- a/src/genn/genn/code_generator/backendSIMT.cc
+++ b/src/genn/genn/code_generator/backendSIMT.cc
@@ -195,6 +195,12 @@ size_t BackendSIMT::getNumInitialisationRNGStreams(const ModelSpecMerged &modelM
     return numInitThreads;
 }
 //--------------------------------------------------------------------------
+size_t BackendSIMT::getPaddedNumCustomUpdateThreads(const CustomUpdateInternal &cg, unsigned int batchSize) const
+{
+    const size_t numCopies = cg.isBatched() ? batchSize : 1;
+    return numCopies * padKernelSize(cg.getSize(), KernelCustomUpdate);
+}
+//--------------------------------------------------------------------------
 size_t BackendSIMT::getPaddedNumCustomUpdateWUThreads(const CustomUpdateWUInternal &cg, unsigned int batchSize) const
 {
     const SynapseGroupInternal *sgInternal = static_cast<const SynapseGroupInternal*>(cg.getSynapseGroup());


### PR DESCRIPTION
I've been trying to use custom updates to do more of the resetting style stuff in mlGeNN and everything was breaking as batch size increased. Turns out this was totally broken as, for custom updates targetting neurons, the indices within which threads binary search to find their population were generated as if batch size = 1.

None of your models use custom updates on duplicated (i.e. batched) neuron group variables do they @tnowotny?