### PR TITLE
More compiler friendly error handling.

### DIFF
--- a/include/genn/backends/cuda/backend.h
+++ b/include/genn/backends/cuda/backend.h
@@ -78,7 +78,12 @@ struct Preferences : public PreferencesBase
 
     //! Generate corresponding NCCL batch reductions
     bool enableNCCLReductions = false;
-
+    
+    //! By default, GeNN generates CUDA error-handling code that generates exceptions with line numbers etc.
+    //! This can make compilation of large models very slow and require a large amount of memory.
+    //! Turning on this option generates much simpler error-handling code that simply raises an abort signal.
+    bool generateSimpleErrorHandling = false;
+    
     //! How to select GPU device
     DeviceSelect deviceSelectMethod = DeviceSelect::OPTIMAL;
 
@@ -114,6 +119,7 @@ struct Preferences : public PreferencesBase
         Utils::updateHash(deviceSelectMethod, hash);
         Utils::updateHash(constantCacheOverhead, hash);
         Utils::updateHash(enableNCCLReductions, hash);
+        Utils::updateHash(generateSimpleErrorHandling, hash);
     }
 };
 

--- a/src/genn/backends/cuda/backend.cc
+++ b/src/genn/backends/cuda/backend.cc
@@ -1098,7 +1098,12 @@ void Backend::genDefinitionsInternalPreamble(CodeStream &os, const ModelSpecMerg
     os << "#define CHECK_CUDA_ERRORS(call) {\\" << std::endl;
     os << "    cudaError_t error = call;\\" << std::endl;
     os << "    if (error != cudaSuccess) {\\" << std::endl;
-    os << "        throw std::runtime_error(__FILE__\": \" + std::to_string(__LINE__) + \": cuda error \" + std::to_string(error) + \": \" + cudaGetErrorString(error));\\" << std::endl;
+    if(getPreferences<Preferences>().generateSimpleErrorHandling) {
+        os << "        std::abort();\\" << std::endl;
+    }
+    else {
+        os << "        throw std::runtime_error(__FILE__\": \" + std::to_string(__LINE__) + \": cuda error \" + std::to_string(error) + \": \" + cudaGetErrorString(error));\\" << std::endl;
+    }
     os << "    }\\" << std::endl;
     os << "}" << std::endl;
     os << std::endl;


### PR DESCRIPTION
Turns out that compiling the code generated by our ``CHECK_CUDA_ERRORS`` macro can cause runner.cc compilation to take a long time and a lot of memory. Switching this out of a simpler macro that just calls ``std::abort`` can reduce compile times by up to 10x on a model with 10000 state variables (100 neuron populations, nearly all-to-all connected):
![fig_2_alternate_error](https://user-images.githubusercontent.com/6793242/199303748-712f008b-a091-47b3-bdf5-260698a3ed04.png)
This simpler error handling macro can now be enabled from C++ with:
```c++
void modelDefinition(NNmodel &model)
{
    ...
    GENN_PREFERENCES.generateSimpleErrorHandling = true;
    ...
}
```
or from Python like:
```python
model = GeNNModel("float", "my_model", generateSimpleErrorHandling=True)
```