### PR TITLE
Replace synRemap mechanism with much simpler one

### DIFF
--- a/include/genn/backends/single_threaded_cpu/backend.h
+++ b/include/genn/backends/single_threaded_cpu/backend.h
@@ -141,7 +141,6 @@ public:
     //! Different backends seed RNGs in different ways. Does this one initialise population RNGS on device?
     virtual bool isPopulationRNGInitialisedOnDevice() const override { return false; }
 
-    virtual bool isSynRemapRequired(const SynapseGroupInternal&) const override{ return false; }
     virtual bool isPostsynapticRemapRequired() const override{ return true; }
 
     //! Backends which support batch-parallelism might require an additional host reduction phase after reduction kernels

--- a/include/genn/genn/code_generator/backendBase.h
+++ b/include/genn/genn/code_generator/backendBase.h
@@ -382,9 +382,6 @@ public:
     //! Different backends seed RNGs in different ways. Does this one initialise population RNGS on device?
     virtual bool isPopulationRNGInitialisedOnDevice() const = 0;
 
-    //! Different backends may implement synapse dynamics differently. Does this one require a synapse remapping data structure for synapse group?
-    virtual bool isSynRemapRequired(const SynapseGroupInternal &sg) const = 0;
-
     //! Different backends may implement synaptic plasticity differently. Does this one require a postsynaptic remapping data structure?
     virtual bool isPostsynapticRemapRequired() const = 0;
 

--- a/include/genn/genn/code_generator/backendSIMT.h
+++ b/include/genn/genn/code_generator/backendSIMT.h
@@ -143,7 +143,6 @@ public:
     virtual bool isGlobalDeviceRNGRequired(const ModelSpecMerged &modelMerged) const final;
     virtual bool isPopulationRNGRequired() const final { return true; }
 
-    virtual bool isSynRemapRequired(const SynapseGroupInternal &sg) const final;
     virtual bool isPostsynapticRemapRequired() const final { return true; }
 
     //------------------------------------------------------------------------

--- a/src/genn/genn/code_generator/backendSIMT.cc
+++ b/src/genn/genn/code_generator/backendSIMT.cc
@@ -128,13 +128,6 @@ bool BackendSIMT::isGlobalDeviceRNGRequired(const ModelSpecMerged &modelMerged) 
     return false;
 }
 //--------------------------------------------------------------------------
