### PR TITLE
Custom updates on KERNEL variables

### DIFF
--- a/include/genn/backends/single_threaded_cpu/backend.h
+++ b/include/genn/backends/single_threaded_cpu/backend.h
@@ -95,6 +95,7 @@ public:
     virtual void genSparseSynapseVariableRowInit(CodeStream &os, const Substitutions &kernelSubs, Handler handler) const override;
     virtual void genDenseSynapseVariableRowInit(CodeStream &os, const Substitutions &kernelSubs, Handler handler) const override;
     virtual void genKernelSynapseVariableInit(CodeStream &os, const SynapseKernelInitGroupMerged &sg, const Substitutions &kernelSubs, Handler handler) const final;
+    virtual void genKernelCustomUpdateVariableInit(CodeStream &os, const CustomWUUpdateKernelInitGroupMerged &cu, const Substitutions &kernelSubs, Handler handler) const final;
 
     virtual void genVariablePush(CodeStream &os, const std::string &type, const std::string &name, VarLocation loc, bool autoInitialized, size_t count) const override;
     virtual void genVariablePull(CodeStream &os, const std::string &type, const std::string &name, VarLocation loc, size_t count) const override;

--- a/include/genn/backends/single_threaded_cpu/backend.h
+++ b/include/genn/backends/single_threaded_cpu/backend.h
@@ -95,7 +95,7 @@ public:
     virtual void genSparseSynapseVariableRowInit(CodeStream &os, const Substitutions &kernelSubs, Handler handler) const override;
     virtual void genDenseSynapseVariableRowInit(CodeStream &os, const Substitutions &kernelSubs, Handler handler) const override;
     virtual void genKernelSynapseVariableInit(CodeStream &os, const SynapseInitGroupMerged &sg, const Substitutions &kernelSubs, Handler handler) const final;
-    virtual void genKernelCustomUpdateVariableInit(CodeStream &os, const CustomWUUpdateKernelInitGroupMerged &cu, const Substitutions &kernelSubs, Handler handler) const final;
+    virtual void genKernelCustomUpdateVariableInit(CodeStream &os, const CustomWUUpdateInitGroupMerged &cu, const Substitutions &kernelSubs, Handler handler) const final;
 
     virtual void genVariablePush(CodeStream &os, const std::string &type, const std::string &name, VarLocation loc, bool autoInitialized, size_t count) const override;
     virtual void genVariablePull(CodeStream &os, const std::string &type, const std::string &name, VarLocation loc, size_t count) const override;

--- a/include/genn/backends/single_threaded_cpu/backend.h
+++ b/include/genn/backends/single_threaded_cpu/backend.h
@@ -94,7 +94,7 @@ public:
                                  const Substitutions &kernelSubs, Handler handler) const override;
     virtual void genSparseSynapseVariableRowInit(CodeStream &os, const Substitutions &kernelSubs, Handler handler) const override;
     virtual void genDenseSynapseVariableRowInit(CodeStream &os, const Substitutions &kernelSubs, Handler handler) const override;
-    virtual void genKernelSynapseVariableInit(CodeStream &os, const SynapseKernelInitGroupMerged &sg, const Substitutions &kernelSubs, Handler handler) const final;
+    virtual void genKernelSynapseVariableInit(CodeStream &os, const SynapseInitGroupMerged &sg, const Substitutions &kernelSubs, Handler handler) const final;
     virtual void genKernelCustomUpdateVariableInit(CodeStream &os, const CustomWUUpdateKernelInitGroupMerged &cu, const Substitutions &kernelSubs, Handler handler) const final;
 
     virtual void genVariablePush(CodeStream &os, const std::string &type, const std::string &name, VarLocation loc, bool autoInitialized, size_t count) const override;

--- a/include/genn/genn/code_generator/backendBase.h
+++ b/include/genn/genn/code_generator/backendBase.h
@@ -40,9 +40,8 @@ namespace CodeGenerator
     class CustomUpdateTransposeWUGroupMerged;
     class NeuronInitGroupMerged;
     class CustomUpdateInitGroupMerged;
-    class CustomWUUpdateDenseInitGroupMerged;
+    class CustomWUUpdateInitGroupMerged;
     class CustomWUUpdateSparseInitGroupMerged;
-    class CustomWUUpdateKernelInitGroupMerged;
     class SynapseConnectivityInitGroupMerged;
     class SynapseInitGroupMerged;
     class SynapseSparseInitGroupMerged;
@@ -283,7 +282,7 @@ public:
     virtual void genSparseSynapseVariableRowInit(CodeStream &os, const Substitutions &kernelSubs, Handler handler) const = 0;
     virtual void genDenseSynapseVariableRowInit(CodeStream &os, const Substitutions &kernelSubs, Handler handler) const = 0;
     virtual void genKernelSynapseVariableInit(CodeStream &os, const SynapseInitGroupMerged &sg, const Substitutions &kernelSubs, Handler handler) const = 0;
-    virtual void genKernelCustomUpdateVariableInit(CodeStream &os, const CustomWUUpdateKernelInitGroupMerged &cu, const Substitutions &kernelSubs, Handler handler) const = 0;
+    virtual void genKernelCustomUpdateVariableInit(CodeStream &os, const CustomWUUpdateInitGroupMerged &cu, const Substitutions &kernelSubs, Handler handler) const = 0;
 
     //! Generate code for pushing a variable to the 'device'
     virtual void genVariablePush(CodeStream &os, const std::string &type, const std::string &name, VarLocation loc, bool autoInitialized, size_t count) const = 0;

--- a/include/genn/genn/code_generator/backendBase.h
+++ b/include/genn/genn/code_generator/backendBase.h
@@ -42,6 +42,7 @@ namespace CodeGenerator
     class CustomUpdateInitGroupMerged;
     class CustomWUUpdateDenseInitGroupMerged;
     class CustomWUUpdateSparseInitGroupMerged;
+    class CustomWUUpdateKernelInitGroupMerged;
     class SynapseConnectivityInitGroupMerged;
     class SynapseDenseInitGroupMerged;
     class SynapseSparseInitGroupMerged;
@@ -283,6 +284,7 @@ public:
     virtual void genSparseSynapseVariableRowInit(CodeStream &os, const Substitutions &kernelSubs, Handler handler) const = 0;
     virtual void genDenseSynapseVariableRowInit(CodeStream &os, const Substitutions &kernelSubs, Handler handler) const = 0;
     virtual void genKernelSynapseVariableInit(CodeStream &os, const SynapseKernelInitGroupMerged &sg, const Substitutions &kernelSubs, Handler handler) const = 0;
+    virtual void genKernelCustomUpdateVariableInit(CodeStream &os, const CustomWUUpdateKernelInitGroupMerged &cu, const Substitutions &kernelSubs, Handler handler) const = 0;
 
     //! Generate code for pushing a variable to the 'device'
     virtual void genVariablePush(CodeStream &os, const std::string &type, const std::string &name, VarLocation loc, bool autoInitialized, size_t count) const = 0;

--- a/include/genn/genn/code_generator/backendBase.h
+++ b/include/genn/genn/code_generator/backendBase.h
@@ -44,9 +44,8 @@ namespace CodeGenerator
     class CustomWUUpdateSparseInitGroupMerged;
     class CustomWUUpdateKernelInitGroupMerged;
     class SynapseConnectivityInitGroupMerged;
-    class SynapseDenseInitGroupMerged;
+    class SynapseInitGroupMerged;
     class SynapseSparseInitGroupMerged;
-    class SynapseKernelInitGroupMerged;
     
 }
 
@@ -283,7 +282,7 @@ public:
                                  const Substitutions &kernelSubs, Handler handler) const = 0;
     virtual void genSparseSynapseVariableRowInit(CodeStream &os, const Substitutions &kernelSubs, Handler handler) const = 0;
     virtual void genDenseSynapseVariableRowInit(CodeStream &os, const Substitutions &kernelSubs, Handler handler) const = 0;
-    virtual void genKernelSynapseVariableInit(CodeStream &os, const SynapseKernelInitGroupMerged &sg, const Substitutions &kernelSubs, Handler handler) const = 0;
+    virtual void genKernelSynapseVariableInit(CodeStream &os, const SynapseInitGroupMerged &sg, const Substitutions &kernelSubs, Handler handler) const = 0;
     virtual void genKernelCustomUpdateVariableInit(CodeStream &os, const CustomWUUpdateKernelInitGroupMerged &cu, const Substitutions &kernelSubs, Handler handler) const = 0;
 
     //! Generate code for pushing a variable to the 'device'

--- a/include/genn/genn/code_generator/backendSIMT.h
+++ b/include/genn/genn/code_generator/backendSIMT.h
@@ -135,6 +135,7 @@ public:
     }
     
     virtual void genKernelSynapseVariableInit(CodeStream &os, const SynapseKernelInitGroupMerged &sg, const Substitutions &kernelSubs, Handler handler) const final;
+    virtual void genKernelCustomUpdateVariableInit(CodeStream &os, const CustomWUUpdateKernelInitGroupMerged &cu, const Substitutions &kernelSubs, Handler handler) const final;
 
     //! Should 'scalar' variables be implemented on device or can host variables be used directly?
     virtual bool isDeviceScalarRequired() const final { return true; }

--- a/include/genn/genn/code_generator/backendSIMT.h
+++ b/include/genn/genn/code_generator/backendSIMT.h
@@ -135,7 +135,7 @@ public:
     }
     
     virtual void genKernelSynapseVariableInit(CodeStream &os, const SynapseInitGroupMerged &sg, const Substitutions &kernelSubs, Handler handler) const final;
-    virtual void genKernelCustomUpdateVariableInit(CodeStream &os, const CustomWUUpdateKernelInitGroupMerged &cu, const Substitutions &kernelSubs, Handler handler) const final;
+    virtual void genKernelCustomUpdateVariableInit(CodeStream &os, const CustomWUUpdateInitGroupMerged &cu, const Substitutions &kernelSubs, Handler handler) const final;
 
     //! Should 'scalar' variables be implemented on device or can host variables be used directly?
     virtual bool isDeviceScalarRequired() const final { return true; }
@@ -167,6 +167,7 @@ public:
     static size_t getNumSynapseDynamicsThreads(const SynapseGroupInternal &sg);
     static size_t getNumConnectivityInitThreads(const SynapseGroupInternal &sg);
     static size_t getNumInitThreads(const SynapseGroupInternal &sg);
+    static size_t getNumInitThreads(const CustomUpdateWUInternal &cg);
 
     //! Register a new presynaptic update strategy
     /*! This function should be called with strategies in ascending order of preference */

--- a/include/genn/genn/code_generator/backendSIMT.h
+++ b/include/genn/genn/code_generator/backendSIMT.h
@@ -435,8 +435,8 @@ private:
     
     // Helper function to generate kernel code to initialise variables associated with synapse group or custom WU update with sparse connectivity
     template<typename G>
-    void genSparseSynapseVarInit(CodeStream &os, const ModelSpecMerged &modelMerged, const G &g, Substitutions &popSubs, bool varInitRequired = true, 
-                                 GroupHandler<G> handler = [](CodeStream&, const G&, Substitutions&){}) const
+    void genSparseSynapseVarInit(CodeStream &os, const ModelSpecMerged &modelMerged, const G &g, Substitutions &popSubs, 
+                                 bool varInitRequired, GroupHandler<G> handler) const
     {
         // Calculate how many blocks rows need to be processed in (in order to store row lengths in shared memory)
         const size_t blockSize = getKernelBlockSize(KernelInitializeSparse);

--- a/include/genn/genn/code_generator/backendSIMT.h
+++ b/include/genn/genn/code_generator/backendSIMT.h
@@ -134,7 +134,7 @@ public:
         genSynapseVariableRowInit(os, kernelSubs, handler);
     }
     
-    virtual void genKernelSynapseVariableInit(CodeStream &os, const SynapseKernelInitGroupMerged &sg, const Substitutions &kernelSubs, Handler handler) const final;
+    virtual void genKernelSynapseVariableInit(CodeStream &os, const SynapseInitGroupMerged &sg, const Substitutions &kernelSubs, Handler handler) const final;
     virtual void genKernelCustomUpdateVariableInit(CodeStream &os, const CustomWUUpdateKernelInitGroupMerged &cu, const Substitutions &kernelSubs, Handler handler) const final;
 
     //! Should 'scalar' variables be implemented on device or can host variables be used directly?
@@ -166,6 +166,7 @@ public:
     static size_t getNumPostsynapticUpdateThreads(const SynapseGroupInternal &sg);
     static size_t getNumSynapseDynamicsThreads(const SynapseGroupInternal &sg);
     static size_t getNumConnectivityInitThreads(const SynapseGroupInternal &sg);
+    static size_t getNumInitThreads(const SynapseGroupInternal &sg);
 
     //! Register a new presynaptic update strategy
     /*! This function should be called with strategies in ascending order of preference */

--- a/include/genn/genn/code_generator/codeGenUtils.h
+++ b/include/genn/genn/code_generator/codeGenUtils.h
@@ -157,7 +157,7 @@ bool isKernelSizeHeterogeneous(const G *group, size_t dimensionIndex, K getKerne
     // Return true if any of the other groups have a different value
     return std::any_of(group->getGroups().cbegin(), group->getGroups().cend(),
                        [archetypeValue, dimensionIndex, getKernelSizeFn]
-                       (const G::GroupInternal& g)
+                       (const typename G::GroupInternal& g)
                        {
                            return (getKernelSizeFn(g).at(dimensionIndex) != archetypeValue);
                        });

--- a/include/genn/genn/code_generator/customUpdateGroupMerged.h
+++ b/include/genn/genn/code_generator/customUpdateGroupMerged.h
@@ -1,6 +1,7 @@
 #pragma once
 
 // GeNN code generator includes
+#include "code_generator/codeGenUtils.h"
 #include "code_generator/groupMerged.h"
 
 //----------------------------------------------------------------------------
@@ -61,10 +62,33 @@ public:
     std::string getVarIndex(VarAccessDuplication varDuplication, const std::string &index) const;
     std::string getVarRefIndex(VarAccessDuplication varDuplication, const std::string &index) const;
 
+    //! Is kernel size heterogeneous in this dimension?
+    bool isKernelSizeHeterogeneous(size_t dimensionIndex) const
+    {
+        return CodeGenerator::isKernelSizeHeterogeneous(this, dimensionIndex, getGroupKernelSize);
+    }
+
+    //! Get expression for kernel size in dimension (may be literal or group->kernelSizeXXX)
+    std::string getKernelSize(size_t dimensionIndex) const
+    {
+        return CodeGenerator::getKernelSize(this, dimensionIndex, getGroupKernelSize);
+    }
+
+    //! Generate an index into a kernel based on the id_kernel_XXX variables in subs
+    void genKernelIndex(std::ostream& os, const CodeGenerator::Substitutions& subs) const
+    {
+        return CodeGenerator::genKernelIndex(this, os, subs, getGroupKernelSize);
+    }
+
 protected:
     CustomUpdateWUGroupMergedBase(size_t index, const std::string &precision, const std::string &, const BackendBase &backend,
                                   const std::vector<std::reference_wrapper<const CustomUpdateWUInternal>> &groups);
 
+private:
+    static const std::vector<unsigned int>& getGroupKernelSize(const CustomUpdateWUInternal& g)
+    {
+        return g.getSynapseGroup()->getKernelSize();
+    }
 };
 
 // ----------------------------------------------------------------------------

