### PR TITLE
Mac debugging with LLDB

### DIFF
--- a/bin/genn-buildmodel.sh
+++ b/bin/genn-buildmodel.sh
@@ -95,7 +95,11 @@ BASEDIR=$(dirname "$0")
 make -j $CORE_COUNT -C $BASEDIR/../src/genn/generator -f $GENERATOR_MAKEFILE $MACROS
 
 if [[ -n "$DEBUG" ]]; then
-    gdb -tui --args "$GENERATOR" "$BASEDIR/../" "$OUT_PATH" "$FORCE_REBUILD"
+    if [[ $(uname) == "Darwin" ]]; then
+        lldb -f "$GENERATOR" "$BASEDIR/../" "$OUT_PATH" "$FORCE_REBUILD"
+    else
+        gdb -tui --args "$GENERATOR" "$BASEDIR/../" "$OUT_PATH" "$FORCE_REBUILD"
+    fi
 else
     "$GENERATOR" "$BASEDIR/../" "$OUT_PATH" "$FORCE_REBUILD"
 fi


### PR DESCRIPTION
While investigating #517, I wanted to use the debugger but no one had been tempted by the "good first issue" to fix #57. I now have and GeNN users on the Mac can now debug code generator bugs to their heart's content :D (this also must win some sort of "oldest bug fixed" prize as it was first raised in 2015!)

Fixes #57