### PR TITLE
Fix nasty corner case

### DIFF
--- a/bin/genn-buildmodel.sh
+++ b/bin/genn-buildmodel.sh
@@ -95,7 +95,11 @@ BASEDIR=$(dirname "$0")
 make -j $CORE_COUNT -C $BASEDIR/../src/genn/generator -f $GENERATOR_MAKEFILE $MACROS
 
 if [[ -n "$DEBUG" ]]; then
-    gdb -tui --args "$GENERATOR" "$BASEDIR/../" "$OUT_PATH" "$FORCE_REBUILD"
+    if [[ $(uname) == "Darwin" ]]; then
+        lldb -f "$GENERATOR" "$BASEDIR/../" "$OUT_PATH" "$FORCE_REBUILD"
+    else
+        gdb -tui --args "$GENERATOR" "$BASEDIR/../" "$OUT_PATH" "$FORCE_REBUILD"
+    fi
 else
     "$GENERATOR" "$BASEDIR/../" "$OUT_PATH" "$FORCE_REBUILD"
 fi

--- a/src/genn/backends/cuda/backend.cc
+++ b/src/genn/backends/cuda/backend.cc
@@ -931,7 +931,7 @@ void Backend::genInit(CodeStream &os, const ModelSpecMerged &modelMerged,
 
     // Sparse initialization kernel code
     size_t idSparseInitStart = 0;
-    if(!modelMerged.getMergedSynapseSparseInitGroups().empty()) {
+    if(!modelMerged.getMergedSynapseSparseInitGroups().empty() || !modelMerged.getMergedCustomWUUpdateSparseInitGroups().empty()) {
         os << "extern \"C\" __global__ void " << KernelNames[KernelInitializeSparse] << "()";
         {
             CodeStream::Scope b(os);

--- a/src/genn/backends/opencl/backend.cc
+++ b/src/genn/backends/opencl/backend.cc
@@ -1181,7 +1181,7 @@ void Backend::genInit(CodeStream &os, const ModelSpecMerged &modelMerged,
 
     // Generate sparse initialisation kernel
     size_t idSparseInitStart = 0;
-    if(!modelMerged.getMergedSynapseSparseInitGroups().empty()) {
+    if(!modelMerged.getMergedSynapseSparseInitGroups().empty() || !modelMerged.getMergedCustomWUUpdateSparseInitGroups().empty()) {
         initializeKernels << "__attribute__((reqd_work_group_size(" << getKernelBlockSize(KernelInitializeSparse) << ", 1, 1)))" << std::endl;
         initializeKernels << "__kernel void " << KernelNames[KernelInitializeSparse] << "(";
         const bool anyCustomWUUpdateSparseInitGroups = !modelMerged.getMergedCustomWUUpdateSparseInitGroups().empty();


### PR DESCRIPTION
While going through the output from the build machines, I spotted that good 'ole m011322 was throwing a divide by zero exception (I'm guessing these don't actually halt execution Linux) in the ``custom_update_reduction`` test:

1. Turns out that this was because a the sparse initialization kernel's block size was zero
2. And _that_ was because the kernel wasn't being generated although it was required
3. And _that_ was because this test is rather unusual in that it has a synapse group with sparse connectivity that doesn't have any variables that need initialising (they're marked with ``uninitialisedVar()``) but it has a custom update which hangs off that **does** require initialisation and whether there were any groups of this sort wasn't being tested when the code generator was figuring out whether to generate the kernel or not