### PR TITLE
Fix max connections issues

### DIFF
--- a/src/genn/genn/code_generator/groupMerged.cc
+++ b/src/genn/genn/code_generator/groupMerged.cc
@@ -1258,10 +1258,9 @@ boost::uuids::detail::sha1::digest_type SynapseGroupMergedBase::getHashDigest(Ro
     // Update hash with number of neurons in pre and postsynaptic population
     updateHash([](const SynapseGroupInternal &g) { return g.getSrcNeuronGroup()->getNumNeurons(); }, hash);
     updateHash([](const SynapseGroupInternal &g) { return g.getTrgNeuronGroup()->getNumNeurons(); }, hash);
+    updateHash([](const SynapseGroupInternal &g) { return g.getMaxConnections(); }, hash);
     updateHash([](const SynapseGroupInternal &g) { return g.getMaxSourceConnections(); }, hash);
-    // **NOTE** ideally we'd include the row stride but this needs a backend and it SHOULDN'T be necessary
-    // as I can't think of any way of changing this without changing the hash in other places
-
+    
     if(updateRole) {
         // Update hash with weight update model parameters and derived parameters
         updateHash([](const SynapseGroupInternal &g) { return g.getWUParams(); }, hash);

--- a/src/genn/genn/synapseGroup.cc
+++ b/src/genn/genn/synapseGroup.cc
@@ -146,8 +146,16 @@ void SynapseGroup::setMaxConnections(unsigned int maxConnections)
     }
     else {
         if(getMatrixType() & SynapseMatrixConnectivity::SPARSE) {
-            if(m_SparseConnectivityInitialiser.getSnippet()->getCalcMaxRowLengthFunc()) {
-                throw std::runtime_error("setMaxConnections: Synapse group already has max connections defined by sparse connectivity initialisation snippet.");
+            // If sparse connectivity initialiser provides a function to calculate max row length
+            auto calcMaxRowLengthFunc = m_SparseConnectivityInitialiser.getSnippet()->getCalcMaxRowLengthFunc();
+            if(calcMaxRowLengthFunc) {
+
+                // Call function and if max connections we specify is less than the bound imposed by the snippet, give error
+                auto connectivityMaxRowLength = calcMaxRowLengthFunc(getSrcNeuronGroup()->getNumNeurons(), getTrgNeuronGroup()->getNumNeurons(),
+                                                                     m_SparseConnectivityInitialiser.getParams());
+                if (maxConnections < connectivityMaxRowLength) {
+                    throw std::runtime_error("setMaxConnections: max connections must be higher than that already specified by sparse connectivity initialisation snippet.");
+                }
             }
 
             m_MaxConnections = maxConnections;
@@ -168,8 +176,15 @@ void SynapseGroup::setMaxSourceConnections(unsigned int maxConnections)
     }
     else {
         if(getMatrixType() & SynapseMatrixConnectivity::SPARSE) {
-            if(m_SparseConnectivityInitialiser.getSnippet()->getCalcMaxColLengthFunc()) {
-                throw std::runtime_error("setMaxSourceConnections: Synapse group already has max source connections defined by connectivity initialisation snippet.");
+            // If sparse connectivity initialiser provides a function to calculate max col length
+            auto calcMaxColLengthFunc = m_SparseConnectivityInitialiser.getSnippet()->getCalcMaxColLengthFunc();
+            if (calcMaxColLengthFunc) {
+                // Call function and if max connections we specify is less than the bound imposed by the snippet, give error
+                auto connectivityMaxRowLength = calcMaxColLengthFunc(getSrcNeuronGroup()->getNumNeurons(), getTrgNeuronGroup()->getNumNeurons(),
+                    m_SparseConnectivityInitialiser.getParams());
+                if (maxConnections < connectivityMaxRowLength) {
+                    throw std::runtime_error("setMaxSourceConnections: max source connections must be higher than that already specified by sparse connectivity initialisation snippet.");
+                }
             }
 
             m_MaxSourceConnections = maxConnections;

--- a/src/genn/genn/synapseGroup.cc
+++ b/src/genn/genn/synapseGroup.cc
@@ -149,7 +149,6 @@ void SynapseGroup::setMaxConnections(unsigned int maxConnections)
             // If sparse connectivity initialiser provides a function to calculate max row length
             auto calcMaxRowLengthFunc = m_SparseConnectivityInitialiser.getSnippet()->getCalcMaxRowLengthFunc();
             if(calcMaxRowLengthFunc) {
-
                 // Call function and if max connections we specify is less than the bound imposed by the snippet, give error
                 auto connectivityMaxRowLength = calcMaxRowLengthFunc(getSrcNeuronGroup()->getNumNeurons(), getTrgNeuronGroup()->getNumNeurons(),
                                                                      m_SparseConnectivityInitialiser.getParams());
@@ -180,9 +179,9 @@ void SynapseGroup::setMaxSourceConnections(unsigned int maxConnections)
             auto calcMaxColLengthFunc = m_SparseConnectivityInitialiser.getSnippet()->getCalcMaxColLengthFunc();
             if (calcMaxColLengthFunc) {
                 // Call function and if max connections we specify is less than the bound imposed by the snippet, give error
-                auto connectivityMaxRowLength = calcMaxColLengthFunc(getSrcNeuronGroup()->getNumNeurons(), getTrgNeuronGroup()->getNumNeurons(),
-                    m_SparseConnectivityInitialiser.getParams());
-                if (maxConnections < connectivityMaxRowLength) {
+                auto connectivityMaxColLength = calcMaxColLengthFunc(getSrcNeuronGroup()->getNumNeurons(), getTrgNeuronGroup()->getNumNeurons(),
+                                                                     m_SparseConnectivityInitialiser.getParams());
+                if (maxConnections < connectivityMaxColLength) {
                     throw std::runtime_error("setMaxSourceConnections: max source connections must be higher than that already specified by sparse connectivity initialisation snippet.");
                 }
             }


### PR DESCRIPTION
This fixes two issues:
1. Even if you've used a sparse connectivity initialisation snippet to initialise connectivity, as long as you're _increasing_ it, you should still be able to manually increase max connections e.g. to leave a bit more padding at the end of each row for rewiring
2. Max connections wasn't being included in hashes used to determine if model had changed so if you had build a model based on some manually specified connectivity and changed it you ended up in a really broken state