### PR TITLE
Fix hashing bugs

### DIFF
--- a/include/genn/genn/gennUtils.h
+++ b/include/genn/genn/gennUtils.h
@@ -123,23 +123,25 @@ inline std::string writePreciseString(T value)
     return s.str();
 }
 
+//! Hash arithmetic types and enums
+template<typename T, typename std::enable_if<std::is_arithmetic<T>::value || std::is_enum<T>::value>::type* = nullptr>
+inline void updateHash(const T& value, boost::uuids::detail::sha1& hash)
+{
+    hash.process_bytes(&value, sizeof(T));
+}
+
 //! Hash strings
 inline void updateHash(const std::string &string, boost::uuids::detail::sha1 &hash)
 {
+    updateHash(string.size(), hash);
     hash.process_bytes(string.data(), string.size());
-}
-
-//! Hash arithmetic types and enums
-template<typename T, typename std::enable_if<std::is_arithmetic<T>::value || std::is_enum<T>::value>::type * = nullptr>
-inline void updateHash(const T &value, boost::uuids::detail::sha1 &hash)
-{
-    hash.process_bytes(&value, sizeof(T));
 }
 
 //! Hash arrays of types which can, themselves, be hashed
 template<typename T, size_t N>
 inline void updateHash(const std::array<T, N> &array, boost::uuids::detail::sha1 &hash)
 {
+    updateHash(array.size(), hash);
     for(const auto &v : array) {
         updateHash(v, hash);
     }
@@ -149,6 +151,7 @@ inline void updateHash(const std::array<T, N> &array, boost::uuids::detail::sha1
 template<typename T>
 inline void updateHash(const std::vector<T> &vector, boost::uuids::detail::sha1 &hash)
 {
+    updateHash(vector.size(), hash);
     for(const auto &v : vector) {
         updateHash(v, hash);
     }
@@ -157,6 +160,7 @@ inline void updateHash(const std::vector<T> &vector, boost::uuids::detail::sha1 
 //! Hash vectors of bools
 inline void updateHash(const std::vector<bool> &vector, boost::uuids::detail::sha1 &hash)
 {
+    updateHash(vector.size(), hash);
     for(bool v : vector) {
         updateHash(v, hash);
     }

--- a/src/genn/genn/synapseGroup.cc
+++ b/src/genn/genn/synapseGroup.cc
@@ -978,6 +978,9 @@ boost::uuids::detail::sha1::digest_type SynapseGroup::getWUInitHashDigest() cons
     Utils::updateHash(getSparseIndType(), hash);
     Utils::updateHash(getWUModel()->getVars(), hash);
 
+    Utils::updateHash(getWUModel()->getSynapseDynamicsCode().empty(), hash);
+    Utils::updateHash(getWUModel()->getLearnPostCode().empty(), hash);
+
     // Include variable initialiser hashes
     for(const auto &w : getWUVarInitialisers()) {
         Utils::updateHash(w.getHashDigest(), hash);

--- a/tests/unit/gennUtils.cc
+++ b/tests/unit/gennUtils.cc
@@ -86,3 +86,36 @@ TEST(GeNNUtils, ValidateVecNames)
     catch(const std::runtime_error &) {
     }
 }
+//--------------------------------------------------------------------------
+TEST(GeNNUtils, StringHashing)
+{
+    // Hash "hello" followed by empty string
+    boost::uuids::detail::sha1 hash1;
+    Utils::updateHash("hello", hash1);
+    Utils::updateHash("", hash1);
+
+    // Hash empty string followed by "hello"
+    boost::uuids::detail::sha1 hash2;
+    Utils::updateHash("", hash2);
+    Utils::updateHash("hello", hash2);
+
+    ASSERT_NE(hash1.get_digest(), hash2.get_digest());
+}
+//--------------------------------------------------------------------------
+TEST(GeNNUtils, VectorHashing)
+{
+    const std::vector<float> vector1{ 1.0f, 0.0f };
+    const std::vector<float> vector2;
+
+    // Hash "hello" followed by empty string
+    boost::uuids::detail::sha1 hash1;
+    Utils::updateHash(vector1, hash1);
+    Utils::updateHash(vector2, hash1);
+
+    // Hash empty string followed by "hello"
+    boost::uuids::detail::sha1 hash2;
+    Utils::updateHash(vector2, hash2);
+    Utils::updateHash(vector1, hash2);
+
+    ASSERT_NE(hash1.get_digest(), hash2.get_digest());
+}


### PR DESCRIPTION
When calculating the hashes used to merge groups together for **initialization**, _usually_ all that we care about is the names and types of the state variables and how they are initialised _but_ with SIMT backends where additional data structures are required for synapse dynamics/postsynaptic updates this is not enough. This fix simply includes whether weight update models include synapse dynamics and postsynaptic update code in the hash used to determine mergeability - this ignores the backend specific-details so will sometimes split initialization unnecessarily on CPU but fixes this (nasty) issue.

Furthermore, while trying to write a unit test to test this, I found a subtler issue that could also potentially cause issues. Essentially hashing an empty container (``std::vector``, ``std::string`` etc) had no effect on the hash so the following code:
 ```cpp
 Utils::updateHash("", hash);
 Utils::updateHash("test", hash);
 ```
generates the same hash as:
 ```cpp
 Utils::updateHash("test", hash);
 ```

I've fixed this by hashing the size of the container before hashing the contents (which, one way or another, involves looping through the bytes of the contents). This PR fixes both issues.