### PR TITLE
Fix batch init

### DIFF
--- a/src/genn/genn/code_generator/initGroupMerged.cc
+++ b/src/genn/genn/code_generator/initGroupMerged.cc
@@ -326,7 +326,7 @@ void NeuronInitGroupMerged::generateInit(const BackendBase &backend, CodeStream 
             [&model, i] (CodeStream &os, Substitutions &varSubs)
             {
                 genVariableFill(os, "inSynInSyn" + std::to_string(i), model.scalarExpr(0.0), 
-                                "id", "group->numNeurons", VarAccessDuplication::DUPLICATE, model.getBatchSize());
+                                varSubs["id"], "group->numNeurons", VarAccessDuplication::DUPLICATE, model.getBatchSize());
 
             });
 
@@ -337,7 +337,7 @@ void NeuronInitGroupMerged::generateInit(const BackendBase &backend, CodeStream 
                 [&model, sg, i](CodeStream &os, Substitutions &varSubs)
                 {
                     genVariableFill(os, "denDelayInSyn" + std::to_string(i), model.scalarExpr(0.0),
-                                    "id", "group->numNeurons", VarAccessDuplication::DUPLICATE, model.getBatchSize());
+                                    varSubs["id"], "group->numNeurons", VarAccessDuplication::DUPLICATE, model.getBatchSize());
                 });
 
             // Zero dendritic delay pointer
@@ -388,7 +388,7 @@ void NeuronInitGroupMerged::generateInit(const BackendBase &backend, CodeStream 
                                 [&model, i] (CodeStream &os, Substitutions &varSubs)
                                 {
                                     genVariableFill(os, "revInSynOutSyn" + std::to_string(i), model.scalarExpr(0.0),
-                                                    "id", "group->numNeurons", VarAccessDuplication::DUPLICATE, model.getBatchSize());
+                                                    varSubs["id"], "group->numNeurons", VarAccessDuplication::DUPLICATE, model.getBatchSize());
                                 });
     }
     

--- a/src/genn/genn/code_generator/initGroupMerged.cc
+++ b/src/genn/genn/code_generator/initGroupMerged.cc
@@ -337,7 +337,8 @@ void NeuronInitGroupMerged::generateInit(const BackendBase &backend, CodeStream 
                 [&model, sg, i](CodeStream &os, Substitutions &varSubs)
                 {
                     genVariableFill(os, "denDelayInSyn" + std::to_string(i), model.scalarExpr(0.0),
-                                    varSubs["id"], "group->numNeurons", VarAccessDuplication::DUPLICATE, model.getBatchSize());
+                                    varSubs["id"], "group->numNeurons", VarAccessDuplication::DUPLICATE, model.getBatchSize(),
+                                    true, sg->getMaxDendriticDelayTimesteps());
                 });
 
             // Zero dendritic delay pointer


### PR DESCRIPTION
When implementing batching I wrote a helper function called ``genVariableFill`` for initialising variables, taking account of delays and batching. However, for some reason, I forgot to actually _use_ this when initializing ``inSyn``, ``denDelay`` (which was subsequently copy-pasted into the initialisation of ``revInSyn``). CUDA seems to zero newly allocated memory so, generally, this has minimal effect but, if you _reinitialise_ your model, you may be left with large residual neural input currents in some batch instances (which, if you're using dendritic delays will continue to appear for max dendritic delay timesteps!). 

This finally fixes the issues we were seeing in Felix Schmitt's model - big thanks to him for testing my various speculative fixes and suggesting that (re-)initialization could be the problem!