--- a/include/genn/genn/code_generator/groupMerged.h
+++ b/include/genn/genn/code_generator/groupMerged.h
@@ -1122,9 +1122,8 @@ protected:
         PresynapticUpdate,
         PostsynapticUpdate,
         SynapseDynamics,
-        DenseInit,
+        Init,
         SparseInit,
-        KernelInit,
         ConnectivityInit,
     };
 

--- a/include/genn/genn/code_generator/groupMerged.h
+++ b/include/genn/genn/code_generator/groupMerged.h
@@ -1049,13 +1049,22 @@ public:
     bool isTrgNeuronDerivedParamHeterogeneous(size_t paramIndex) const;
 
     //! Is kernel size heterogeneous in this dimension?
-    bool isKernelSizeHeterogeneous(size_t dimensionIndex) const;
+    bool isKernelSizeHeterogeneous(size_t dimensionIndex) const
+    {
+        return CodeGenerator::isKernelSizeHeterogeneous(this, dimensionIndex, getGroupKernelSize);
+    }
     
     //! Get expression for kernel size in dimension (may be literal or group->kernelSizeXXX)
-    std::string getKernelSize(size_t dimensionIndex) const;
+    std::string getKernelSize(size_t dimensionIndex) const
+    {
+        return CodeGenerator::getKernelSize(this, dimensionIndex, getGroupKernelSize);
+    }
     
     //! Generate an index into a kernel based on the id_kernel_XXX variables in subs
-    void genKernelIndex(std::ostream &os, const CodeGenerator::Substitutions &subs) const;
+    void genKernelIndex(std::ostream& os, const CodeGenerator::Substitutions& subs) const
+    {
+        return CodeGenerator::genKernelIndex(this, os, subs, getGroupKernelSize);
+    }
 
     std::string getPreSlot(unsigned int batchSize) const;
     std::string getPostSlot(unsigned int batchSize) const;
@@ -1177,6 +1186,11 @@ private:
 
     //! Is postsynaptic neuron derived parameter referenced?
     bool isTrgNeuronDerivedParamReferenced(size_t paramIndex) const;
+
+    static const std::vector<unsigned int>& getGroupKernelSize(const SynapseGroupInternal& g)
+    {
+        return g.getKernelSize();
+    }
 
     //------------------------------------------------------------------------
     // Members

--- a/include/genn/genn/code_generator/initGroupMerged.h
+++ b/include/genn/genn/code_generator/initGroupMerged.h
@@ -324,13 +324,13 @@ public:
 
 
 // ----------------------------------------------------------------------------
-// CodeGenerator::CustomWUUpdateDenseInitGroupMerged
+// CodeGenerator::CustomWUUpdateInitGroupMerged
 //----------------------------------------------------------------------------
-class GENN_EXPORT CustomWUUpdateDenseInitGroupMerged : public CustomUpdateInitGroupMergedBase<CustomUpdateWUInternal>
+class GENN_EXPORT CustomWUUpdateInitGroupMerged : public CustomUpdateInitGroupMergedBase<CustomUpdateWUInternal>
 {
 public:
-    CustomWUUpdateDenseInitGroupMerged(size_t index, const std::string &precision, const std::string &, const BackendBase &backend,
-                                       const std::vector<std::reference_wrapper<const CustomUpdateWUInternal>> &groups);
+    CustomWUUpdateInitGroupMerged(size_t index, const std::string &precision, const std::string &, const BackendBase &backend,
+                                  const std::vector<std::reference_wrapper<const CustomUpdateWUInternal>> &groups);
 
     //----------------------------------------------------------------------------
     // Public API
@@ -347,10 +347,37 @@ public:
 
     void generateInit(const BackendBase &backend, CodeStream &os, const ModelSpecMerged &modelMerged, Substitutions &popSubs) const;
 
+    //! Is kernel size heterogeneous in this dimension?
+    bool isKernelSizeHeterogeneous(size_t dimensionIndex) const
+    {
+        return CodeGenerator::isKernelSizeHeterogeneous(this, dimensionIndex, getGroupKernelSize);
+    }
+
+    //! Get expression for kernel size in dimension (may be literal or group->kernelSizeXXX)
+    std::string getKernelSize(size_t dimensionIndex) const
+    {
+        return CodeGenerator::getKernelSize(this, dimensionIndex, getGroupKernelSize);
+    }
+
+    //! Generate an index into a kernel based on the id_kernel_XXX variables in subs
+    void genKernelIndex(std::ostream &os, const CodeGenerator::Substitutions &subs) const
+    {
+        return CodeGenerator::genKernelIndex(this, os, subs, getGroupKernelSize);
+    }
+
     //----------------------------------------------------------------------------
     // Static constants
     //----------------------------------------------------------------------------
     static const std::string name;
+
+private:
+    //----------------------------------------------------------------------------
+    // Private static methods
+    //----------------------------------------------------------------------------
+    static const std::vector<unsigned int> &getGroupKernelSize(const CustomUpdateWUInternal &g)
+    {
+        return g.getSynapseGroup()->getKernelSize();
+    }
 };
 
 // ----------------------------------------------------------------------------
@@ -382,59 +409,4 @@ public:
     //----------------------------------------------------------------------------
     static const std::string name;
 };
-
-// ----------------------------------------------------------------------------
-// CodeGenerator::CustomWUUpdateKernelInitGroupMerged
-//----------------------------------------------------------------------------
-class GENN_EXPORT CustomWUUpdateKernelInitGroupMerged : public CustomUpdateInitGroupMergedBase<CustomUpdateWUInternal>
-{
-public:
-    CustomWUUpdateKernelInitGroupMerged(size_t index, const std::string &precision, const std::string &, const BackendBase &backend,
-                                        const std::vector<std::reference_wrapper<const CustomUpdateWUInternal>> &groups);
-
-    //----------------------------------------------------------------------------
-    // Public API
-    //----------------------------------------------------------------------------
-    boost::uuids::detail::sha1::digest_type getHashDigest() const;
-
-    //! Is kernel size heterogeneous in this dimension?
-    bool isKernelSizeHeterogeneous(size_t dimensionIndex) const
-    {
-        return CodeGenerator::isKernelSizeHeterogeneous(this, dimensionIndex, getGroupKernelSize);
-    }
-
-    //! Get expression for kernel size in dimension (may be literal or group->kernelSizeXXX)
-    std::string getKernelSize(size_t dimensionIndex) const
-    {
-        return CodeGenerator::getKernelSize(this, dimensionIndex, getGroupKernelSize);
-    }
-
-    //! Generate an index into a kernel based on the id_kernel_XXX variables in subs
-    void genKernelIndex(std::ostream &os, const CodeGenerator::Substitutions &subs) const
-    {
-        return CodeGenerator::genKernelIndex(this, os, subs, getGroupKernelSize);
-    }
-
-    void generateRunner(const BackendBase &backend, CodeStream &definitionsInternal,
-                        CodeStream &definitionsInternalFunc, CodeStream &definitionsInternalVar,
-                        CodeStream &runnerVarDecl, CodeStream &runnerMergedStructAlloc) const
-    {
-        generateRunnerBase(backend, definitionsInternal, definitionsInternalFunc, definitionsInternalVar,
-                           runnerVarDecl, runnerMergedStructAlloc, name);
-    }
-
-    void generateInit(const BackendBase &backend, CodeStream &os, const ModelSpecMerged &modelMerged, Substitutions &popSubs) const;
-
-    //----------------------------------------------------------------------------
-    // Static constants
-    //----------------------------------------------------------------------------
-    static const std::string name;
-
-private:
-    static const std::vector<unsigned int> &getGroupKernelSize(const CustomUpdateWUInternal &g)
-    {
-        return g.getSynapseGroup()->getKernelSize();
-    }
-};
-
 }   // namespace CodeGenerator

--- a/include/genn/genn/code_generator/initGroupMerged.h
+++ b/include/genn/genn/code_generator/initGroupMerged.h
@@ -95,19 +95,19 @@ private:
 
 
 //----------------------------------------------------------------------------
-// CodeGenerator::SynapseDenseInitGroupMerged
+// CodeGenerator::SynapseInitGroupMerged
 //----------------------------------------------------------------------------
-class GENN_EXPORT SynapseDenseInitGroupMerged : public SynapseGroupMergedBase
+class GENN_EXPORT SynapseInitGroupMerged : public SynapseGroupMergedBase
 {
 public:
-    SynapseDenseInitGroupMerged(size_t index, const std::string &precision, const std::string &timePrecision, const BackendBase &backend, 
+    SynapseInitGroupMerged(size_t index, const std::string &precision, const std::string &timePrecision, const BackendBase &backend, 
                                 const std::vector<std::reference_wrapper<const SynapseGroupInternal>> &groups)
-    :   SynapseGroupMergedBase(index, precision, timePrecision, backend, SynapseGroupMergedBase::Role::DenseInit, "", groups)
+    :   SynapseGroupMergedBase(index, precision, timePrecision, backend, SynapseGroupMergedBase::Role::Init, "", groups)
     {}
 
     boost::uuids::detail::sha1::digest_type getHashDigest() const
     {
-        return SynapseGroupMergedBase::getHashDigest(SynapseGroupMergedBase::Role::DenseInit);
+        return SynapseGroupMergedBase::getHashDigest(SynapseGroupMergedBase::Role::Init);
     }
 
     void generateRunner(const BackendBase &backend, CodeStream &definitionsInternal,
@@ -157,39 +157,6 @@ public:
     //----------------------------------------------------------------------------
     static const std::string name;
 };
-
-//----------------------------------------------------------------------------
-// CodeGenerator::SynapseKernelInitGroupMerged
-//----------------------------------------------------------------------------
-class GENN_EXPORT SynapseKernelInitGroupMerged : public SynapseGroupMergedBase
-{
-public:
-    SynapseKernelInitGroupMerged(size_t index, const std::string &precision, const std::string &timePrecision, const BackendBase &backend, 
-                                 const std::vector<std::reference_wrapper<const SynapseGroupInternal>> &groups)
-    :   SynapseGroupMergedBase(index, precision, timePrecision, backend, SynapseGroupMergedBase::Role::KernelInit, "", groups)
-    {}
-
-    boost::uuids::detail::sha1::digest_type getHashDigest() const
-    {
-        return SynapseGroupMergedBase::getHashDigest(SynapseGroupMergedBase::Role::KernelInit);
-    }
-
-    void generateRunner(const BackendBase &backend, CodeStream &definitionsInternal,
-                        CodeStream &definitionsInternalFunc, CodeStream &definitionsInternalVar,
-                        CodeStream &runnerVarDecl, CodeStream &runnerMergedStructAlloc) const
-    {
-        generateRunnerBase(backend, definitionsInternal, definitionsInternalFunc, definitionsInternalVar,
-                           runnerVarDecl, runnerMergedStructAlloc, name);
-    }
-
-    void generateInit(const BackendBase &backend, CodeStream &os, const ModelSpecMerged &modelMerged, Substitutions &popSubs) const;
-
-    //----------------------------------------------------------------------------
-    // Static constants
-    //----------------------------------------------------------------------------
-    static const std::string name;
-};
-
 
 // ----------------------------------------------------------------------------
 // CodeGenerator::SynapseConnectivityInitGroupMerged

--- a/include/genn/genn/code_generator/initGroupMerged.h
+++ b/include/genn/genn/code_generator/initGroupMerged.h
@@ -416,4 +416,58 @@ public:
     static const std::string name;
 };
 
+// ----------------------------------------------------------------------------
+// CodeGenerator::CustomWUUpdateKernelInitGroupMerged
+//----------------------------------------------------------------------------
+class GENN_EXPORT CustomWUUpdateKernelInitGroupMerged : public CustomUpdateInitGroupMergedBase<CustomUpdateWUInternal>
+{
+public:
+    CustomWUUpdateKernelInitGroupMerged(size_t index, const std::string &precision, const std::string &, const BackendBase &backend,
+                                        const std::vector<std::reference_wrapper<const CustomUpdateWUInternal>> &groups);
+
+    //----------------------------------------------------------------------------
+    // Public API
+    //----------------------------------------------------------------------------
+    boost::uuids::detail::sha1::digest_type getHashDigest() const;
+
+    //! Is kernel size heterogeneous in this dimension?
+    bool isKernelSizeHeterogeneous(size_t dimensionIndex) const
+    {
+        return CodeGenerator::isKernelSizeHeterogeneous(this, dimensionIndex, getGroupKernelSize);
+    }
+
+    //! Get expression for kernel size in dimension (may be literal or group->kernelSizeXXX)
+    std::string getKernelSize(size_t dimensionIndex) const
+    {
+        return CodeGenerator::getKernelSize(this, dimensionIndex, getGroupKernelSize);
+    }
+
+    //! Generate an index into a kernel based on the id_kernel_XXX variables in subs
+    void genKernelIndex(std::ostream &os, const CodeGenerator::Substitutions &subs) const
+    {
+        return CodeGenerator::genKernelIndex(this, os, subs, getGroupKernelSize);
+    }
+
+    void generateRunner(const BackendBase &backend, CodeStream &definitionsInternal,
+                        CodeStream &definitionsInternalFunc, CodeStream &definitionsInternalVar,
+                        CodeStream &runnerVarDecl, CodeStream &runnerMergedStructAlloc) const
+    {
+        generateRunnerBase(backend, definitionsInternal, definitionsInternalFunc, definitionsInternalVar,
+                           runnerVarDecl, runnerMergedStructAlloc, name);
+    }
+
+    void generateInit(const BackendBase &backend, CodeStream &os, const ModelSpecMerged &modelMerged, Substitutions &popSubs) const;
+
+    //----------------------------------------------------------------------------
+    // Static constants
+    //----------------------------------------------------------------------------
+    static const std::string name;
+
+private:
+    static const std::vector<unsigned int> &getGroupKernelSize(const CustomUpdateWUInternal &g)
+    {
+        return g.getSynapseGroup()->getKernelSize();
+    }
+};
+
 }   // namespace CodeGenerator

--- a/include/genn/genn/code_generator/modelSpecMerged.h
+++ b/include/genn/genn/code_generator/modelSpecMerged.h
@@ -119,7 +119,7 @@ public:
     const std::vector<CustomUpdateInitGroupMerged> &getMergedCustomUpdateInitGroups() const { return m_MergedCustomUpdateInitGroups; }
 
     //! Get merged custom updategroups with dense connectivity which require initialisation
-    const std::vector<CustomWUUpdateDenseInitGroupMerged> &getMergedCustomWUUpdateDenseInitGroups() const { return m_MergedCustomWUUpdateDenseInitGroups; }
+    const std::vector<CustomWUUpdateInitGroupMerged> &getMergedCustomWUUpdateInitGroups() const { return m_MergedCustomWUUpdateInitGroups; }
 
     //! Get merged synapse groups with dense connectivity which require initialisation
     const std::vector<SynapseInitGroupMerged> &getMergedSynapseInitGroups() const{ return m_MergedSynapseInitGroups; }
