### PR TITLE
Reduce unnecessary strictness in configuration of custom updates

### DIFF
--- a/include/genn/genn/code_generator/backendBase.h
+++ b/include/genn/genn/code_generator/backendBase.h
@@ -472,7 +472,7 @@ protected:
 
     void genSynapseIndexCalculation(CodeStream &os, const SynapseGroupMergedBase &sg, unsigned int batchSize) const;
 
-    void genCustomUpdateIndexCalculation(CodeStream &os, const CustomUpdateGroupMerged &cu, unsigned int batchSize) const;
+    void genCustomUpdateIndexCalculation(CodeStream &os, const CustomUpdateGroupMerged &cu) const;
 
 private:
     //--------------------------------------------------------------------------

--- a/include/genn/genn/code_generator/customUpdateGroupMerged.h
+++ b/include/genn/genn/code_generator/customUpdateGroupMerged.h
@@ -35,8 +35,8 @@ public:
     //----------------------------------------------------------------------------
     // Static API
     //----------------------------------------------------------------------------
-    std::string getVarIndex(unsigned int batchSize, VarAccessDuplication varDuplication, const std::string &index) const;
-    std::string getVarRefIndex(bool delay, unsigned int batchSize, VarAccessDuplication varDuplication, const std::string &index) const;
+    std::string getVarIndex(VarAccessDuplication varDuplication, const std::string &index) const;
+    std::string getVarRefIndex(bool delay, VarAccessDuplication varDuplication, const std::string &index) const;
 
     //----------------------------------------------------------------------------
     // Static constants
@@ -58,8 +58,8 @@ public:
 
     boost::uuids::detail::sha1::digest_type getHashDigest() const;
 
