### PR TITLE
pretty sure those quotes aren't required and they seem to break VC2017

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -70,7 +70,7 @@ extension_kwargs = {
     "swig_opts": swig_opts,
     "include_dirs": include_dirs,
     "library_dirs": [genn_wrapper_path],
-    "extra_compile_args" : ["/wd\"4251\"", "-DWIN32_LEAN_AND_MEAN", "-DNOMINMAX"] if windows else ["-std=c++11"],
+    "extra_compile_args" : ["/wd4251", "-DWIN32_LEAN_AND_MEAN", "-DNOMINMAX"] if windows else ["-std=c++11"],
     "extra_link_args": []}
 
 # Always package LibGeNN


### PR DESCRIPTION
Not sure why I originally came up with the weird quoting of this command line argument but, while it works on Visual C++ 2019, it doesn't on Visual C++ 2017. Without the weird quotes it's fine on both!

Fixes #528 