@@ -132,9 +132,6 @@ public:
 
     //! Get merged custom update groups with sparse connectivity which require initialisation
     const std::vector<CustomWUUpdateSparseInitGroupMerged> &getMergedCustomWUUpdateSparseInitGroups() const { return m_MergedCustomWUUpdateSparseInitGroups; }
-
-    //! Get merged custom update groups with kernel connectivity which require initialisation
-    const std::vector<CustomWUUpdateKernelInitGroupMerged> &getMergedCustomWUUpdateKernelInitGroups() const { return m_MergedCustomWUUpdateKernelInitGroups; }
 
     //! Get merged neuron groups which require their spike queues updating
     const std::vector<NeuronSpikeQueueUpdateGroupMerged> &getMergedNeuronSpikeQueueUpdateGroups() const { return m_MergedNeuronSpikeQueueUpdateGroups; }
@@ -169,12 +166,11 @@ public:
     void genMergedSynapseDynamicsGroupStructs(CodeStream &os, const BackendBase &backend) const { genMergedStructures(os, backend, m_MergedSynapseDynamicsGroups); }
     void genMergedNeuronInitGroupStructs(CodeStream &os, const BackendBase &backend) const { genMergedStructures(os, backend, m_MergedNeuronInitGroups); }
     void genMergedCustomUpdateInitGroupStructs(CodeStream &os, const BackendBase &backend) const { genMergedStructures(os, backend, m_MergedCustomUpdateInitGroups); }
-    void genMergedCustomWUUpdateDenseInitGroupStructs(CodeStream &os, const BackendBase &backend) const { genMergedStructures(os, backend, m_MergedCustomWUUpdateDenseInitGroups); }
+    void genMergedCustomWUUpdateInitGroupStructs(CodeStream &os, const BackendBase &backend) const { genMergedStructures(os, backend, m_MergedCustomWUUpdateInitGroups); }
     void genMergedSynapseInitGroupStructs(CodeStream &os, const BackendBase &backend) const { genMergedStructures(os, backend, m_MergedSynapseInitGroups); }
     void genMergedSynapseConnectivityInitGroupStructs(CodeStream &os, const BackendBase &backend) const { genMergedStructures(os, backend, m_MergedSynapseConnectivityInitGroups); }
     void genMergedSynapseSparseInitGroupStructs(CodeStream &os, const BackendBase &backend) const { genMergedStructures(os, backend, m_MergedSynapseSparseInitGroups); }
     void genMergedCustomWUUpdateSparseInitGroupStructs(CodeStream &os, const BackendBase &backend) const { genMergedStructures(os, backend, m_MergedCustomWUUpdateSparseInitGroups); }
-    void genMergedCustomWUUpdateKernelInitGroupStructs(CodeStream &os, const BackendBase &backend) const { genMergedStructures(os, backend, m_MergedCustomWUUpdateKernelInitGroups); }
     void genMergedNeuronSpikeQueueUpdateStructs(CodeStream &os, const BackendBase &backend) const{ genMergedStructures(os, backend, m_MergedNeuronSpikeQueueUpdateGroups); }
     void genMergedNeuronPrevSpikeTimeUpdateStructs(CodeStream &os, const BackendBase &backend) const{ genMergedStructures(os, backend, m_MergedNeuronPrevSpikeTimeUpdateGroups); }
     void genMergedSynapseDendriticDelayUpdateStructs(CodeStream &os, const BackendBase &backend) const { genMergedStructures(os, backend, m_MergedSynapseDendriticDelayUpdateGroups); }
@@ -389,8 +385,8 @@ private:
     //! Merged custom update groups which require initialisation
     std::vector<CustomUpdateInitGroupMerged> m_MergedCustomUpdateInitGroups;
 
-    //! Merged custom update groups with dense connectivity which require initialisation
-    std::vector<CustomWUUpdateDenseInitGroupMerged> m_MergedCustomWUUpdateDenseInitGroups;
+    //! Merged custom update weight update groups which require initialisation
+    std::vector<CustomWUUpdateInitGroupMerged> m_MergedCustomWUUpdateInitGroups;
 
     //! Merged synapse groups with dense connectivity which require initialisation
     std::vector<SynapseInitGroupMerged> m_MergedSynapseInitGroups;
@@ -403,9 +399,6 @@ private:
 
     //! Merged custom update groups with sparse connectivity which require initialisation
     std::vector<CustomWUUpdateSparseInitGroupMerged> m_MergedCustomWUUpdateSparseInitGroups;
-
-    //! Merged custom update groups with kernel weights which require initialisation
-    std::vector<CustomWUUpdateKernelInitGroupMerged> m_MergedCustomWUUpdateKernelInitGroups;
 
     //! Merged neuron groups which require their spike queues updating
     std::vector<NeuronSpikeQueueUpdateGroupMerged> m_MergedNeuronSpikeQueueUpdateGroups;

--- a/include/genn/genn/code_generator/modelSpecMerged.h
+++ b/include/genn/genn/code_generator/modelSpecMerged.h
@@ -122,16 +122,13 @@ public:
     const std::vector<CustomWUUpdateDenseInitGroupMerged> &getMergedCustomWUUpdateDenseInitGroups() const { return m_MergedCustomWUUpdateDenseInitGroups; }
 
     //! Get merged synapse groups with dense connectivity which require initialisation
-    const std::vector<SynapseDenseInitGroupMerged> &getMergedSynapseDenseInitGroups() const{ return m_MergedSynapseDenseInitGroups; }
+    const std::vector<SynapseInitGroupMerged> &getMergedSynapseInitGroups() const{ return m_MergedSynapseInitGroups; }
 
     //! Get merged synapse groups which require connectivity initialisation
     const std::vector<SynapseConnectivityInitGroupMerged> &getMergedSynapseConnectivityInitGroups() const{ return m_MergedSynapseConnectivityInitGroups; }
 
     //! Get merged synapse groups with sparse connectivity which require initialisation
     const std::vector<SynapseSparseInitGroupMerged> &getMergedSynapseSparseInitGroups() const{ return m_MergedSynapseSparseInitGroups; }
-    
-    //! Get merged synapse groups with kernel connectivity which require initialisation
-    const std::vector<SynapseKernelInitGroupMerged> &getMergedSynapseKernelInitGroups() const{ return m_MergedSynapseKernelInitGroups; }
 
     //! Get merged custom update groups with sparse connectivity which require initialisation
     const std::vector<CustomWUUpdateSparseInitGroupMerged> &getMergedCustomWUUpdateSparseInitGroups() const { return m_MergedCustomWUUpdateSparseInitGroups; }
@@ -173,10 +170,9 @@ public:
     void genMergedNeuronInitGroupStructs(CodeStream &os, const BackendBase &backend) const { genMergedStructures(os, backend, m_MergedNeuronInitGroups); }
     void genMergedCustomUpdateInitGroupStructs(CodeStream &os, const BackendBase &backend) const { genMergedStructures(os, backend, m_MergedCustomUpdateInitGroups); }
     void genMergedCustomWUUpdateDenseInitGroupStructs(CodeStream &os, const BackendBase &backend) const { genMergedStructures(os, backend, m_MergedCustomWUUpdateDenseInitGroups); }
-    void genMergedSynapseDenseInitGroupStructs(CodeStream &os, const BackendBase &backend) const { genMergedStructures(os, backend, m_MergedSynapseDenseInitGroups); }
+    void genMergedSynapseInitGroupStructs(CodeStream &os, const BackendBase &backend) const { genMergedStructures(os, backend, m_MergedSynapseInitGroups); }
     void genMergedSynapseConnectivityInitGroupStructs(CodeStream &os, const BackendBase &backend) const { genMergedStructures(os, backend, m_MergedSynapseConnectivityInitGroups); }
     void genMergedSynapseSparseInitGroupStructs(CodeStream &os, const BackendBase &backend) const { genMergedStructures(os, backend, m_MergedSynapseSparseInitGroups); }
-    void genMergedSynapseKernelInitGroupStructs(CodeStream &os, const BackendBase &backend) const { genMergedStructures(os, backend, m_MergedSynapseKernelInitGroups); }
     void genMergedCustomWUUpdateSparseInitGroupStructs(CodeStream &os, const BackendBase &backend) const { genMergedStructures(os, backend, m_MergedCustomWUUpdateSparseInitGroups); }
     void genMergedCustomWUUpdateKernelInitGroupStructs(CodeStream &os, const BackendBase &backend) const { genMergedStructures(os, backend, m_MergedCustomWUUpdateKernelInitGroups); }
     void genMergedNeuronSpikeQueueUpdateStructs(CodeStream &os, const BackendBase &backend) const{ genMergedStructures(os, backend, m_MergedNeuronSpikeQueueUpdateGroups); }
@@ -397,16 +393,13 @@ private:
     std::vector<CustomWUUpdateDenseInitGroupMerged> m_MergedCustomWUUpdateDenseInitGroups;
 
     //! Merged synapse groups with dense connectivity which require initialisation
-    std::vector<SynapseDenseInitGroupMerged> m_MergedSynapseDenseInitGroups;
+    std::vector<SynapseInitGroupMerged> m_MergedSynapseInitGroups;
 
     //! Merged synapse groups which require connectivity initialisation
     std::vector<SynapseConnectivityInitGroupMerged> m_MergedSynapseConnectivityInitGroups;
 
     //! Merged synapse groups with sparse connectivity which require initialisation
     std::vector<SynapseSparseInitGroupMerged> m_MergedSynapseSparseInitGroups;
-    
-    //! Merged synapse groups with kernel connectivity which require initialisation
-    std::vector<SynapseKernelInitGroupMerged> m_MergedSynapseKernelInitGroups;
 
     //! Merged custom update groups with sparse connectivity which require initialisation
     std::vector<CustomWUUpdateSparseInitGroupMerged> m_MergedCustomWUUpdateSparseInitGroups;

--- a/include/genn/genn/code_generator/modelSpecMerged.h
+++ b/include/genn/genn/code_generator/modelSpecMerged.h
@@ -136,6 +136,9 @@ public:
     //! Get merged custom update groups with sparse connectivity which require initialisation
     const std::vector<CustomWUUpdateSparseInitGroupMerged> &getMergedCustomWUUpdateSparseInitGroups() const { return m_MergedCustomWUUpdateSparseInitGroups; }
 
+    //! Get merged custom update groups with kernel connectivity which require initialisation
+    const std::vector<CustomWUUpdateKernelInitGroupMerged> &getMergedCustomWUUpdateKernelInitGroups() const { return m_MergedCustomWUUpdateKernelInitGroups; }
+
     //! Get merged neuron groups which require their spike queues updating
     const std::vector<NeuronSpikeQueueUpdateGroupMerged> &getMergedNeuronSpikeQueueUpdateGroups() const { return m_MergedNeuronSpikeQueueUpdateGroups; }
 
@@ -175,6 +178,7 @@ public:
     void genMergedSynapseSparseInitGroupStructs(CodeStream &os, const BackendBase &backend) const { genMergedStructures(os, backend, m_MergedSynapseSparseInitGroups); }
     void genMergedSynapseKernelInitGroupStructs(CodeStream &os, const BackendBase &backend) const { genMergedStructures(os, backend, m_MergedSynapseKernelInitGroups); }
     void genMergedCustomWUUpdateSparseInitGroupStructs(CodeStream &os, const BackendBase &backend) const { genMergedStructures(os, backend, m_MergedCustomWUUpdateSparseInitGroups); }
+    void genMergedCustomWUUpdateKernelInitGroupStructs(CodeStream &os, const BackendBase &backend) const { genMergedStructures(os, backend, m_MergedCustomWUUpdateKernelInitGroups); }
     void genMergedNeuronSpikeQueueUpdateStructs(CodeStream &os, const BackendBase &backend) const{ genMergedStructures(os, backend, m_MergedNeuronSpikeQueueUpdateGroups); }
     void genMergedNeuronPrevSpikeTimeUpdateStructs(CodeStream &os, const BackendBase &backend) const{ genMergedStructures(os, backend, m_MergedNeuronPrevSpikeTimeUpdateGroups); }
     void genMergedSynapseDendriticDelayUpdateStructs(CodeStream &os, const BackendBase &backend) const { genMergedStructures(os, backend, m_MergedSynapseDendriticDelayUpdateGroups); }
@@ -406,6 +410,9 @@ private:
 
     //! Merged custom update groups with sparse connectivity which require initialisation
     std::vector<CustomWUUpdateSparseInitGroupMerged> m_MergedCustomWUUpdateSparseInitGroups;
+
+    //! Merged custom update groups with kernel weights which require initialisation
+    std::vector<CustomWUUpdateKernelInitGroupMerged> m_MergedCustomWUUpdateKernelInitGroups;
 
     //! Merged neuron groups which require their spike queues updating
     std::vector<NeuronSpikeQueueUpdateGroupMerged> m_MergedNeuronSpikeQueueUpdateGroups;

