### PR TITLE
build: Dockerfile and docker-compose to launch notebook with pygenn resolves genn-team/genn#546

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,4 @@
 /pygenn.egg-info/
 .vscode/
 /pygenn/share/
+.idea

--- a/Makefile
+++ b/Makefile
@@ -73,3 +73,7 @@ clean:
 .PHONY docker-build:
 docker-build:
 	@docker build -f ./build_steps/Dockerfile -t pygenn:latest .
+
+.PHONY docker-jupyter:
+docker-jupyter:
+	@docker run -p 127.0.0.1:8888:8888/tcp -v '$(CURDIR)'/pygenn/notebooks:/root/pygenn/notebooks pygenn jupyter notebook --ip 0.0.0.0 --no-browser

--- a/Makefile
+++ b/Makefile
@@ -69,3 +69,7 @@ clean:
 	@# Delete libGeNN
 	@rm -f $(LIBGENN)
 	@rm -f $(BACKEND_LIBS)
+
+.PHONY docker-build:
+docker-build:
+	@docker build -f ./build_steps/Dockerfile -t pygenn:latest .

--- a/build_steps/.dockerignore
+++ b/build_steps/.dockerignore
@@ -1,0 +1,10 @@
+.git
+build
+dist
+docs
+doxygenn
+lib
+obj*
+tests
+userproject
+!userproject/include

--- a/build_steps/Dockerfile
+++ b/build_steps/Dockerfile
@@ -18,7 +18,9 @@ WORKDIR ${HOME}
 
 COPY . ${HOME}
 
-RUN adduser --disabled-password --gecos "" $USERNAME
-RUN chown -R ${USERNAME}:${USERNAME} "/root"
+RUN adduser --disabled-password --gecos "" $USERNAME && chown -R ${USERNAME}:${USERNAME} "/root"
+
 RUN make DYNAMIC=1 LIBRARY_DIRECTORY=${HOME}/pygenn/genn_wrapper/
 RUN python3 setup.py develop
+
+USER $USERNAME

--- a/build_steps/Dockerfile
+++ b/build_steps/Dockerfile
@@ -1,0 +1,24 @@
+FROM nvidia/cuda:11.5.0-devel-ubuntu20.04
+
+ARG USERNAME="pygennuser"
+ARG PYGENN_HOME="/root"
+
+RUN apt-get update && \
+    apt-get upgrade -y
+
+RUN apt-get install -yq --no-install-recommends curl vim python3-dev python3-pip
+
+RUN pip install swig numpy jupyter
+
+ENV CUDA_PATH=/usr/local/cuda-11.5
+ENV HOME=${PYGENN_HOME}
+ENV USERNAME=${USERNAME}
+
+WORKDIR ${HOME}
+
+COPY . ${HOME}
+
+RUN adduser --disabled-password --gecos "" $USERNAME
+RUN chown -R ${USERNAME}:${USERNAME} "/root"
+RUN make DYNAMIC=1 LIBRARY_DIRECTORY=${HOME}/pygenn/genn_wrapper/
+RUN python3 setup.py develop

--- a/build_steps/docker-compose.yml
+++ b/build_steps/docker-compose.yml
@@ -1,0 +1,28 @@
+version: "3.4"
+
+services:
+    pygenn:
+        image: pygenn:latest
+        container_name: pygenn
+        restart: always
+        ports:
+            - 8888:8888
+        volumes:
+            - ../pygenn/notebooks:/root/pygenn/notebooks
+        networks:
+            - pygenn
+        command: /bin/bash /root/build/entrypoint.sh
+        user: pygennuser:pygennuser
+        healthcheck:
+            test: ["CMD", "curl", "-f", "host.docker.internal:8888"]
+            interval: 30s
+            timeout: 10s
+            retries: 5
+            start_period: 5m
+
+volumes:
+    pygenn_notebooks:
+
+networks:
+    pygenn:
+        driver: bridge

--- a/build_steps/entrypoint.sh
+++ b/build_steps/entrypoint.sh
@@ -1,0 +1,2 @@
+#!/bin/sh
+jupyter notebook --ip 0.0.0.0 --no-browser

--- a/pygenn/README.md
+++ b/pygenn/README.md
@@ -13,3 +13,8 @@ PyGeNN wraps the C++ GeNN API using SWIG, allowing GeNN to be used either direct
  - Navigate to the GeNN directory and build GeNN as a dll using ``msbuild genn.sln /t:Build /p:Configuration=Release_DLL`` (if you don't have CUDA installed, building the CUDA backend will fail but it should still build the CPU backend).
  - Copy the newly built DLLs into pygenn using ``copy /Y lib\genn*Release_DLL.* pygenn\genn_wrapper``
  - Build the Python extension with setup tools using ``python setup.py develop`` command
+
+### Docker
+ - `make docker-build` (from project root) to build Docker image
+ - `docker-compose up` (from /buildsteps) to launch the container. This will start a Jupyter notebook that can be accessed at `localhost:8888` with the token printed to screen
+ - Note that a volume is created so that notebooks created in `pygenn/notebooks` will be persisted


### PR DESCRIPTION
Run pyGeNN models from a docker image. `docker-compose` is used to launch a jupyter notebook with files from the local filesystem.