-    std::string getVarIndex(unsigned int batchSize, VarAccessDuplication varDuplication, const std::string &index) const;
-    std::string getVarRefIndex(unsigned int batchSize, VarAccessDuplication varDuplication, const std::string &index) const;
+    std::string getVarIndex(VarAccessDuplication varDuplication, const std::string &index) const;
+    std::string getVarRefIndex(VarAccessDuplication varDuplication, const std::string &index) const;
 
 protected:
     CustomUpdateWUGroupMergedBase(size_t index, const std::string &precision, const std::string &, const BackendBase &backend,

--- a/include/genn/genn/customUpdateInternal.h
+++ b/include/genn/genn/customUpdateInternal.h
@@ -55,6 +55,7 @@ public:
     using CustomUpdateBase::isReduction;
     using CustomUpdateBase::getVarLocationHashDigest;
     
+    using CustomUpdateWU::finalize;
     using CustomUpdateWU::getHashDigest;
     using CustomUpdateWU::getInitHashDigest;
     using CustomUpdateWU::getSynapseGroup;

--- a/src/genn/backends/single_threaded_cpu/backend.cc
+++ b/src/genn/backends/single_threaded_cpu/backend.cc
@@ -512,7 +512,7 @@ void Backend::genCustomUpdate(CodeStream &os, const ModelSpecMerged &modelMerged
                         // Get reference to group
                         os << "const auto *group = &mergedCustomUpdateGroup" << c.getIndex() << "[g]; " << std::endl;
 
-                        genCustomUpdateIndexCalculation(os, c, 1);
+                        genCustomUpdateIndexCalculation(os, c);
 
                         // Loop through group members
                         os << "for(unsigned int i = 0; i < group->size; i++)";

--- a/src/genn/genn/code_generator/backendBase.cc
+++ b/src/genn/genn/code_generator/backendBase.cc
@@ -203,10 +203,10 @@ void CodeGenerator::BackendBase::genSynapseIndexCalculation(CodeStream &os, cons
     }
 }
 //-----------------------------------------------------------------------
-void CodeGenerator::BackendBase::genCustomUpdateIndexCalculation(CodeStream &os, const CustomUpdateGroupMerged &cu, unsigned int batchSize) const
+void CodeGenerator::BackendBase::genCustomUpdateIndexCalculation(CodeStream &os, const CustomUpdateGroupMerged &cu) const
 {
     // If batching is enabled, calculate batch offset
-    if(cu.getArchetype().isBatched() && batchSize > 1) {
+    if(cu.getArchetype().isBatched()) {
         os << "const unsigned int batchOffset = group->size * batch;" << std::endl;
     }
             
@@ -216,7 +216,7 @@ void CodeGenerator::BackendBase::genCustomUpdateIndexCalculation(CodeStream &os,
         os << "const unsigned int delayOffset = (*group->spkQuePtr * group->size);" << std::endl;
 
         // If batching is also enabled, calculate offset including delay and batch
-        if(cu.getArchetype().isBatched() && batchSize > 1) {
+        if(cu.getArchetype().isBatched()) {
             os << "const unsigned int batchDelayOffset = delayOffset + (batchOffset * " << cu.getArchetype().getDelayNeuronGroup()->getNumDelaySlots() << ");" << std::endl;
         }
     }

--- a/src/genn/genn/code_generator/backendSIMT.cc
+++ b/src/genn/genn/code_generator/backendSIMT.cc
@@ -885,7 +885,7 @@ void BackendSIMT::genCustomUpdateKernel(CodeStream &os, const Substitutions &ker
                         CodeStream::Scope b(os);
                         cuSubs.addVarSubstitution("batch", "batch");
 
-                        genCustomUpdateIndexCalculation(os, cg, batchSize);
+                        genCustomUpdateIndexCalculation(os, cg);
                         cg.generateCustomUpdate(*this, os, modelMerged, cuSubs);
 
                         // Loop through reduction targets and generate reduction
@@ -902,7 +902,7 @@ void BackendSIMT::genCustomUpdateKernel(CodeStream &os, const Substitutions &ker
             }
             // Otherwise
             else {
-                if(cg.getArchetype().isBatched() && batchSize > 1) {
+                if(cg.getArchetype().isBatched()) {
                     // Split ID into intra-batch ID and batch
                     // **TODO** fast-divide style optimisations here
                     os << "const unsigned int paddedSize = " << blockSize << " * ((group->size + " << blockSize << " - 1) / " << blockSize << ");" << std::endl;
@@ -923,7 +923,7 @@ void BackendSIMT::genCustomUpdateKernel(CodeStream &os, const Substitutions &ker
                 {
                     CodeStream::Scope b(os);
 
-                    genCustomUpdateIndexCalculation(os, cg, batchSize);
+                    genCustomUpdateIndexCalculation(os, cg);
                     cg.generateCustomUpdate(*this, os, modelMerged, cuSubs);
                 }
             }
@@ -954,7 +954,7 @@ void BackendSIMT::genCustomUpdateWUKernel(CodeStream &os, const Substitutions &k
             Substitutions cuSubs(&popSubs);
             if(!cg.getArchetype().isReduction()) {
                 // If it's batched
-                if(cg.getArchetype().isBatched() && batchSize > 1) {
+                if(cg.getArchetype().isBatched()) {
                     os << "const unsigned int paddedSize = " << blockSize << " * ((size + " << blockSize << " - 1) / " << blockSize << ");" << std::endl;
 
                     // Split ID into intra-batch ID and batch
@@ -1013,7 +1013,7 @@ void BackendSIMT::genCustomUpdateWUKernel(CodeStream &os, const Substitutions &k
                 }
 
                 // Calculate batch offset if required
-                if(cg.getArchetype().isBatched() && batchSize > 1) {
+                if(cg.getArchetype().isBatched()) {
                     os << "const unsigned int batchOffset = size * batch;" << std::endl;
                 }
 
@@ -1059,7 +1059,6 @@ void BackendSIMT::genCustomTransposeUpdateWUKernel(CodeStream &os, const Substit
                                                          std::find_if(cg.getArchetype().getVarReferences().cbegin(), cg.getArchetype().getVarReferences().cend(),
                                                                       [](const Models::WUVarReference &v) { return v.getTransposeSynapseGroup() != nullptr; }));
             const std::string transposeVarName = cg.getArchetype().getCustomUpdateModel()->getVarRefs().at(transposeVarIdx).name;
-            const unsigned int batchSize = modelMerged.getModel().getBatchSize();
 
             // To allow these kernels to be batched, we turn 2D grid into wide 1D grid of 2D block so calculate size
             os << "const unsigned int numXBlocks = (group->numTrgNeurons + " << (blockSize - 1) << ") / " << blockSize << ";" << std::endl;
@@ -1068,7 +1067,7 @@ void BackendSIMT::genCustomTransposeUpdateWUKernel(CodeStream &os, const Substit
             os << "const unsigned int blockStart = " << popSubs["group_start_id"] << " / " << blockSize << ";" << std::endl;
 
             Substitutions synSubs(&popSubs);
-            if(cg.getArchetype().isBatched() && batchSize > 1) {
+            if(cg.getArchetype().isBatched()) {
                 // If there's multiple batches we also need to know how many Y blocks and hence total blocks there are
                 os << "const unsigned int numYBlocks = (group->numSrcNeurons + " << (blockSize - 1) << ") / " << blockSize << ";" << std::endl;
                 os << "const unsigned int numBlocks = numXBlocks * numYBlocks;" << std::endl;
@@ -1147,7 +1146,7 @@ void BackendSIMT::genCustomTransposeUpdateWUKernel(CodeStream &os, const Substit
                         {
                             CodeStream::Scope b(os);
                             os << "group->" << transposeVarName << "Transpose[";
-                            if(cg.getArchetype().isBatched() && batchSize > 1) {
+                            if(cg.getArchetype().isBatched()) {
                                 os << "batchOffset + ";
                             }
                             os << "((y + j) * group->numSrcNeurons) + x] = shTile[" << getThreadID(0) << "][" << getThreadID(1) << " + j];" << std::endl;

--- a/src/genn/genn/customUpdate.cc
+++ b/src/genn/genn/customUpdate.cc
@@ -115,8 +115,11 @@ CustomUpdate::CustomUpdate(const std::string &name, const std::string &updateGro
     }
 }
 //----------------------------------------------------------------------------
-void CustomUpdate::finalize()
+void CustomUpdate::finalize(unsigned int batchSize)
 {
+    // Check variable reference batching
+    checkVarReferenceBatching(m_VarReferences, batchSize);
+
     // If any variable references have delays
     auto delayRef = std::find_if(m_VarReferences.cbegin(), m_VarReferences.cend(),
                                  [](const Models::VarReference &v) { return v.getDelayNeuronGroup() != nullptr; });
@@ -217,6 +220,13 @@ CustomUpdateWU::CustomUpdateWU(const std::string &name, const std::string &updat
             throw std::runtime_error("Each custom update can only calculate the tranpose of a single variable,");
         }
     }
+}
+//----------------------------------------------------------------------------
+void CustomUpdateWU::finalize(unsigned int batchSize)
+{
+    // Check variable reference types
+    checkVarReferenceBatching(m_VarReferences, batchSize);
+
 }
 //----------------------------------------------------------------------------
 bool CustomUpdateWU::isTransposeOperation() const

--- a/src/genn/genn/modelSpec.cc
+++ b/src/genn/genn/modelSpec.cc
@@ -176,12 +176,13 @@ void ModelSpec::finalize()
 
     // Custom update groups
     for(auto &c : m_CustomUpdates) {
-        c.second.finalize();
+        c.second.finalize(m_BatchSize);
         c.second.initDerivedParams(m_DT);
     }
 
     // Custom WUM update groups
     for(auto &c : m_CustomWUUpdates) {
+        c.second.finalize(m_BatchSize);
         c.second.initDerivedParams(m_DT);
     }
 

--- a/tests/unit/customUpdate.cc
+++ b/tests/unit/customUpdate.cc
@@ -301,9 +301,10 @@ TEST(CustomUpdates, ReduceDuplicate)
     // Create custom update which tries to create a read-write refernece to a (which isn't batched)
     Sum2::VarValues sum2VarValues(1.0);
     Sum2::VarReferences sum2VarReferences(createVarRef(pop, "a"), createVarRef(pop, "V"));
+    model.addCustomUpdate<Sum2>("Sum1", "CustomUpdate",
+                                {}, sum2VarValues, sum2VarReferences);
     try {
-        model.addCustomUpdate<Sum2>("Sum1", "CustomUpdate",
-                                    {}, sum2VarValues, sum2VarReferences);
+        model.finalize();
         FAIL();
     }
     catch(const std::runtime_error &) {


### PR DESCRIPTION
When you built a model with custom updates, GeNN was previously a bit over-zealous is enforcing ``SHARED`` vs ``DUPLICATE`` variable settings even if the model wasn't batched. This PR moves this logic into finalize where batch size is known so the checks can be dis-regarded if batch size is 1. This enables custom updates to _actually_ know whether they're batched rather than just whether they would be if batch size > 1 and allows a bit of tidying.