### PR TITLE
Make sure $(batch) is set to zero on CPU

### DIFF
--- a/src/genn/backends/cuda/backend.cc
+++ b/src/genn/backends/cuda/backend.cc
@@ -442,7 +442,6 @@ void Backend::genNeuronUpdate(CodeStream &os, const ModelSpecMerged &modelMerged
             os << "const unsigned int id = " << getKernelBlockSize(KernelNeuronPrevSpikeTimeUpdate) << " * blockIdx.x + threadIdx.x;" << std::endl;
             if(model.getBatchSize() > 1) {
                 os << "const unsigned int batch = blockIdx.y;" << std::endl;
-                kernelSubs.addVarSubstitution("batch", "batch");
             }
             kernelSubs.addVarSubstitution("t", "t");
 

--- a/src/genn/backends/single_threaded_cpu/backend.cc
+++ b/src/genn/backends/single_threaded_cpu/backend.cc
@@ -112,6 +112,7 @@ void Backend::genNeuronUpdate(CodeStream &os, const ModelSpecMerged &modelMerged
 
         Substitutions funcSubs(getFunctionTemplates(model.getPrecision()));
         funcSubs.addVarSubstitution("t", "t");
+        funcSubs.addVarSubstitution("batch", "0");
 
         // Push any required EGPs
         pushEGPHandler(os);
@@ -282,6 +283,7 @@ void Backend::genSynapseUpdate(CodeStream &os, const ModelSpecMerged &modelMerge
         CodeStream::Scope b(os);
         Substitutions funcSubs(getFunctionTemplates(model.getPrecision()));
         funcSubs.addVarSubstitution("t", "t");
+        funcSubs.addVarSubstitution("batch", "0");
 
         // Push any required EGPs
         pushEGPHandler(os);
@@ -489,6 +491,7 @@ void Backend::genCustomUpdate(CodeStream &os, const ModelSpecMerged &modelMerged
 
             Substitutions funcSubs(getFunctionTemplates(model.getPrecision()));
             funcSubs.addVarSubstitution("t", "t");
+            funcSubs.addVarSubstitution("batch", "0");
 
             // Push any required EGPs
             pushEGPHandler(os);


### PR DESCRIPTION
Code using ``$(batch)`` previously didn't work on the single-threaded CPU backend. This PR fixes this by substituting zero for ``$(batch)`` in all CPU kernels

Fixes #513