--- a/src/genn/backends/cuda/backend.cc
+++ b/src/genn/backends/cuda/backend.cc
@@ -858,22 +858,20 @@ void Backend::genInit(CodeStream &os, const ModelSpecMerged &modelMerged,
 
     // Generate struct definitions
     modelMerged.genMergedNeuronInitGroupStructs(os, *this);
-    modelMerged.genMergedCustomUpdateInitGroupStructs(os, *this);
-    modelMerged.genMergedCustomWUUpdateDenseInitGroupStructs(os, *this);
     modelMerged.genMergedSynapseInitGroupStructs(os, *this);
-    modelMerged.genMergedCustomWUUpdateKernelInitGroupStructs(os, *this);
     modelMerged.genMergedSynapseConnectivityInitGroupStructs(os, *this);
     modelMerged.genMergedSynapseSparseInitGroupStructs(os, *this);
+    modelMerged.genMergedCustomUpdateInitGroupStructs(os, *this);
+    modelMerged.genMergedCustomWUUpdateInitGroupStructs(os, *this);
     modelMerged.genMergedCustomWUUpdateSparseInitGroupStructs(os, *this);
 
     // Generate arrays of merged structs and functions to push them
     genMergedStructArrayPush(os, modelMerged.getMergedNeuronInitGroups());
-    genMergedStructArrayPush(os, modelMerged.getMergedCustomUpdateInitGroups());
-    genMergedStructArrayPush(os, modelMerged.getMergedCustomWUUpdateDenseInitGroups());
     genMergedStructArrayPush(os, modelMerged.getMergedSynapseInitGroups());
-    genMergedStructArrayPush(os, modelMerged.getMergedCustomWUUpdateKernelInitGroups());
     genMergedStructArrayPush(os, modelMerged.getMergedSynapseConnectivityInitGroups());
     genMergedStructArrayPush(os, modelMerged.getMergedSynapseSparseInitGroups());
+    genMergedStructArrayPush(os, modelMerged.getMergedCustomUpdateInitGroups());
+    genMergedStructArrayPush(os, modelMerged.getMergedCustomWUUpdateInitGroups());
     genMergedStructArrayPush(os, modelMerged.getMergedCustomWUUpdateSparseInitGroups());
 
     // Generate preamble
@@ -886,10 +884,9 @@ void Backend::genInit(CodeStream &os, const ModelSpecMerged &modelMerged,
     genMergedKernelDataStructures(
         os, totalConstMem,
         modelMerged.getMergedNeuronInitGroups(), [this](const NeuronGroupInternal &ng){ return padKernelSize(ng.getNumNeurons(), KernelInitialize); },
-        modelMerged.getMergedCustomUpdateInitGroups(), [this](const CustomUpdateInternal &cg) { return padKernelSize(cg.getSize(), KernelInitialize); },
-        modelMerged.getMergedCustomWUUpdateDenseInitGroups(), [this](const CustomUpdateWUInternal &cg){ return padKernelSize(cg.getSynapseGroup()->getTrgNeuronGroup()->getNumNeurons(), KernelInitialize); },
         modelMerged.getMergedSynapseInitGroups(), [this](const SynapseGroupInternal &sg){ return padKernelSize(getNumInitThreads(sg), KernelInitialize); },
-        modelMerged.getMergedCustomWUUpdateKernelInitGroups(), [this](const CustomUpdateWUInternal &sg) { return padKernelSize(sg.getSynapseGroup()->getKernelSizeFlattened(), KernelInitialize); },
+        modelMerged.getMergedCustomUpdateInitGroups(), [this](const CustomUpdateInternal &cg) { return padKernelSize(cg.getSize(), KernelInitialize); },
+        modelMerged.getMergedCustomWUUpdateInitGroups(), [this](const CustomUpdateWUInternal &cg){ return padKernelSize(getNumInitThreads(cg), KernelInitialize); },        
         modelMerged.getMergedSynapseConnectivityInitGroups(), [this](const SynapseGroupInternal &sg){ return padKernelSize(getNumConnectivityInitThreads(sg), KernelInitialize); });
 
     // Generate data structure for accessing merged groups from within sparse initialisation kernel

--- a/src/genn/backends/cuda/backend.cc
+++ b/src/genn/backends/cuda/backend.cc
@@ -862,6 +862,7 @@ void Backend::genInit(CodeStream &os, const ModelSpecMerged &modelMerged,
     modelMerged.genMergedCustomWUUpdateDenseInitGroupStructs(os, *this);
     modelMerged.genMergedSynapseDenseInitGroupStructs(os, *this);
     modelMerged.genMergedSynapseKernelInitGroupStructs(os, *this);
+    modelMerged.genMergedCustomWUUpdateKernelInitGroupStructs(os, *this);
     modelMerged.genMergedSynapseConnectivityInitGroupStructs(os, *this);
     modelMerged.genMergedSynapseSparseInitGroupStructs(os, *this);
     modelMerged.genMergedCustomWUUpdateSparseInitGroupStructs(os, *this);
@@ -872,6 +873,7 @@ void Backend::genInit(CodeStream &os, const ModelSpecMerged &modelMerged,
     genMergedStructArrayPush(os, modelMerged.getMergedCustomWUUpdateDenseInitGroups());
     genMergedStructArrayPush(os, modelMerged.getMergedSynapseDenseInitGroups());
     genMergedStructArrayPush(os, modelMerged.getMergedSynapseKernelInitGroups());
+    genMergedStructArrayPush(os, modelMerged.getMergedCustomWUUpdateKernelInitGroups());
     genMergedStructArrayPush(os, modelMerged.getMergedSynapseConnectivityInitGroups());
     genMergedStructArrayPush(os, modelMerged.getMergedSynapseSparseInitGroups());
     genMergedStructArrayPush(os, modelMerged.getMergedCustomWUUpdateSparseInitGroups());
@@ -890,6 +892,7 @@ void Backend::genInit(CodeStream &os, const ModelSpecMerged &modelMerged,
         modelMerged.getMergedCustomWUUpdateDenseInitGroups(), [this](const CustomUpdateWUInternal &cg){ return padKernelSize(cg.getSynapseGroup()->getTrgNeuronGroup()->getNumNeurons(), KernelInitialize); },
         modelMerged.getMergedSynapseDenseInitGroups(), [this](const SynapseGroupInternal &sg){ return padKernelSize(sg.getTrgNeuronGroup()->getNumNeurons(), KernelInitialize); },
         modelMerged.getMergedSynapseKernelInitGroups(), [this](const SynapseGroupInternal &sg){ return padKernelSize(sg.getKernelSizeFlattened(), KernelInitialize); },
+        modelMerged.getMergedCustomWUUpdateKernelInitGroups(), [this](const CustomUpdateWUInternal &sg) { return padKernelSize(sg.getSynapseGroup()->getKernelSizeFlattened(), KernelInitialize); },
         modelMerged.getMergedSynapseConnectivityInitGroups(), [this](const SynapseGroupInternal &sg){ return padKernelSize(getNumConnectivityInitThreads(sg), KernelInitialize); });
 
     // Generate data structure for accessing merged groups from within sparse initialisation kernel

--- a/src/genn/backends/cuda/backend.cc
+++ b/src/genn/backends/cuda/backend.cc
@@ -860,8 +860,7 @@ void Backend::genInit(CodeStream &os, const ModelSpecMerged &modelMerged,
     modelMerged.genMergedNeuronInitGroupStructs(os, *this);
     modelMerged.genMergedCustomUpdateInitGroupStructs(os, *this);
     modelMerged.genMergedCustomWUUpdateDenseInitGroupStructs(os, *this);
-    modelMerged.genMergedSynapseDenseInitGroupStructs(os, *this);
-    modelMerged.genMergedSynapseKernelInitGroupStructs(os, *this);
+    modelMerged.genMergedSynapseInitGroupStructs(os, *this);
     modelMerged.genMergedCustomWUUpdateKernelInitGroupStructs(os, *this);
     modelMerged.genMergedSynapseConnectivityInitGroupStructs(os, *this);
     modelMerged.genMergedSynapseSparseInitGroupStructs(os, *this);
@@ -871,8 +870,7 @@ void Backend::genInit(CodeStream &os, const ModelSpecMerged &modelMerged,
     genMergedStructArrayPush(os, modelMerged.getMergedNeuronInitGroups());
     genMergedStructArrayPush(os, modelMerged.getMergedCustomUpdateInitGroups());
     genMergedStructArrayPush(os, modelMerged.getMergedCustomWUUpdateDenseInitGroups());
-    genMergedStructArrayPush(os, modelMerged.getMergedSynapseDenseInitGroups());
-    genMergedStructArrayPush(os, modelMerged.getMergedSynapseKernelInitGroups());
+    genMergedStructArrayPush(os, modelMerged.getMergedSynapseInitGroups());
     genMergedStructArrayPush(os, modelMerged.getMergedCustomWUUpdateKernelInitGroups());
     genMergedStructArrayPush(os, modelMerged.getMergedSynapseConnectivityInitGroups());
     genMergedStructArrayPush(os, modelMerged.getMergedSynapseSparseInitGroups());
@@ -890,8 +888,7 @@ void Backend::genInit(CodeStream &os, const ModelSpecMerged &modelMerged,
         modelMerged.getMergedNeuronInitGroups(), [this](const NeuronGroupInternal &ng){ return padKernelSize(ng.getNumNeurons(), KernelInitialize); },
         modelMerged.getMergedCustomUpdateInitGroups(), [this](const CustomUpdateInternal &cg) { return padKernelSize(cg.getSize(), KernelInitialize); },
         modelMerged.getMergedCustomWUUpdateDenseInitGroups(), [this](const CustomUpdateWUInternal &cg){ return padKernelSize(cg.getSynapseGroup()->getTrgNeuronGroup()->getNumNeurons(), KernelInitialize); },
-        modelMerged.getMergedSynapseDenseInitGroups(), [this](const SynapseGroupInternal &sg){ return padKernelSize(sg.getTrgNeuronGroup()->getNumNeurons(), KernelInitialize); },
-        modelMerged.getMergedSynapseKernelInitGroups(), [this](const SynapseGroupInternal &sg){ return padKernelSize(sg.getKernelSizeFlattened(), KernelInitialize); },
+        modelMerged.getMergedSynapseInitGroups(), [this](const SynapseGroupInternal &sg){ return padKernelSize(getNumInitThreads(sg), KernelInitialize); },
         modelMerged.getMergedCustomWUUpdateKernelInitGroups(), [this](const CustomUpdateWUInternal &sg) { return padKernelSize(sg.getSynapseGroup()->getKernelSizeFlattened(), KernelInitialize); },
         modelMerged.getMergedSynapseConnectivityInitGroups(), [this](const SynapseGroupInternal &sg){ return padKernelSize(getNumConnectivityInitThreads(sg), KernelInitialize); });
 

--- a/src/genn/backends/opencl/backend.cc
+++ b/src/genn/backends/opencl/backend.cc
@@ -1242,6 +1242,7 @@ void Backend::genInit(CodeStream &os, const ModelSpecMerged &modelMerged,
             genMergedStructBuild(os, modelMerged, modelMerged.getMergedNeuronInitGroups(), "initializeProgram");
             genMergedStructBuild(os, modelMerged, modelMerged.getMergedCustomUpdateInitGroups(), "initializeProgram");
             genMergedStructBuild(os, modelMerged, modelMerged.getMergedCustomWUUpdateDenseInitGroups(), "initializeProgram");
+            genMergedStructBuild(os, modelMerged, modelMerged.getMergedCustomWUUpdateKernelInitGroups(), "initializeProgram");
             genMergedStructBuild(os, modelMerged, modelMerged.getMergedSynapseDenseInitGroups(), "initializeProgram");
             genMergedStructBuild(os, modelMerged, modelMerged.getMergedSynapseKernelInitGroups(), "initializeProgram");
             genMergedStructBuild(os, modelMerged, modelMerged.getMergedSynapseConnectivityInitGroups(), "initializeProgram");
@@ -1257,6 +1258,7 @@ void Backend::genInit(CodeStream &os, const ModelSpecMerged &modelMerged,
             setMergedGroupKernelParams(os, KernelNames[KernelInitialize], modelMerged.getMergedNeuronInitGroups(), start);
             setMergedGroupKernelParams(os, KernelNames[KernelInitialize], modelMerged.getMergedCustomUpdateInitGroups(), start);
             setMergedGroupKernelParams(os, KernelNames[KernelInitialize], modelMerged.getMergedCustomWUUpdateDenseInitGroups(), start);
+            setMergedGroupKernelParams(os, KernelNames[KernelInitialize], modelMerged.getMergedCustomWUUpdateKernelInitGroups(), start);
             setMergedGroupKernelParams(os, KernelNames[KernelInitialize], modelMerged.getMergedSynapseDenseInitGroups(), start);
             setMergedGroupKernelParams(os, KernelNames[KernelInitialize], modelMerged.getMergedSynapseKernelInitGroups(), start);
             setMergedGroupKernelParams(os, KernelNames[KernelInitialize], modelMerged.getMergedSynapseConnectivityInitGroups(), start);
@@ -1319,8 +1321,9 @@ void Backend::genInit(CodeStream &os, const ModelSpecMerged &modelMerged,
             genKernelDimensions(os, KernelInitialize, idInitStart, 1);
             if(globalRNGRequired) {
                 const size_t numInitGroups = (modelMerged.getMergedNeuronInitGroups().size() + modelMerged.getMergedCustomUpdateInitGroups().size() +
-                                              modelMerged.getMergedCustomWUUpdateDenseInitGroups().size() + modelMerged.getMergedSynapseDenseInitGroups().size() +
-                                              modelMerged.getMergedSynapseKernelInitGroups().size() + modelMerged.getMergedSynapseConnectivityInitGroups().size());
+                                              modelMerged.getMergedCustomWUUpdateDenseInitGroups().size() + modelMerged.getMergedCustomWUUpdateKernelInitGroups().size() +
+                                              modelMerged.getMergedSynapseDenseInitGroups().size() + modelMerged.getMergedSynapseKernelInitGroups().size() + 
+                                              modelMerged.getMergedSynapseConnectivityInitGroups().size());
 
                 os << "CHECK_OPENCL_ERRORS(" << KernelNames[KernelInitialize] << ".setArg(" << numInitGroups << ", d_rng));" << std::endl;
             }

--- a/src/genn/backends/opencl/backend.cc
+++ b/src/genn/backends/opencl/backend.cc
@@ -1081,10 +1081,9 @@ void Backend::genInit(CodeStream &os, const ModelSpecMerged &modelMerged,
     os << "cl::Kernel " << KernelNames[KernelInitialize] << ";" << std::endl;
     os << "cl::Kernel " << KernelNames[KernelInitializeSparse] << ";" << std::endl;
     genMergedStructPreamble(os, modelMerged, modelMerged.getMergedNeuronInitGroups());
-    genMergedStructPreamble(os, modelMerged, modelMerged.getMergedCustomUpdateInitGroups());
-    genMergedStructPreamble(os, modelMerged, modelMerged.getMergedCustomWUUpdateDenseInitGroups());
-    genMergedStructPreamble(os, modelMerged, modelMerged.getMergedCustomWUUpdateKernelInitGroups());
     genMergedStructPreamble(os, modelMerged, modelMerged.getMergedSynapseInitGroups());
+    genMergedStructPreamble(os, modelMerged, modelMerged.getMergedCustomUpdateInitGroups());
+    genMergedStructPreamble(os, modelMerged, modelMerged.getMergedCustomWUUpdateInitGroups());
     genMergedStructPreamble(os, modelMerged, modelMerged.getMergedSynapseConnectivityInitGroups());
     genMergedStructPreamble(os, modelMerged, modelMerged.getMergedSynapseSparseInitGroups());
     genMergedStructPreamble(os, modelMerged, modelMerged.getMergedCustomWUUpdateSparseInitGroups());
@@ -1108,10 +1107,9 @@ void Backend::genInit(CodeStream &os, const ModelSpecMerged &modelMerged,
 
     // Generate struct definitions
     modelMerged.genMergedNeuronInitGroupStructs(initializeKernels, *this);
-    modelMerged.genMergedCustomUpdateInitGroupStructs(initializeKernels, *this);
-    modelMerged.genMergedCustomWUUpdateDenseInitGroupStructs(initializeKernels, *this);
-    modelMerged.genMergedCustomWUUpdateKernelInitGroupStructs(initializeKernels, *this);
     modelMerged.genMergedSynapseInitGroupStructs(initializeKernels, *this);
+    modelMerged.genMergedCustomUpdateInitGroupStructs(initializeKernels, *this);
+    modelMerged.genMergedCustomWUUpdateInitGroupStructs(initializeKernels, *this);
     modelMerged.genMergedSynapseConnectivityInitGroupStructs(initializeKernels, *this);
     modelMerged.genMergedSynapseSparseInitGroupStructs(initializeKernels, *this);
     modelMerged.genMergedCustomWUUpdateSparseInitGroupStructs(initializeKernels, *this);
@@ -1121,10 +1119,9 @@ void Backend::genInit(CodeStream &os, const ModelSpecMerged &modelMerged,
     genMergedKernelDataStructures(
         initializeKernels,
         modelMerged.getMergedNeuronInitGroups(), [this](const NeuronGroupInternal &ng) { return padKernelSize(ng.getNumNeurons(), KernelInitialize); },
-        modelMerged.getMergedCustomUpdateInitGroups(), [this](const CustomUpdateInternal &cg) { return padKernelSize(cg.getSize(), KernelInitialize); },
-        modelMerged.getMergedCustomWUUpdateDenseInitGroups(), [this](const CustomUpdateWUInternal &cg) { return padKernelSize(cg.getSynapseGroup()->getTrgNeuronGroup()->getNumNeurons(), KernelInitialize); },
-        modelMerged.getMergedCustomWUUpdateKernelInitGroups(), [this](const CustomUpdateWUInternal &cg) { return padKernelSize(cg.getSynapseGroup()->getKernelSizeFlattened(), KernelInitialize); },
         modelMerged.getMergedSynapseInitGroups(), [this](const SynapseGroupInternal &sg) { return padKernelSize(getNumInitThreads(sg), KernelInitialize); },
+        modelMerged.getMergedCustomUpdateInitGroups(), [this](const CustomUpdateInternal &cg) { return padKernelSize(cg.getSize(), KernelInitialize); },
+        modelMerged.getMergedCustomWUUpdateInitGroups(), [this](const CustomUpdateWUInternal &cg) { return padKernelSize(getNumInitThreads(cg), KernelInitialize); },
         modelMerged.getMergedSynapseConnectivityInitGroups(), [this](const SynapseGroupInternal &sg) { return padKernelSize(getNumConnectivityInitThreads(sg), KernelInitialize); });
 
     // Generate data structure for accessing merged groups from within sparse initialisation kernel
@@ -1136,10 +1133,9 @@ void Backend::genInit(CodeStream &os, const ModelSpecMerged &modelMerged,
 
     // Generate kernels used to populate merged structs
     genMergedStructBuildKernels(initializeKernels, modelMerged, modelMerged.getMergedNeuronInitGroups());
-    genMergedStructBuildKernels(initializeKernels, modelMerged, modelMerged.getMergedCustomUpdateInitGroups());
-    genMergedStructBuildKernels(initializeKernels, modelMerged, modelMerged.getMergedCustomWUUpdateDenseInitGroups());
-    genMergedStructBuildKernels(initializeKernels, modelMerged, modelMerged.getMergedCustomWUUpdateKernelInitGroups());
     genMergedStructBuildKernels(initializeKernels, modelMerged, modelMerged.getMergedSynapseInitGroups());
+    genMergedStructBuildKernels(initializeKernels, modelMerged, modelMerged.getMergedCustomUpdateInitGroups());
+    genMergedStructBuildKernels(initializeKernels, modelMerged, modelMerged.getMergedCustomWUUpdateInitGroups());
     genMergedStructBuildKernels(initializeKernels, modelMerged, modelMerged.getMergedSynapseConnectivityInitGroups());
     genMergedStructBuildKernels(initializeKernels, modelMerged, modelMerged.getMergedSynapseSparseInitGroups());
     genMergedStructBuildKernels(initializeKernels, modelMerged, modelMerged.getMergedCustomWUUpdateSparseInitGroups());
@@ -1149,19 +1145,17 @@ void Backend::genInit(CodeStream &os, const ModelSpecMerged &modelMerged,
     bool globalRNGRequired = isGlobalDeviceRNGRequired(modelMerged);
     bool additionalParamsRequired = globalRNGRequired || shouldUseSubBufferAllocations();
     const bool anyCustomUpdateInitGroups = !modelMerged.getMergedCustomUpdateInitGroups().empty();
-    const bool anyCustomWUUpdateDenseInitGroups = !modelMerged.getMergedCustomWUUpdateDenseInitGroups().empty();
-    const bool anyCustomWUUpdateKernelInitGroups = !modelMerged.getMergedCustomWUUpdateKernelInitGroups().empty();
+    const bool anyCustomWUUpdateInitGroups = !modelMerged.getMergedCustomWUUpdateInitGroups().empty();
     const bool anySynapseInitGroups = !modelMerged.getMergedSynapseInitGroups().empty();
     const bool anyConnectivityInitGroups = !modelMerged.getMergedSynapseConnectivityInitGroups().empty();
     genMergedGroupKernelParams(initializeKernels, modelMerged.getMergedNeuronInitGroups(), 
-                               anyCustomUpdateInitGroups || anyCustomWUUpdateDenseInitGroups || anyCustomWUUpdateKernelInitGroups || anySynapseInitGroups || anyConnectivityInitGroups || additionalParamsRequired);
+                              anySynapseInitGroups ||  anyCustomUpdateInitGroups || anyCustomWUUpdateInitGroups || anyConnectivityInitGroups || additionalParamsRequired);
+    genMergedGroupKernelParams(initializeKernels, modelMerged.getMergedSynapseInitGroups(), 
+                               anyCustomUpdateInitGroups || anyCustomWUUpdateInitGroups || anyConnectivityInitGroups || additionalParamsRequired);
     genMergedGroupKernelParams(initializeKernels, modelMerged.getMergedCustomUpdateInitGroups(), 
-                               anyCustomWUUpdateDenseInitGroups || anyCustomWUUpdateKernelInitGroups || anySynapseInitGroups || anyConnectivityInitGroups || additionalParamsRequired);
-    genMergedGroupKernelParams(initializeKernels, modelMerged.getMergedCustomWUUpdateDenseInitGroups(), 
-                               anyCustomWUUpdateKernelInitGroups || anySynapseInitGroups || anyConnectivityInitGroups || additionalParamsRequired);
-    genMergedGroupKernelParams(initializeKernels, modelMerged.getMergedCustomWUUpdateKernelInitGroups(),
-                               anySynapseInitGroups || anyConnectivityInitGroups || additionalParamsRequired);
-    genMergedGroupKernelParams(initializeKernels, modelMerged.getMergedSynapseInitGroups(), anyConnectivityInitGroups || additionalParamsRequired);
+                               anyCustomWUUpdateInitGroups || anyConnectivityInitGroups || additionalParamsRequired);
+    genMergedGroupKernelParams(initializeKernels, modelMerged.getMergedCustomWUUpdateInitGroups(), 
+                               anyConnectivityInitGroups || additionalParamsRequired);
     genMergedGroupKernelParams(initializeKernels, modelMerged.getMergedSynapseConnectivityInitGroups(), additionalParamsRequired);
     if(globalRNGRequired) {
         initializeKernels << "__global clrngPhilox432HostStream *d_rng";
@@ -1234,10 +1228,9 @@ void Backend::genInit(CodeStream &os, const ModelSpecMerged &modelMerged,
 
             os << "// Configure merged struct building kernels" << std::endl;
             genMergedStructBuild(os, modelMerged, modelMerged.getMergedNeuronInitGroups(), "initializeProgram");
-            genMergedStructBuild(os, modelMerged, modelMerged.getMergedCustomUpdateInitGroups(), "initializeProgram");
-            genMergedStructBuild(os, modelMerged, modelMerged.getMergedCustomWUUpdateDenseInitGroups(), "initializeProgram");
-            genMergedStructBuild(os, modelMerged, modelMerged.getMergedCustomWUUpdateKernelInitGroups(), "initializeProgram");
             genMergedStructBuild(os, modelMerged, modelMerged.getMergedSynapseInitGroups(), "initializeProgram");
+            genMergedStructBuild(os, modelMerged, modelMerged.getMergedCustomUpdateInitGroups(), "initializeProgram");
+            genMergedStructBuild(os, modelMerged, modelMerged.getMergedCustomWUUpdateInitGroups(), "initializeProgram");
             genMergedStructBuild(os, modelMerged, modelMerged.getMergedSynapseConnectivityInitGroups(), "initializeProgram");
             genMergedStructBuild(os, modelMerged, modelMerged.getMergedSynapseSparseInitGroups(), "initializeProgram");
             genMergedStructBuild(os, modelMerged, modelMerged.getMergedCustomWUUpdateSparseInitGroups(), "initializeProgram");
@@ -1249,10 +1242,9 @@ void Backend::genInit(CodeStream &os, const ModelSpecMerged &modelMerged,
             os << "CHECK_OPENCL_ERRORS_POINTER(" << KernelNames[KernelInitialize] << " = cl::Kernel(initializeProgram, \"" << KernelNames[KernelInitialize] << "\", &error));" << std::endl;
             size_t start = 0;
             setMergedGroupKernelParams(os, KernelNames[KernelInitialize], modelMerged.getMergedNeuronInitGroups(), start);
-            setMergedGroupKernelParams(os, KernelNames[KernelInitialize], modelMerged.getMergedCustomUpdateInitGroups(), start);
-            setMergedGroupKernelParams(os, KernelNames[KernelInitialize], modelMerged.getMergedCustomWUUpdateDenseInitGroups(), start);
-            setMergedGroupKernelParams(os, KernelNames[KernelInitialize], modelMerged.getMergedCustomWUUpdateKernelInitGroups(), start);
             setMergedGroupKernelParams(os, KernelNames[KernelInitialize], modelMerged.getMergedSynapseInitGroups(), start);
+            setMergedGroupKernelParams(os, KernelNames[KernelInitialize], modelMerged.getMergedCustomUpdateInitGroups(), start);
+            setMergedGroupKernelParams(os, KernelNames[KernelInitialize], modelMerged.getMergedCustomWUUpdateInitGroups(), start);
             setMergedGroupKernelParams(os, KernelNames[KernelInitialize], modelMerged.getMergedSynapseConnectivityInitGroups(), start);
             if(shouldUseSubBufferAllocations()) {
                 os << "CHECK_OPENCL_ERRORS(" << KernelNames[KernelInitialize] << ".setArg(" << (start + (globalRNGRequired ? 1 : 0)) << ", d_staticBuffer));" << std::endl;
@@ -1312,9 +1304,9 @@ void Backend::genInit(CodeStream &os, const ModelSpecMerged &modelMerged,
             CodeStream::Scope b(os);
             genKernelDimensions(os, KernelInitialize, idInitStart, 1);
             if(globalRNGRequired) {
-                const size_t numInitGroups = (modelMerged.getMergedNeuronInitGroups().size() + modelMerged.getMergedCustomUpdateInitGroups().size() +
-                                              modelMerged.getMergedCustomWUUpdateDenseInitGroups().size() + modelMerged.getMergedCustomWUUpdateKernelInitGroups().size() +
-                                              modelMerged.getMergedSynapseInitGroups().size() + modelMerged.getMergedSynapseConnectivityInitGroups().size());
+                const size_t numInitGroups = (modelMerged.getMergedNeuronInitGroups().size() + modelMerged.getMergedSynapseInitGroups().size() + 
+                                              modelMerged.getMergedCustomUpdateInitGroups().size() + modelMerged.getMergedCustomWUUpdateInitGroups().size() + 
+                                              modelMerged.getMergedSynapseConnectivityInitGroups().size());
 
                 os << "CHECK_OPENCL_ERRORS(" << KernelNames[KernelInitialize] << ".setArg(" << numInitGroups << ", d_rng));" << std::endl;
             }

--- a/src/genn/backends/single_threaded_cpu/backend.cc
+++ b/src/genn/backends/single_threaded_cpu/backend.cc
@@ -718,8 +718,7 @@ void Backend::genInit(CodeStream &os, const ModelSpecMerged &modelMerged,
     modelMerged.genMergedCustomUpdateInitGroupStructs(os, *this);
     modelMerged.genMergedCustomWUUpdateDenseInitGroupStructs(os, *this);
     modelMerged.genMergedCustomWUUpdateKernelInitGroupStructs(os, *this);
-    modelMerged.genMergedSynapseDenseInitGroupStructs(os, *this);
-    modelMerged.genMergedSynapseKernelInitGroupStructs(os, *this);
+    modelMerged.genMergedSynapseInitGroupStructs(os, *this);
     modelMerged.genMergedSynapseConnectivityInitGroupStructs(os, *this);
     modelMerged.genMergedSynapseSparseInitGroupStructs(os, *this);
     modelMerged.genMergedCustomWUUpdateSparseInitGroupStructs(os, *this);
@@ -729,8 +728,7 @@ void Backend::genInit(CodeStream &os, const ModelSpecMerged &modelMerged,
     genMergedStructArrayPush(os, modelMerged.getMergedCustomUpdateInitGroups());
     genMergedStructArrayPush(os, modelMerged.getMergedCustomWUUpdateDenseInitGroups());
     genMergedStructArrayPush(os, modelMerged.getMergedCustomWUUpdateKernelInitGroups());
-    genMergedStructArrayPush(os, modelMerged.getMergedSynapseDenseInitGroups());
-    genMergedStructArrayPush(os, modelMerged.getMergedSynapseKernelInitGroups());
+    genMergedStructArrayPush(os, modelMerged.getMergedSynapseInitGroups());
     genMergedStructArrayPush(os, modelMerged.getMergedSynapseConnectivityInitGroups());
     genMergedStructArrayPush(os, modelMerged.getMergedSynapseSparseInitGroups());
     genMergedStructArrayPush(os, modelMerged.getMergedCustomWUUpdateSparseInitGroups());
@@ -818,32 +816,16 @@ void Backend::genInit(CodeStream &os, const ModelSpecMerged &modelMerged,
         }
 
         os << "// ------------------------------------------------------------------------" << std::endl;
-        os << "// Synapse groups with dense connectivity" << std::endl;
-        for(const auto &s : modelMerged.getMergedSynapseDenseInitGroups()) {
+        os << "// Synapse groups" << std::endl;
+        for(const auto &s : modelMerged.getMergedSynapseInitGroups()) {
             CodeStream::Scope b(os);
-            os << "// merged synapse dense init group " << s.getIndex() << std::endl;
+            os << "// merged synapse init group " << s.getIndex() << std::endl;
             os << "for(unsigned int g = 0; g < " << s.getGroups().size() << "; g++)";
             {
                 CodeStream::Scope b(os);
 
                 // Get reference to group
-                os << "const auto *group = &mergedSynapseDenseInitGroup" << s.getIndex() << "[g]; " << std::endl;
-                Substitutions popSubs(&funcSubs);
-                s.generateInit(*this, os, modelMerged, popSubs);
-            }
-        }
-        
-        os << "// ------------------------------------------------------------------------" << std::endl;
-        os << "// Synapse groups with kernel connectivity" << std::endl;
-        for(const auto &s : modelMerged.getMergedSynapseKernelInitGroups()) {
-            CodeStream::Scope b(os);
-            os << "// merged synapse dense init group " << s.getIndex() << std::endl;
-            os << "for(unsigned int g = 0; g < " << s.getGroups().size() << "; g++)";
-            {
-                CodeStream::Scope b(os);
-
-                // Get reference to group
-                os << "const auto *group = &mergedSynapseKernelInitGroup" << s.getIndex() << "[g]; " << std::endl;
+                os << "const auto *group = &mergedSynapseInitGroup" << s.getIndex() << "[g]; " << std::endl;
                 Substitutions popSubs(&funcSubs);
                 s.generateInit(*this, os, modelMerged, popSubs);
             }
@@ -1319,7 +1301,7 @@ void Backend::genDenseSynapseVariableRowInit(CodeStream &os, const Substitutions
     }
 }
 //--------------------------------------------------------------------------
-void Backend::genKernelSynapseVariableInit(CodeStream &os, const SynapseKernelInitGroupMerged &sg, const Substitutions &kernelSubs, Handler handler) const
+void Backend::genKernelSynapseVariableInit(CodeStream &os, const SynapseInitGroupMerged &sg, const Substitutions &kernelSubs, Handler handler) const
 {
     genKernelIteration(os, sg, sg.getArchetype().getKernelSize().size(), kernelSubs, handler);
 }

--- a/src/genn/genn/code_generator/backendSIMT.cc
+++ b/src/genn/genn/code_generator/backendSIMT.cc
@@ -1507,7 +1507,9 @@ void BackendSIMT::genInitializeSparseKernel(CodeStream &os, const Substitutions 
             }
             
             // Generate sparse synapse variable initialisation code
-            genSparseSynapseVarInit(os, modelMerged, cg, popSubs);
+            genSparseSynapseVarInit<CustomWUUpdateSparseInitGroupMerged>(
+                os, modelMerged, cg, popSubs, true,
+                [](CodeStream&, const CustomWUUpdateSparseInitGroupMerged&, Substitutions&){});
         });
 }
 //--------------------------------------------------------------------------

--- a/src/genn/genn/code_generator/backendSIMT.cc
+++ b/src/genn/genn/code_generator/backendSIMT.cc
@@ -215,7 +215,7 @@ size_t BackendSIMT::getPaddedNumCustomUpdateWUThreads(const CustomUpdateWUIntern
     }
     else {
         return numCopies * padKernelSize((size_t)sgInternal->getSrcNeuronGroup()->getNumNeurons() * sgInternal->getMaxConnections(),
-                                            KernelCustomUpdate);
+                                         KernelCustomUpdate);
     }
 }
 //--------------------------------------------------------------------------

--- a/src/genn/genn/code_generator/generateModules.cc
+++ b/src/genn/genn/code_generator/generateModules.cc
@@ -161,7 +161,7 @@ std::pair<std::vector<std::string>, MemAlloc> CodeGenerator::generateAll(const M
     LOGI_CODE_GEN << "\t" << modelMerged.getMergedNeuronInitGroups().size() << " merged neuron init groups";
     LOGI_CODE_GEN << "\t" << modelMerged.getMergedCustomUpdateInitGroups().size() << " merged custom update init groups";
     LOGI_CODE_GEN << "\t" << modelMerged.getMergedCustomWUUpdateDenseInitGroups().size() << " merged custom WU update dense init groups";
-    LOGI_CODE_GEN << "\t" << modelMerged.getMergedSynapseDenseInitGroups().size() << " merged synapse dense init groups";
+    LOGI_CODE_GEN << "\t" << modelMerged.getMergedSynapseInitGroups().size() << " merged synapse init groups";
     LOGI_CODE_GEN << "\t" << modelMerged.getMergedSynapseConnectivityInitGroups().size() << " merged synapse connectivity init groups";
     LOGI_CODE_GEN << "\t" << modelMerged.getMergedSynapseSparseInitGroups().size() << " merged synapse sparse init groups";
     LOGI_CODE_GEN << "\t" << modelMerged.getMergedCustomWUUpdateSparseInitGroups().size() << " merged custom WU update sparse init groups";
@@ -281,7 +281,7 @@ void CodeGenerator::generateInit(const filesystem::path &outputPath, const Model
             modelMerged.genMergedGroupPush(os, modelMerged.getMergedNeuronInitGroups(), backend);
             modelMerged.genMergedGroupPush(os, modelMerged.getMergedCustomUpdateInitGroups(), backend);
             modelMerged.genMergedGroupPush(os, modelMerged.getMergedCustomWUUpdateDenseInitGroups(), backend);
-            modelMerged.genMergedGroupPush(os, modelMerged.getMergedSynapseDenseInitGroups(), backend);
+            modelMerged.genMergedGroupPush(os, modelMerged.getMergedSynapseInitGroups(), backend);
             modelMerged.genMergedGroupPush(os, modelMerged.getMergedSynapseConnectivityInitGroups(), backend);
             modelMerged.genMergedGroupPush(os, modelMerged.getMergedSynapseSparseInitGroups(), backend);
         },
@@ -291,7 +291,7 @@ void CodeGenerator::generateInit(const filesystem::path &outputPath, const Model
             modelMerged.genScalarEGPPush<NeuronInitGroupMerged>(os, backend);
             modelMerged.genScalarEGPPush<CustomUpdateInitGroupMerged>(os, backend);
             modelMerged.genScalarEGPPush<CustomWUUpdateDenseInitGroupMerged>(os, backend);
-            modelMerged.genScalarEGPPush<SynapseDenseInitGroupMerged>(os, backend);
+            modelMerged.genScalarEGPPush<SynapseInitGroupMerged>(os, backend);
             modelMerged.genScalarEGPPush<SynapseConnectivityInitGroupMerged>(os, backend);
         },
         // Initialise sparse push EGP handler

--- a/src/genn/genn/code_generator/generateModules.cc
+++ b/src/genn/genn/code_generator/generateModules.cc
@@ -160,7 +160,7 @@ std::pair<std::vector<std::string>, MemAlloc> CodeGenerator::generateAll(const M
     LOGI_CODE_GEN << "\t" << modelMerged.getMergedCustomUpdateTransposeWUGroups().size() << " merged custom weight transpose update groups";
     LOGI_CODE_GEN << "\t" << modelMerged.getMergedNeuronInitGroups().size() << " merged neuron init groups";
     LOGI_CODE_GEN << "\t" << modelMerged.getMergedCustomUpdateInitGroups().size() << " merged custom update init groups";
-    LOGI_CODE_GEN << "\t" << modelMerged.getMergedCustomWUUpdateDenseInitGroups().size() << " merged custom WU update dense init groups";
+    LOGI_CODE_GEN << "\t" << modelMerged.getMergedCustomWUUpdateInitGroups().size() << " merged custom WU update init groups";
     LOGI_CODE_GEN << "\t" << modelMerged.getMergedSynapseInitGroups().size() << " merged synapse init groups";
     LOGI_CODE_GEN << "\t" << modelMerged.getMergedSynapseConnectivityInitGroups().size() << " merged synapse connectivity init groups";
     LOGI_CODE_GEN << "\t" << modelMerged.getMergedSynapseSparseInitGroups().size() << " merged synapse sparse init groups";
@@ -280,7 +280,7 @@ void CodeGenerator::generateInit(const filesystem::path &outputPath, const Model
         {
             modelMerged.genMergedGroupPush(os, modelMerged.getMergedNeuronInitGroups(), backend);
             modelMerged.genMergedGroupPush(os, modelMerged.getMergedCustomUpdateInitGroups(), backend);
-            modelMerged.genMergedGroupPush(os, modelMerged.getMergedCustomWUUpdateDenseInitGroups(), backend);
+            modelMerged.genMergedGroupPush(os, modelMerged.getMergedCustomWUUpdateInitGroups(), backend);
             modelMerged.genMergedGroupPush(os, modelMerged.getMergedSynapseInitGroups(), backend);
             modelMerged.genMergedGroupPush(os, modelMerged.getMergedSynapseConnectivityInitGroups(), backend);
             modelMerged.genMergedGroupPush(os, modelMerged.getMergedSynapseSparseInitGroups(), backend);
@@ -290,7 +290,7 @@ void CodeGenerator::generateInit(const filesystem::path &outputPath, const Model
         {
             modelMerged.genScalarEGPPush<NeuronInitGroupMerged>(os, backend);
             modelMerged.genScalarEGPPush<CustomUpdateInitGroupMerged>(os, backend);
-            modelMerged.genScalarEGPPush<CustomWUUpdateDenseInitGroupMerged>(os, backend);
+            modelMerged.genScalarEGPPush<CustomWUUpdateInitGroupMerged>(os, backend);
             modelMerged.genScalarEGPPush<SynapseInitGroupMerged>(os, backend);
             modelMerged.genScalarEGPPush<SynapseConnectivityInitGroupMerged>(os, backend);
         },

--- a/src/genn/genn/code_generator/generateRunner.cc
+++ b/src/genn/genn/code_generator/generateRunner.cc
@@ -726,6 +726,12 @@ MemAlloc CodeGenerator::generateRunner(const filesystem::path &outputPath, const
                           runnerVarDecl, runnerMergedStructAlloc);
     }
 
+    // Loop through merged custom sparse WU update initialisation groups
+    for (const auto &m : modelMerged.getMergedCustomWUUpdateKernelInitGroups()) {
+        m.generateRunner(backend, definitionsInternal, definitionsInternalFunc, definitionsInternalVar,
+                         runnerVarDecl, runnerMergedStructAlloc);
+    }
+
     // Loop through merged synapse connectivity initialisation groups
     for(const auto &m : modelMerged.getMergedSynapseConnectivityInitGroups()) {
         m.generateRunner(backend, definitionsInternal, definitionsInternalFunc, definitionsInternalVar,

--- a/src/genn/genn/code_generator/generateRunner.cc
+++ b/src/genn/genn/code_generator/generateRunner.cc
@@ -702,28 +702,10 @@ MemAlloc CodeGenerator::generateRunner(const filesystem::path &outputPath, const
                          runnerVarDecl, runnerMergedStructAlloc);
     }
 
-    // Generate merged custom update initialisation groups
-    for(const auto &m : modelMerged.getMergedCustomUpdateInitGroups()) {
-        m.generateRunner(backend, definitionsInternal, definitionsInternalFunc, definitionsInternalVar,
-                         runnerVarDecl, runnerMergedStructAlloc);
-    }
-
-    // Generate merged custom dense WU update initialisation groups
-    for(const auto &m : modelMerged.getMergedCustomWUUpdateDenseInitGroups()) {
-        m.generateRunner(backend, definitionsInternal, definitionsInternalFunc, definitionsInternalVar,
-                         runnerVarDecl, runnerMergedStructAlloc);
-    }
-
     // Loop through merged synapse init groups
     for(const auto &m : modelMerged.getMergedSynapseInitGroups()) {
          m.generateRunner(backend, definitionsInternal, definitionsInternalFunc, definitionsInternalVar,
                           runnerVarDecl, runnerMergedStructAlloc);
-    }
-
-    // Loop through merged custom sparse WU update initialisation groups
-    for (const auto &m : modelMerged.getMergedCustomWUUpdateKernelInitGroups()) {
-        m.generateRunner(backend, definitionsInternal, definitionsInternalFunc, definitionsInternalVar,
-                         runnerVarDecl, runnerMergedStructAlloc);
     }
 
     // Loop through merged synapse connectivity initialisation groups
@@ -734,6 +716,18 @@ MemAlloc CodeGenerator::generateRunner(const filesystem::path &outputPath, const
 
     // Loop through merged sparse synapse init groups
     for(const auto &m : modelMerged.getMergedSynapseSparseInitGroups()) {
+        m.generateRunner(backend, definitionsInternal, definitionsInternalFunc, definitionsInternalVar,
+                         runnerVarDecl, runnerMergedStructAlloc);
+    }
+
+    // Generate merged custom update initialisation groups
+    for(const auto &m : modelMerged.getMergedCustomUpdateInitGroups()) {
+        m.generateRunner(backend, definitionsInternal, definitionsInternalFunc, definitionsInternalVar,
+                         runnerVarDecl, runnerMergedStructAlloc);
+    }
+
+    // Generate merged custom WU update initialisation groups
+    for(const auto &m : modelMerged.getMergedCustomWUUpdateInitGroups()) {
         m.generateRunner(backend, definitionsInternal, definitionsInternalFunc, definitionsInternalVar,
                          runnerVarDecl, runnerMergedStructAlloc);
     }

--- a/src/genn/genn/code_generator/generateRunner.cc
+++ b/src/genn/genn/code_generator/generateRunner.cc
@@ -714,14 +714,8 @@ MemAlloc CodeGenerator::generateRunner(const filesystem::path &outputPath, const
                          runnerVarDecl, runnerMergedStructAlloc);
     }
 
-    // Loop through merged dense synapse init groups
-    for(const auto &m : modelMerged.getMergedSynapseDenseInitGroups()) {
-         m.generateRunner(backend, definitionsInternal, definitionsInternalFunc, definitionsInternalVar,
-                          runnerVarDecl, runnerMergedStructAlloc);
-    }
-    
-    // Loop through merged kernel synapse init groups
-    for(const auto &m : modelMerged.getMergedSynapseKernelInitGroups()) {
+    // Loop through merged synapse init groups
+    for(const auto &m : modelMerged.getMergedSynapseInitGroups()) {
          m.generateRunner(backend, definitionsInternal, definitionsInternalFunc, definitionsInternalVar,
                           runnerVarDecl, runnerMergedStructAlloc);
     }

--- a/src/genn/genn/code_generator/generateRunner.cc
+++ b/src/genn/genn/code_generator/generateRunner.cc
@@ -1119,7 +1119,13 @@ MemAlloc CodeGenerator::generateRunner(const filesystem::path &outputPath, const
                     mem, statePushPullFunctions, 
                     [&backend](const CustomUpdateWUInternal &c) 
                     { 
-                        return c.getSynapseGroup()->getSrcNeuronGroup()->getNumNeurons() * backend.getSynapticMatrixRowStride(*c.getSynapseGroup()); 
+                        const SynapseGroupInternal *sg = c.getSynapseGroup();
+                        if (sg->getMatrixType() & SynapseMatrixWeight::KERNEL) {
+                            return sg->getKernelSizeFlattened();
+                        }
+                        else {
+                            return sg->getSrcNeuronGroup()->getNumNeurons() * backend.getSynapticMatrixRowStride(*sg);
+                        }
                     });
     allVarStreams << std::endl;
 

--- a/src/genn/genn/code_generator/groupMerged.cc
+++ b/src/genn/genn/code_generator/groupMerged.cc
@@ -876,7 +876,8 @@ SynapseGroupMergedBase::SynapseGroupMergedBase(size_t index, const std::string &
                              || (role == Role::SynapseDynamics));
     const WeightUpdateModels::Base *wum = getArchetype().getWUModel();
 
-    if(role != Role::KernelInit) {
+    // If role isn't an init role or weights aren't kernel
+    if(role != Role::Init || !(getArchetype().getMatrixType() & SynapseMatrixWeight::KERNEL)) {
         addField("unsigned int", "rowStride",
                  [&backend](const SynapseGroupInternal &sg, size_t) { return std::to_string(backend.getSynapticMatrixRowStride(sg)); });
         addField("unsigned int", "numSrcNeurons",
@@ -1127,7 +1128,7 @@ SynapseGroupMergedBase::SynapseGroupMergedBase(size_t index, const std::string &
     // Otherwise (weights are individual or procedural)
     else {
         const bool connectInitRole = (role == Role::ConnectivityInit);
-        const bool varInitRole = (role == Role::DenseInit || role == Role::SparseInit || role == Role::KernelInit);
+        const bool varInitRole = (role == Role::Init || role == Role::SparseInit);
         const bool proceduralWeights = (getArchetype().getMatrixType() & SynapseMatrixWeight::PROCEDURAL);
         const bool kernelWeights = (getArchetype().getMatrixType() & SynapseMatrixWeight::KERNEL);
         const bool individualWeights = (getArchetype().getMatrixType() & SynapseMatrixWeight::INDIVIDUAL);
@@ -1279,7 +1280,7 @@ boost::uuids::detail::sha1::digest_type SynapseGroupMergedBase::getHashDigest(Ro
     // Otherwise (weights are individual or procedural)
     else {
         const bool connectInitRole = (role == Role::ConnectivityInit);
-        const bool varInitRole = (role == Role::DenseInit || role == Role::SparseInit);
+        const bool varInitRole = (role == Role::Init || role == Role::SparseInit);
         const bool proceduralWeights = (getArchetype().getMatrixType() & SynapseMatrixWeight::PROCEDURAL);
         const bool individualWeights = (getArchetype().getMatrixType() & SynapseMatrixWeight::INDIVIDUAL);
         const bool kernelWeights = (getArchetype().getMatrixType() & SynapseMatrixWeight::INDIVIDUAL);

--- a/src/genn/genn/code_generator/groupMerged.cc
+++ b/src/genn/genn/code_generator/groupMerged.cc
@@ -775,50 +775,6 @@ bool SynapseGroupMergedBase::isTrgNeuronDerivedParamHeterogeneous(size_t paramIn
             isParamValueHeterogeneous(paramIndex, [](const SynapseGroupInternal &sg) { return sg.getTrgNeuronGroup()->getDerivedParams(); }));
 }
 //----------------------------------------------------------------------------
-bool SynapseGroupMergedBase::isKernelSizeHeterogeneous(size_t dimensionIndex) const
-{
-    // Get size of this kernel dimension for archetype
-    const unsigned archetypeValue = getArchetype().getKernelSize().at(dimensionIndex);
-
-    // Return true if any of the other groups have a different value
-    return std::any_of(getGroups().cbegin(), getGroups().cend(),
-                       [archetypeValue, dimensionIndex](const GroupInternal &g)
-                       {
-                           return (g.getKernelSize().at(dimensionIndex) != archetypeValue);
-                       });
-}
-//----------------------------------------------------------------------------
-std::string SynapseGroupMergedBase::getKernelSize(size_t dimensionIndex) const
-{
-    // If kernel size if heterogeneous in this dimension, return group structure entry
-    if(isKernelSizeHeterogeneous(dimensionIndex)) {
-        return "group->kernelSize" + std::to_string(dimensionIndex);
-    }
-    // Otherwise, return literal
-    else {
-        return std::to_string(getArchetype().getKernelSize().at(dimensionIndex));
-    }
-}
-//----------------------------------------------------------------------------
-void SynapseGroupMergedBase::genKernelIndex(std::ostream &os, const CodeGenerator::Substitutions &subs) const
-{
-    // Loop through kernel dimensions to calculate array index
-    const auto &kernelSize = getArchetype().getKernelSize();
-    for(size_t i = 0; i < kernelSize.size(); i++) {
-        os << "(" << subs["id_kernel_" + std::to_string(i)];
-        // Loop through remainining dimensions of kernel and multiply
-        for(size_t j = i + 1; j < kernelSize.size(); j++) {
-            os << " * " << getKernelSize(j);
-        }
-        os << ")";
-
-        // If this isn't the last dimension, add +
-        if(i != (kernelSize.size() - 1)) {
-            os << " + ";
-        }
-    }
-}
-//----------------------------------------------------------------------------
 std::string SynapseGroupMergedBase::getPreSlot(unsigned int batchSize) const
 {
     if(getArchetype().getSrcNeuronGroup()->isDelayRequired()) {

--- a/src/genn/genn/code_generator/initGroupMerged.cc
+++ b/src/genn/genn/code_generator/initGroupMerged.cc
@@ -746,63 +746,110 @@ void CustomUpdateInitGroupMerged::generateInit(const BackendBase &backend, CodeS
 }
 
 // ----------------------------------------------------------------------------
-// CustomWUUpdateDenseInitGroupMerged
+// CustomWUUpdateInitGroupMerged
 //----------------------------------------------------------------------------
-const std::string CustomWUUpdateDenseInitGroupMerged::name = "CustomWUUpdateDenseInit";
+const std::string CustomWUUpdateInitGroupMerged::name = "CustomWUUpdateInit";
 //----------------------------------------------------------------------------
-CustomWUUpdateDenseInitGroupMerged::CustomWUUpdateDenseInitGroupMerged(size_t index, const std::string &precision, const std::string &, const BackendBase &backend,
-                                                                       const std::vector<std::reference_wrapper<const CustomUpdateWUInternal>> &groups)
+CustomWUUpdateInitGroupMerged::CustomWUUpdateInitGroupMerged(size_t index, const std::string &precision, const std::string &, const BackendBase &backend,
+                                                             const std::vector<std::reference_wrapper<const CustomUpdateWUInternal>> &groups)
 :   CustomUpdateInitGroupMergedBase<CustomUpdateWUInternal>(index, precision, backend, groups)
 {
-    addField("unsigned int", "rowStride",
-             [&backend](const CustomUpdateWUInternal &cg, size_t) { return std::to_string(backend.getSynapticMatrixRowStride(*cg.getSynapseGroup())); });
-  
-    addField("unsigned int", "numSrcNeurons",
-             [](const CustomUpdateWUInternal &cg, size_t) { return std::to_string(cg.getSynapseGroup()->getSrcNeuronGroup()->getNumNeurons()); });
-    addField("unsigned int", "numTrgNeurons",
-             [](const CustomUpdateWUInternal &cg, size_t) { return std::to_string(cg.getSynapseGroup()->getTrgNeuronGroup()->getNumNeurons()); });
+    if(getArchetype().getSynapseGroup()->getMatrixType() & SynapseMatrixWeight::KERNEL) {
+        // Loop through kernel size dimensions
+        for (size_t d = 0; d < getArchetype().getSynapseGroup()->getKernelSize().size(); d++) {
+            // If this dimension has a heterogeneous size, add it to struct
+            if (isKernelSizeHeterogeneous(d)) {
+                addField("unsigned int", "kernelSize" + std::to_string(d),
+                        [d](const CustomUpdateWUInternal &g, size_t) { return std::to_string(g.getSynapseGroup()->getKernelSize().at(d)); });
+            }
+        }
+    }
+    else {
+        addField("unsigned int", "rowStride",
+                [&backend](const CustomUpdateWUInternal &cg, size_t) { return std::to_string(backend.getSynapticMatrixRowStride(*cg.getSynapseGroup())); });
+        addField("unsigned int", "numSrcNeurons",
+                [](const CustomUpdateWUInternal &cg, size_t) { return std::to_string(cg.getSynapseGroup()->getSrcNeuronGroup()->getNumNeurons()); });
+        addField("unsigned int", "numTrgNeurons",
+                [](const CustomUpdateWUInternal &cg, size_t) { return std::to_string(cg.getSynapseGroup()->getTrgNeuronGroup()->getNumNeurons()); });
+    }
 }
 //----------------------------------------------------------------------------
-boost::uuids::detail::sha1::digest_type CustomWUUpdateDenseInitGroupMerged::getHashDigest() const
+boost::uuids::detail::sha1::digest_type CustomWUUpdateInitGroupMerged::getHashDigest() const
 {
     boost::uuids::detail::sha1 hash;
     
     // Update hash with generic custom update init data
     updateBaseHash(hash);
 
-    // Update hash with sizes of pre and postsynaptic neuron groups
-    updateHash([](const CustomUpdateWUInternal &cg) 
-               {
-                   return static_cast<const SynapseGroupInternal*>(cg.getSynapseGroup())->getSrcNeuronGroup()->getNumNeurons();
-               }, hash);
+    // If underlying synapse group has kernel weights, update hash with kernel size
+    if(getArchetype().getSynapseGroup()->getMatrixType() & SynapseMatrixWeight::KERNEL) {
+        updateHash([](const CustomUpdateWUInternal &g) { return g.getSynapseGroup()->getKernelSize(); }, hash);
+    }
+    // Otherwise, update hash with sizes of pre and postsynaptic neuron groups
+    else {
+        updateHash([](const CustomUpdateWUInternal &cg) 
+                   {
+                       return static_cast<const SynapseGroupInternal*>(cg.getSynapseGroup())->getSrcNeuronGroup()->getNumNeurons();
+                   }, hash);
 
-    updateHash([](const CustomUpdateWUInternal &cg) 
-               {
-                   return static_cast<const SynapseGroupInternal*>(cg.getSynapseGroup())->getTrgNeuronGroup()->getNumNeurons();
-               }, hash);
+        updateHash([](const CustomUpdateWUInternal &cg) 
+                   {
+                       return static_cast<const SynapseGroupInternal*>(cg.getSynapseGroup())->getTrgNeuronGroup()->getNumNeurons();
+                   }, hash);
 
 
-    // **TODO** rowstride
+        updateHash([](const CustomUpdateWUInternal &cg)
+                   {
+                       return static_cast<const SynapseGroupInternal*>(cg.getSynapseGroup())->getMaxConnections(); 
+                   }, hash);
+    }
 
     return hash.get_digest();
 }
 // ----------------------------------------------------------------------------
-void CustomWUUpdateDenseInitGroupMerged::generateInit(const BackendBase &backend, CodeStream &os, const ModelSpecMerged &modelMerged, Substitutions &popSubs) const
+void CustomWUUpdateInitGroupMerged::generateInit(const BackendBase &backend, CodeStream &os, const ModelSpecMerged &modelMerged, Substitutions &popSubs) const
 {
-    // Loop through rows
-    os << "for(unsigned int i = 0; i < group->numSrcNeurons; i++)";
-    {
-        CodeStream::Scope b(os);
+    const bool kernel = (getArchetype().getSynapseGroup()->getMatrixType() & SynapseMatrixWeight::KERNEL);
+    if(kernel && modelMerged.getModel().getBatchSize() > 1) {
+        // Loop through kernel dimensions and multiply together to calculate batch stride
+        os << "const unsigned int batchStride = ";
+        const auto &kernelSize = getArchetype().getSynapseGroup()->getKernelSize();
+        for (size_t i = 0; i < kernelSize.size(); i++) {
+            os << getKernelSize(i);
+
+            if (i != (kernelSize.size() - 1)) {
+                os << " * ";
+            }
+        }
+        os << ";" << std::endl;
+    }
+    
+    if(!kernel) {
+        os << "for(unsigned int i = 0; i < group->numSrcNeurons; i++)";
+        os << CodeStream::OB(3);
         popSubs.addVarSubstitution("id_pre", "i");
-        genInitWUVarCode(os, popSubs, getArchetype().getCustomUpdateModel()->getVars(),
-                         getArchetype().getVarInitialisers(), "group->numSrcNeurons * group->rowStride", getIndex(),
-                         modelMerged.getModel().getPrecision(), getArchetype().isBatched() ? modelMerged.getModel().getBatchSize() : 1,
-                         [this](size_t v, size_t p) { return isVarInitParamHeterogeneous(v, p); },
-                         [this](size_t v, size_t p) { return isVarInitDerivedParamHeterogeneous(v, p); },
-                         [&backend](CodeStream &os, const Substitutions &kernelSubs, BackendBase::Handler handler)
-                         {
-                             return backend.genDenseSynapseVariableRowInit(os, kernelSubs, handler); 
-                         });
+    }
+ 
+    // Loop through rows
+    const std::string stride = kernel ? "batchStride" : "group->numSrcNeurons * group->rowStride";
+    genInitWUVarCode(os, popSubs, getArchetype().getCustomUpdateModel()->getVars(),
+                    getArchetype().getVarInitialisers(), stride, getIndex(),
+                    modelMerged.getModel().getPrecision(), getArchetype().isBatched() ? modelMerged.getModel().getBatchSize() : 1,
+                    [this](size_t v, size_t p) { return isVarInitParamHeterogeneous(v, p); },
+                    [this](size_t v, size_t p) { return isVarInitDerivedParamHeterogeneous(v, p); },
+                    [&backend, kernel, this](CodeStream &os, const Substitutions &kernelSubs, BackendBase::Handler handler)
+                    {
+                        if (kernel) {
+                            backend.genKernelCustomUpdateVariableInit(os, *this, kernelSubs, handler);
+                        }
+                        else {
+                            backend.genDenseSynapseVariableRowInit(os, kernelSubs, handler);
+                        }
+    
+                    });
+        
+    if(!kernel) {
+        os << CodeStream::CB(3);
     }
 }
 
@@ -873,65 +920,5 @@ void CustomWUUpdateSparseInitGroupMerged::generateInit(const BackendBase &backen
                      [&backend](CodeStream &os, const Substitutions &kernelSubs, BackendBase::Handler handler)
                      {
                          return backend.genSparseSynapseVariableRowInit(os, kernelSubs, handler); 
-                     });
-}
-
-// ----------------------------------------------------------------------------
-// CustomWUUpdateKernelInitGroupMerged
-//----------------------------------------------------------------------------
-const std::string CustomWUUpdateKernelInitGroupMerged::name = "CustomWUUpdateKernelInit";
-//----------------------------------------------------------------------------
-CustomWUUpdateKernelInitGroupMerged::CustomWUUpdateKernelInitGroupMerged(size_t index, const std::string &precision, const std::string &, const BackendBase &backend,
-                                                                         const std::vector<std::reference_wrapper<const CustomUpdateWUInternal>> &groups)
-    : CustomUpdateInitGroupMergedBase<CustomUpdateWUInternal>(index, precision, backend, groups)
-{
-    // Loop through kernel size dimensions
-    for (size_t d = 0; d < getArchetype().getSynapseGroup()->getKernelSize().size(); d++) {
-        // If this dimension has a heterogeneous size, add it to struct
-        if (isKernelSizeHeterogeneous(d)) {
-            addField("unsigned int", "kernelSize" + std::to_string(d),
-                     [d](const CustomUpdateWUInternal &g, size_t) { return std::to_string(g.getSynapseGroup()->getKernelSize().at(d)); });
-        }
-    }
-}
-//----------------------------------------------------------------------------
-boost::uuids::detail::sha1::digest_type CustomWUUpdateKernelInitGroupMerged::getHashDigest() const
-{
-    boost::uuids::detail::sha1 hash;
-
-    // Update hash with generic custom update init data
-    updateBaseHash(hash);
-
-    // Update hash with kernel size
-    updateHash([](const CustomUpdateWUInternal &g) { return g.getSynapseGroup()->getKernelSize(); }, hash);
-
-    return hash.get_digest();
-}
-// ----------------------------------------------------------------------------
-void CustomWUUpdateKernelInitGroupMerged::generateInit(const BackendBase &backend, CodeStream &os, const ModelSpecMerged &modelMerged, Substitutions &popSubs) const
-{
-    // If model is batched
-    if (modelMerged.getModel().getBatchSize() > 1) {
-        // Loop through kernel dimensions and multiply together to calculate batch stride
-        os << "const unsigned int batchStride = ";
-        const auto &kernelSize = getArchetype().getSynapseGroup()->getKernelSize();
-        for (size_t i = 0; i < kernelSize.size(); i++) {
-            os << getKernelSize(i);
-
-            if (i != (kernelSize.size() - 1)) {
-                os << " * ";
-            }
-        }
-        os << ";" << std::endl;;
-    }
-
-    genInitWUVarCode(os, popSubs, getArchetype().getCustomUpdateModel()->getVars(),
-                     getArchetype().getVarInitialisers(), "batchStride", getIndex(),
-                     modelMerged.getModel().getPrecision(), getArchetype().isBatched() ? modelMerged.getModel().getBatchSize() : 1,
-                     [this](size_t v, size_t p) { return isVarInitParamHeterogeneous(v, p); },
-                     [this](size_t v, size_t p) { return isVarInitDerivedParamHeterogeneous(v, p); },
-                     [&backend, this](CodeStream &os, const Substitutions &kernelSubs, BackendBase::Handler handler)
-                     {
-                         return backend.genKernelCustomUpdateVariableInit(os, *this, kernelSubs, handler);
                      });
 }

--- a/src/genn/genn/code_generator/initGroupMerged.cc
+++ b/src/genn/genn/code_generator/initGroupMerged.cc
@@ -575,7 +575,7 @@ void SynapseInitGroupMerged::generateInit(const BackendBase &backend, CodeStream
     // Generate initialisation code
     const std::string stride = kernel ? "batchStride" : "group->numSrcNeurons * group->rowStride";
     genInitWUVarCode(os, popSubs, getArchetype().getWUModel()->getVars(),
-                     getArchetype().getWUVarInitialisers(), "group->numSrcNeurons * group->rowStride", getIndex(),
+                     getArchetype().getWUVarInitialisers(), stride, getIndex(),
                      modelMerged.getModel().getPrecision(), modelMerged.getModel().getBatchSize(),
                      [this](size_t v, size_t p) { return isWUVarInitParamHeterogeneous(v, p); },
                      [this](size_t v, size_t p) { return isWUVarInitDerivedParamHeterogeneous(v, p); },

--- a/tests/features/custom_update/test.cc
+++ b/tests/features/custom_update/test.cc
@@ -54,6 +54,8 @@ TEST_F(SimTest, CustomUpdate)
             pullVWUSparseSetTimeFromDevice();
             pullgSparseFromDevice();
             pullSparseConnectivityFromDevice();
+            pullVWUKernelSetTimeFromDevice();
+            pullgKernelFromDevice();
             pullVCustomWUUpdateSetTimeFromDevice();
             pullCCustomWUUpdateFromDevice();
 
@@ -96,6 +98,11 @@ TEST_F(SimTest, CustomUpdate)
             EXPECT_TRUE(std::all_of(&VWUDenseSetTime[0], &VWUDenseSetTime[100 * 100],
                         [](scalar v) { return v == t; }));
             EXPECT_TRUE(std::all_of(&gDense[0], &gDense[100 * 100],
+                        [](scalar v) { return v == t; }));
+
+            EXPECT_TRUE(std::all_of(&VWUKernelSetTime[0], &VWUKernelSetTime[3 * 3],
+                        [](scalar v) { return v == t; }));
+            EXPECT_TRUE(std::all_of(&gKernel[0], &gKernel[3 * 3],
                         [](scalar v) { return v == t; }));
 
             EXPECT_TRUE(std::all_of(&VCustomWUUpdateSetTime[0], &VCustomWUUpdateSetTime[100 * 100],

--- a/tests/features/custom_update_batch/test.cc
+++ b/tests/features/custom_update_batch/test.cc
@@ -58,13 +58,16 @@ TEST_F(SimTest, CustomUpdateBatch)
             pullUDenseFromDevice();
             pullVSparseFromDevice();
             pullUSparseFromDevice();
-
+            pullVKernelFromDevice();
+            pullUKernelFromDevice();
+            
             // Check shared neuron and synapse variables match time
             ASSERT_TRUE(std::all_of(&UNeuron[0], &UNeuron[50],
                         [](scalar v) { return v == t; }));
             ASSERT_TRUE(std::all_of(&UDense[0], &UDense[50 * 50],
                         [](scalar v) { return v == t; }));
-
+            ASSERT_TRUE(std::all_of(&UKernel[0], &UKernel[3 * 3],
+                        [](scalar v) { return v == t; }));
             checkSparseVar(USparse, [](scalar v){ return v == t; });
     
             // Loop through batches
@@ -73,6 +76,8 @@ TEST_F(SimTest, CustomUpdateBatch)
                 const unsigned int endNeuronIdx = startNeuronIdx + 50;
                 const unsigned int startDenseSynIdx = b * (50 * 50);
                 const unsigned int endDenseSynIdx = startDenseSynIdx + (50 * 50);
+                const unsigned int startKernelIdx = b * (3 * 3);
+                const unsigned int endKernelIdx = startKernelIdx + (3 * 3);
                 const unsigned int startSparseSynIdx = b * (50 * maxRowLengthSparse);
                 const float batchOffset = b * 1000.0f;
                 
@@ -86,11 +91,16 @@ TEST_F(SimTest, CustomUpdateBatch)
                             [batchOffset](scalar v) { return v == (batchOffset + t); }));
                 ASSERT_TRUE(std::all_of(&VDense[startDenseSynIdx], &VDense[endDenseSynIdx],
                             [batchOffset](scalar v) { return v == (batchOffset + t); }));
-                
+
+                ASSERT_TRUE(std::all_of(&VWUMKernelDuplicateSetTime[startKernelIdx], &VWUMKernelDuplicateSetTime[endKernelIdx],
+                            [batchOffset](scalar v) { return v == (batchOffset + t); }));
+                ASSERT_TRUE(std::all_of(&VKernel[startKernelIdx], &VKernel[endKernelIdx],
+                            [batchOffset](scalar v) { return v == (batchOffset + t); }));
+
                 checkSparseVar(&VSparse[startSparseSynIdx],
                                [batchOffset](scalar v) { return v == (batchOffset + t); });
-               checkSparseVar(&VWUMSparseDuplicateSetTime[startSparseSynIdx],
-                              [batchOffset](scalar v) { return v == (batchOffset + t); });
+                checkSparseVar(&VWUMSparseDuplicateSetTime[startSparseSynIdx],
+                               [batchOffset](scalar v) { return v == (batchOffset + t); });
                 
             }
         }

--- a/tests/features/custom_update_batch/test.cc
+++ b/tests/features/custom_update_batch/test.cc
@@ -52,6 +52,7 @@ TEST_F(SimTest, CustomUpdateBatch)
             pullVNeuronDuplicateSetTimeFromDevice();
             pullVWUMDenseDuplicateSetTimeFromDevice();
             pullVWUMSparseDuplicateSetTimeFromDevice();
+            pullVWUMKernelDuplicateSetTimeFromDevice();
             pullVNeuronFromDevice();
             pullUNeuronFromDevice();
             pullVDenseFromDevice();

--- a/tests/features/var_init/test.cc
+++ b/tests/features/var_init/test.cc
@@ -81,6 +81,9 @@ TEST_F(SimTest, Vars)
     pullPSMCustomUpdateStateFromDevice();
     pullWUPreCustomUpdateStateFromDevice();
     pullWUPostCustomUpdateStateFromDevice();
+    pullWUSparseCustomUpdateStateFromDevice();
+    pullWUDenseCustomUpdateStateFromDevice();
+    pullWUKernelCustomUpdateStateFromDevice();
     
     // Test host-generated vars
     PROB_TEST(, Pop, 50000);
@@ -90,11 +93,14 @@ TEST_F(SimTest, Vars)
     PROB_TEST(, Sparse, 50000);
     PROB_TEST(pre_, Sparse, 50000);
     PROB_TEST(post_, Sparse, 50000);
-    PROB_TEST(, Kernel, 9);
+    PROB_TEST(, Kernel, 3 * 3 * 5 * 5);
     PROB_TEST(, NeuronCustomUpdate, 50000);
     PROB_TEST(, CurrentSourceCustomUpdate, 50000);
     PROB_TEST(, PSMCustomUpdate, 50000);
     PROB_TEST(, WUPreCustomUpdate, 50000);
     PROB_TEST(, WUPostCustomUpdate, 50000);
+    PROB_TEST(, WUDenseCustomUpdate, 50000);
+    PROB_TEST(, WUSparseCustomUpdate, 50000);
+    PROB_TEST(, WUKernelCustomUpdate, 3 * 3 * 5 * 5);
 }
 

--- a/tests/unit/customUpdate.cc
+++ b/tests/unit/customUpdate.cc
@@ -558,7 +558,7 @@ TEST(CustomUpdates, CompareDifferentWUTranspose)
     // **NOTE** transpose variables don't matter for initialization
     ASSERT_TRUE(modelSpecMerged.getMergedCustomUpdateTransposeWUGroups().size() == 2);
     ASSERT_TRUE(modelSpecMerged.getMergedCustomUpdateWUGroups().empty());
-    ASSERT_TRUE(modelSpecMerged.getMergedCustomWUUpdateDenseInitGroups().size() == 1);
+    ASSERT_TRUE(modelSpecMerged.getMergedCustomWUUpdateInitGroups().size() == 1);
     ASSERT_TRUE(modelSpecMerged.getMergedCustomWUUpdateSparseInitGroups().empty());
 }
 //--------------------------------------------------------------------------
@@ -609,7 +609,7 @@ TEST(CustomUpdates, CompareDifferentWUConnectivity)
     // Check correct groups are merged
     ASSERT_TRUE(modelSpecMerged.getMergedCustomUpdateTransposeWUGroups().empty());
     ASSERT_TRUE(modelSpecMerged.getMergedCustomUpdateWUGroups().size() == 2);
-    ASSERT_TRUE(modelSpecMerged.getMergedCustomWUUpdateDenseInitGroups().size() == 1);
+    ASSERT_TRUE(modelSpecMerged.getMergedCustomWUUpdateInitGroups().size() == 1);
     ASSERT_TRUE(modelSpecMerged.getMergedCustomWUUpdateSparseInitGroups().size() == 1);
 }
 //--------------------------------------------------------------------------

--- a/tests/unit/synapseGroup.cc
+++ b/tests/unit/synapseGroup.cc
@@ -430,7 +430,7 @@ TEST(SynapseGroup, CompareWUDifferentGlobalG)
     ASSERT_TRUE(modelSpecMerged.getMergedNeuronUpdateGroups().size() == 2);
     ASSERT_TRUE(modelSpecMerged.getMergedPresynapticUpdateGroups().size() == 1);
     ASSERT_TRUE(modelSpecMerged.getMergedSynapseConnectivityInitGroups().empty());
-    ASSERT_TRUE(modelSpecMerged.getMergedSynapseDenseInitGroups().empty());
+    ASSERT_TRUE(modelSpecMerged.getMergedSynapseInitGroups().empty());
     ASSERT_TRUE(modelSpecMerged.getMergedSynapseSparseInitGroups().empty());
 
     // Check that global g var is heterogeneous
@@ -485,7 +485,7 @@ TEST(SynapseGroup, CompareWUDifferentProceduralConnectivity)
     ASSERT_TRUE(modelSpecMerged.getMergedNeuronUpdateGroups().size() == 2);
     ASSERT_TRUE(modelSpecMerged.getMergedPresynapticUpdateGroups().size() == 1);
     ASSERT_TRUE(modelSpecMerged.getMergedSynapseConnectivityInitGroups().empty());
-    ASSERT_TRUE(modelSpecMerged.getMergedSynapseDenseInitGroups().empty());
+    ASSERT_TRUE(modelSpecMerged.getMergedSynapseInitGroups().empty());
     ASSERT_TRUE(modelSpecMerged.getMergedSynapseSparseInitGroups().empty());
 
     // Check that connectivity parameter is heterogeneous
@@ -551,7 +551,7 @@ TEST(SynapseGroup, CompareWUDifferentToeplitzConnectivity)
     ASSERT_EQ(modelSpecMerged.getMergedNeuronUpdateGroups().size(), 3);
     ASSERT_EQ(modelSpecMerged.getMergedPresynapticUpdateGroups().size(), 1);
     ASSERT_TRUE(modelSpecMerged.getMergedSynapseConnectivityInitGroups().empty());
-    ASSERT_TRUE(modelSpecMerged.getMergedSynapseDenseInitGroups().empty());
+    ASSERT_EQ(modelSpecMerged.getMergedSynapseInitGroups().size(), 1);
     ASSERT_TRUE(modelSpecMerged.getMergedSynapseSparseInitGroups().empty());
 
     // Check that connectivity parameter is heterogeneous
@@ -617,7 +617,7 @@ TEST(SynapseGroup, CompareWUDifferentProceduralVars)
     ASSERT_TRUE(modelSpecMerged.getMergedNeuronUpdateGroups().size() == 2);
     ASSERT_TRUE(modelSpecMerged.getMergedPresynapticUpdateGroups().size() == 1);
     ASSERT_TRUE(modelSpecMerged.getMergedSynapseConnectivityInitGroups().empty());
-    ASSERT_TRUE(modelSpecMerged.getMergedSynapseDenseInitGroups().empty());
+    ASSERT_TRUE(modelSpecMerged.getMergedSynapseInitGroups().empty());
     ASSERT_TRUE(modelSpecMerged.getMergedSynapseSparseInitGroups().empty());
 
     // Check that only synaptic weight initialistion parameters are heterogeneous
@@ -671,7 +671,7 @@ TEST(SynapseGroup, CompareWUDifferentProceduralSnippet)
     ASSERT_TRUE(modelSpecMerged.getMergedNeuronUpdateGroups().size() == 2);
     ASSERT_TRUE(modelSpecMerged.getMergedPresynapticUpdateGroups().size() == 2);
     ASSERT_TRUE(modelSpecMerged.getMergedSynapseConnectivityInitGroups().empty());
-    ASSERT_TRUE(modelSpecMerged.getMergedSynapseDenseInitGroups().empty());
+    ASSERT_TRUE(modelSpecMerged.getMergedSynapseInitGroups().empty());
     ASSERT_TRUE(modelSpecMerged.getMergedSynapseSparseInitGroups().empty());
 }
 
@@ -731,7 +731,7 @@ TEST(SynapseGroup, InitCompareWUDifferentVars)
     ASSERT_TRUE(modelSpecMerged.getMergedNeuronUpdateGroups().size() == 2);
     ASSERT_TRUE(modelSpecMerged.getMergedPresynapticUpdateGroups().size() == 1);
     ASSERT_TRUE(modelSpecMerged.getMergedSynapseConnectivityInitGroups().size() == 1);
-    ASSERT_TRUE(modelSpecMerged.getMergedSynapseDenseInitGroups().empty());
+    ASSERT_TRUE(modelSpecMerged.getMergedSynapseInitGroups().empty());
     ASSERT_TRUE(modelSpecMerged.getMergedSynapseSparseInitGroups().size() == 1);
 
     // Check that only synaptic weight initialistion parameters are heterogeneous


### PR DESCRIPTION
I **think** this is the missing piece to enable EventProp on convolutional networks - it allows custom updates to be attached to synapse groups with ``KERNEL`` connectivity. This involves:

1. Custom updates can update kernel entries (e.g. for weight decay in convolutional networks)
2. Reductions from ``DUPLICATE`` into ``SHARED`` kernel variables for batched models
3. Initialisation of variables in custom updates attached to a synapse group with `KERNEL` connectivity (which will themselves be kernels)

The feature tests for all three scenarios have been expanded to cover the new cases. The process of implementing this was also *so* annoying and error prone, I did a bit of tidying (which _almost_  allowed me to delete as much code as I added :smile: )