-bool BackendSIMT::isSynRemapRequired(const SynapseGroupInternal &sg) const
-{
-    // This synapse group required synRemap if it's sparse and either has synapse dynamics or is targetted by any custom update
-    return ((sg.getMatrixType() & SynapseMatrixConnectivity::SPARSE) &&
-            (!sg.getWUModel()->getSynapseDynamicsCode().empty() || sg.areWUVarReferencedByCustomUpdate()));
-}
-//--------------------------------------------------------------------------
 size_t BackendSIMT::getNumInitialisationRNGStreams(const ModelSpecMerged &modelMerged) const
 {
     // Calculate total number of threads used for neuron initialisation group
@@ -807,7 +800,7 @@ void BackendSIMT::genSynapseDynamicsKernel(CodeStream &os, const Substitutions &
             Substitutions synSubs(&popSubs);
 
             if(sg.getArchetype().getMatrixType() & SynapseMatrixConnectivity::SPARSE) {
-                os << "if (" << popSubs["id"] << " < group->synRemap[0])";
+                os << "if (" << popSubs["id"] << " < (group->numSrcNeurons * group->rowStride))";
             }
             else {
                 os << "if (" << popSubs["id"] << " < (group->numSrcNeurons * group->numTrgNeurons))";
@@ -816,12 +809,16 @@ void BackendSIMT::genSynapseDynamicsKernel(CodeStream &os, const Substitutions &
                 CodeStream::Scope b(os);
 
                 if(sg.getArchetype().getMatrixType() & SynapseMatrixConnectivity::SPARSE) {
-                    // Determine synapse and presynaptic indices for this thread
-                    os << "const unsigned int s = group->synRemap[1 + " << popSubs["id"] << "];" << std::endl;
+                    // **OPTIMIZE * *we can do a fast constant divide optimization here and use the result to calculate the remainder
+                    os << "const unsigned int row = " << popSubs["id"] << " / group->rowStride;" << std::endl;
+                    os << "const unsigned int col = " << popSubs["id"] << " % group->rowStride;" << std::endl;
 
-                    synSubs.addVarSubstitution("id_pre", "(s / group->rowStride)");
-                    synSubs.addVarSubstitution("id_post", "group->ind[s]");
-                    synSubs.addVarSubstitution("id_syn", "s");
+                    synSubs.addVarSubstitution("id_pre", "row");
+                    synSubs.addVarSubstitution("id_post", "group->ind[" + popSubs["id"] + "]");
+                    synSubs.addVarSubstitution("id_syn", popSubs["id"]);
+
+                    os << "if(col < group->rowLength[row])";
+                    os << CodeStream::OB(1);
                 }
                 else {
                     // **OPTIMIZE** we can do a fast constant divide optimization here and use the result to calculate the remainder
@@ -846,6 +843,10 @@ void BackendSIMT::genSynapseDynamicsKernel(CodeStream &os, const Substitutions &
                 }
  
                 sg.generateSynapseUpdate(*this, os, modelMerged, synSubs);
+
+                if (sg.getArchetype().getMatrixType() & SynapseMatrixConnectivity::SPARSE) {
+                    os << CodeStream::CB(1);
+                }
             }
         });
 }
@@ -975,7 +976,7 @@ void BackendSIMT::genCustomUpdateWUKernel(CodeStream &os, const Substitutions &k
             }
 
             if(cg.getArchetype().getSynapseGroup()->getMatrixType() & SynapseMatrixConnectivity::SPARSE) {
-                os << "if (" << cuSubs["id"] << " < group->synRemap[0])";
+                os << "if (" << popSubs["id"] << " < (group->numSrcNeurons * group->rowStride))";
             }
             else {
                 os << "if (" << cuSubs["id"] << " < size)";
@@ -984,12 +985,16 @@ void BackendSIMT::genCustomUpdateWUKernel(CodeStream &os, const Substitutions &k
                 CodeStream::Scope b(os);
 
                 if(cg.getArchetype().getSynapseGroup()->getMatrixType() & SynapseMatrixConnectivity::SPARSE) {
-                    // Determine synapse and presynaptic indices for this thread
-                    os << "const unsigned int s = group->synRemap[1 + " << cuSubs["id"] << "];" << std::endl;
+                    // **OPTIMIZE * *we can do a fast constant divide optimization here and use the result to calculate the remainder
+                    os << "const unsigned int row = " << popSubs["id"] << " / group->rowStride;" << std::endl;
+                    os << "const unsigned int col = " << popSubs["id"] << " % group->rowStride;" << std::endl;
 
-                    cuSubs.addVarSubstitution("id_pre", "(s / group->rowStride)");
-                    cuSubs.addVarSubstitution("id_post", "group->ind[s]");
-                    cuSubs.addVarSubstitution("id_syn", "s");
+                    cuSubs.addVarSubstitution("id_pre", "row");
+                    cuSubs.addVarSubstitution("id_post", "group->ind[" + cuSubs["id"] + "]");
+                    cuSubs.addVarSubstitution("id_syn", cuSubs["id"]);
+
+                    os << "if(col < group->rowLength[row])";
+                    os << CodeStream::OB(2);
                 }
                 else {
                     // **OPTIMIZE** we can do a fast constant divide optimization here and use the result to calculate the remainder
@@ -1032,6 +1037,10 @@ void BackendSIMT::genCustomUpdateWUKernel(CodeStream &os, const Substitutions &k
                     for(const auto &r : reductionTargets) {
                         os << "group->" << r.name << "[" << cuSubs["id_syn"] << "] = lr" << r.name << ";" << std::endl;
                     }
+                }
+
+                if (cg.getArchetype().getSynapseGroup()->getMatrixType() & SynapseMatrixConnectivity::SPARSE) {
+                    os << CodeStream::CB(2);
                 }
             }
         });
@@ -1495,12 +1504,7 @@ void BackendSIMT::genInitializeSparseKernel(CodeStream &os, const Substitutions 
     // Shared memory array so row lengths don't have to be read by EVERY postsynaptic thread
     // **TODO** check actually required
     os << getSharedPrefix() << "unsigned int shRowLength[" << getKernelBlockSize(KernelInitializeSparse) << "];" << std::endl;
-    if(std::any_of(modelMerged.getModel().getSynapseGroups().cbegin(), modelMerged.getModel().getSynapseGroups().cend(),
-                   [this](const ModelSpec::SynapseGroupValueType &s) { return isSynRemapRequired(s.second); }))
-    {
-        os << getSharedPrefix() << "unsigned int shRowStart[" << getKernelBlockSize(KernelInitializeSparse) + 1 << "];" << std::endl;
-    }
-
+   
     // Initialise weight update variables for synapse groups with sparse connectivity
     genParallelGroup<SynapseSparseInitGroupMerged>(os, kernelSubs, modelMerged.getMergedSynapseSparseInitGroups(), idStart,
         [this](const SynapseGroupInternal &sg) { return padKernelSize(sg.getMaxConnections(), KernelInitializeSparse); },
@@ -1536,42 +1540,6 @@ void BackendSIMT::genInitializeSparseKernel(CodeStream &os, const Substitutions 
                     CodeStream::Scope b(os);
                     os << "shRowLength[" << getThreadID() << "] = group->rowLength[(r * " << blockSize << ") + " << getThreadID() << "];" << std::endl;
                 }
-
-                // If this synapse group has synapse dynamics
-                if(isSynRemapRequired(sg.getArchetype())) {
-                    genSharedMemBarrier(os);
-
-                    // Use first thread to generate cumulative sum
-                    os << "if(" << getThreadID() << " == 0)";
-                    {
-                        CodeStream::Scope b(os);
-
-                        // Get index of last row in resultant synapse dynamics structure
-                        // **NOTE** if there IS a previous block, it will always have had initSparseBlkSz rows in it
-                        os << "unsigned int rowStart = (r == 0) ? 0 : shRowStart[" << blockSize << "];" << std::endl;
-                        os << "shRowStart[0] = rowStart;" << std::endl;
-
-                        // Loop through rows in block
-                        os << "for(unsigned int i = 0; i < numRowsInBlock; i++)";
-                        {
-                            CodeStream::Scope b(os);
-
-                            // Add this row's length to cumulative sum and write this to this row's end
-                            os << "rowStart += shRowLength[i];" << std::endl;
-                            os << "shRowStart[i + 1] = rowStart;" << std::endl;
-                        }
-
-                        // If this is the first thread block of the first block in the group AND the last block of rows,
-                        // write the total cumulative sum to the first entry of the remap structure
-                        os << "if(" << popSubs["id"] << " == 0 && (r == (numBlocks - 1)))";
-                        {
-                            CodeStream::Scope b(os);
-                            os << "group->synRemap[0] = shRowStart[numRowsInBlock];" << std::endl;
-                        }
-
-                    }
-                }
-
                 genSharedMemBarrier(os);
 
                 // Loop through rows
@@ -1607,12 +1575,6 @@ void BackendSIMT::genInitializeSparseKernel(CodeStream &os, const Substitutions 
 
                             // Add remapping entry at this location poining back to row-major index
                             os << "group->remap[colMajorIndex] = idx;" << std::endl;
-                        }
-
-                        // If synapse remap is required, copy idx into first entry of syn remap structure
-                        if(isSynRemapRequired(sg.getArchetype())) {
-                            CodeStream::Scope b(os);
-                            os << "group->synRemap[shRowStart[i] + " + popSubs["id"] + " + 1] = idx;" << std::endl;
                         }
                     }
 

--- a/src/genn/genn/code_generator/backendSIMT.cc
+++ b/src/genn/genn/code_generator/backendSIMT.cc
@@ -976,7 +976,7 @@ void BackendSIMT::genCustomUpdateWUKernel(CodeStream &os, const Substitutions &k
             }
 
             if(cg.getArchetype().getSynapseGroup()->getMatrixType() & SynapseMatrixConnectivity::SPARSE) {
-                os << "if (" << popSubs["id"] << " < (group->numSrcNeurons * group->rowStride))";
+                os << "if (" << cuSubs["id"] << " < (group->numSrcNeurons * group->rowStride))";
             }
             else {
                 os << "if (" << cuSubs["id"] << " < size)";
@@ -986,8 +986,8 @@ void BackendSIMT::genCustomUpdateWUKernel(CodeStream &os, const Substitutions &k
 
                 if(cg.getArchetype().getSynapseGroup()->getMatrixType() & SynapseMatrixConnectivity::SPARSE) {
                     // **OPTIMIZE * *we can do a fast constant divide optimization here and use the result to calculate the remainder
-                    os << "const unsigned int row = " << popSubs["id"] << " / group->rowStride;" << std::endl;
-                    os << "const unsigned int col = " << popSubs["id"] << " % group->rowStride;" << std::endl;
+                    os << "const unsigned int row = " << cuSubs["id"] << " / group->rowStride;" << std::endl;
+                    os << "const unsigned int col = " << cuSubs["id"] << " % group->rowStride;" << std::endl;
 
                     cuSubs.addVarSubstitution("id_pre", "row");
                     cuSubs.addVarSubstitution("id_post", "group->ind[" + cuSubs["id"] + "]");

--- a/src/genn/genn/code_generator/customUpdateGroupMerged.cc
+++ b/src/genn/genn/code_generator/customUpdateGroupMerged.cc
@@ -281,22 +281,11 @@ CustomUpdateWUGroupMergedBase::CustomUpdateWUGroupMergedBase(size_t index, const
                      return backend.getDeviceVarPrefix() + "ind" + cg.getSynapseGroup()->getName(); 
                  });
 
-        // If the referenced synapse group requires synaptic remapping and matrix type is sparse, add field
-        if(backend.isSynRemapRequired(*getArchetype().getSynapseGroup())) {
-            addField("unsigned int*", "synRemap", 
-                     [&backend](const CustomUpdateWUInternal &cg, size_t) 
-                     { 
-                         return backend.getDeviceVarPrefix() + "synRemap" + cg.getSynapseGroup()->getName(); 
-                     });
-        }
-        // Otherwise, add row length
-        else {
-            addField("unsigned int*", "rowLength",
-                     [&backend](const CustomUpdateWUInternal &cg, size_t) 
-                     { 
-                         return backend.getDeviceVarPrefix() + "rowLength" + cg.getSynapseGroup()->getName(); 
-                     });
-        }
+        addField("unsigned int*", "rowLength",
+                [&backend](const CustomUpdateWUInternal &cg, size_t) 
+                { 
+                    return backend.getDeviceVarPrefix() + "rowLength" + cg.getSynapseGroup()->getName(); 
+                });
     }
 
     // Add heterogeneous custom update model parameters

--- a/src/genn/genn/code_generator/generateRunner.cc
+++ b/src/genn/genn/code_generator/generateRunner.cc
@@ -1260,14 +1260,6 @@ MemAlloc CodeGenerator::generateRunner(const filesystem::path &outputPath, const
                 backend.genArray(definitionsVar, definitionsInternalVar, runnerVarDecl, runnerVarAlloc, runnerVarFree,
                                  s.second.getSparseIndType(), "ind" + s.second.getName(), varLoc, size, mem);
 
-
-                // If synapse remap structure is required, allocate synRemap
-                // **THINK** this is over-allocating
-                if(backend.isSynRemapRequired(s.second)) {
-                    backend.genArray(definitionsVar, definitionsInternalVar, runnerVarDecl, runnerVarAlloc, runnerVarFree,
-                                     "unsigned int", "synRemap" + s.second.getName(), VarLocation::DEVICE, size + 1, mem);
-                }
-
                 // **TODO** remap is not always required
                 if(backend.isPostsynapticRemapRequired() && !s.second.getWUModel()->getLearnPostCode().empty()) {
                     const size_t postSize = (size_t)s.second.getTrgNeuronGroup()->getNumNeurons() * (size_t)s.second.getMaxSourceConnections();

--- a/src/genn/genn/code_generator/groupMerged.cc
+++ b/src/genn/genn/code_generator/groupMerged.cc
@@ -1105,13 +1105,6 @@ SynapseGroupMergedBase::SynapseGroupMergedBase(size_t index, const std::string &
             addWeightSharingPointerField("unsigned int", "colLength", backend.getDeviceVarPrefix() + "colLength");
             addWeightSharingPointerField("unsigned int", "remap", backend.getDeviceVarPrefix() + "remap");
         }
-
-        // Add additional structure for synapse dynamics access if required
-        if((role == Role::SynapseDynamics || role == Role::SparseInit) &&
-           backend.isSynRemapRequired(getArchetype()))
-        {
-            addWeightSharingPointerField("unsigned int", "synRemap", backend.getDeviceVarPrefix() + "synRemap");
-        }
     }
     else if(getArchetype().getMatrixType() & SynapseMatrixConnectivity::BITMASK) {
         addWeightSharingPointerField("uint32_t", "gp", backend.getDeviceVarPrefix() + "gp");

--- a/src/genn/genn/code_generator/modelSpecMerged.cc
+++ b/src/genn/genn/code_generator/modelSpecMerged.cc
@@ -86,7 +86,6 @@ ModelSpecMerged::ModelSpecMerged(const ModelSpecInternal &model, const BackendBa
                            {
                                return ((sg.getMatrixType() & SynapseMatrixConnectivity::SPARSE) && 
                                        (sg.isWUVarInitRequired()
-                                        || backend.isSynRemapRequired(sg)
                                         || (backend.isPostsynapticRemapRequired() && !sg.getWUModel()->getLearnPostCode().empty())));
                            },
                            &SynapseGroupInternal::getWUInitHashDigest);


### PR DESCRIPTION
In older versions of GeNN which used a plain CSR matrix format for sparse connectivity, figuring out what presynaptic and postsynaptic neuron a synapse dynamics kernel thread was associated with, required a data structure called ``indInG``.  When we switched to the new 'ragged' format, this was no longer necessary but, for _some_ reason, I introduced a new (``synRemap``) lookup structure which maps contiguous (0, numSynapses] thread indices to indices into the ragged matrix. This adds another 32-bits of memory per sparse synapse, significantly slows down synapse dynamics as each synapse has to read the 32-bit from global memory **and** makes doing structural plasticity much harder than it needs to be as you need to keep the ``synRemap`` structure up to date with all the other bits of synapse state. Theoretically this _could_ have saved a few idle threads but, it doesn't because GeNN has no way of knowing how many synapses there are at compile time so it launches  ``sg.getSrcNeuronGroup()->getNumNeurons() * sg.getMaxConnections()`` anyway. The ``synRemap`` structure is an internal detail which users shouldn't ever be messing with so I have totally removed it and, in this PR, just divide the same number of threads into pre and post indices with / and % respectively (duh). On my machine this reduces the time spent in synapse dynamics kernels by around 25%!
