### PR TITLE
Fix incompatibility with older Python versions

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -29,7 +29,11 @@ opencl_installed = opencl_path is not None and os.path.exists(opencl_path)
 mac_os_x = system() == "Darwin"
 linux = system() == "Linux"
 windows = system() == "Windows"
-wsl = "microsoft" in uname().release
+
+if sys.version_info < (3, 3):
+    wsl = "microsoft" in uname()[2]
+else:
+    wsl = "microsoft" in uname().release
 
 # Determine correct suffix for GeNN libraries
 if windows:


### PR DESCRIPTION
In #500, we started using [``platform.uname``](https://docs.python.org/3/library/platform.html#platform.uname) to get platform information and thus detect WSL. However, in Python < 3.3, this returns a tuple (rather than a namedtuple) - as GeNN 4 still technically supports Python 2.7, handle that too