### PR TITLE
Custom update merge fix

### DIFF
--- a/include/genn/genn/customUpdate.h
+++ b/include/genn/genn/customUpdate.h
@@ -152,7 +152,10 @@ protected:
         // If target of any variable references is duplicated, custom update should be batched
         if(batchSize > 1) {
             m_Batched = std::any_of(varRefs.cbegin(), varRefs.cend(),
-                                    [](const V& v) { return (v.getVar().access & VarAccessDuplication::DUPLICATE); });
+                                    [](const V& v) 
+                                    {
+                                        return (v.isBatched() && (v.getVar().access & VarAccessDuplication::DUPLICATE)); 
+                                    });
         }
         else {
             m_Batched = false;

--- a/include/genn/genn/models.h
+++ b/include/genn/genn/models.h
@@ -163,15 +163,18 @@ public:
     const Models::Base::Var &getVar() const { return m_Var; }
     size_t getVarIndex() const { return m_VarIndex; }
     std::string getTargetName() const { return m_GetTargetName(); }
+    bool isBatched() const{ return m_IsBatched(); }
 
 protected:
     //------------------------------------------------------------------------
     // Typedefines
     //------------------------------------------------------------------------
     typedef std::function<std::string(void)> GetTargetNameFn;
+    typedef std::function<bool(void)> IsBatchedFn;
 
-    VarReferenceBase(size_t varIndex, const Models::Base::VarVec &varVec, GetTargetNameFn getTargetName)
-    : m_VarIndex(varIndex), m_Var(varVec.at(varIndex)), m_GetTargetName(getTargetName)
+    VarReferenceBase(size_t varIndex, const Models::Base::VarVec &varVec, 
+                     GetTargetNameFn getTargetName, IsBatchedFn isBatched)
+    : m_VarIndex(varIndex), m_Var(varVec.at(varIndex)), m_GetTargetName(getTargetName), m_IsBatched(isBatched)
     {}
 
 private:
@@ -181,6 +184,7 @@ private:
     size_t m_VarIndex;
     Models::Base::Var m_Var;
     GetTargetNameFn m_GetTargetName;
+    IsBatchedFn m_IsBatched;
 };
 
 //----------------------------------------------------------------------------
@@ -215,7 +219,8 @@ private:
     VarReference(const CurrentSourceInternal *cs, const std::string &varName);
     VarReference(const CustomUpdate *cu, const std::string &varName);
     VarReference(unsigned int size, GetDelayNeuronGroupFn getDelayNeuronGroup,
-                 size_t varIndex, const Models::Base::VarVec &varVec, GetTargetNameFn getTargetNameFn);
+                 size_t varIndex, const Models::Base::VarVec &varVec, 
+                 GetTargetNameFn getTargetName, IsBatchedFn isBatched);
 
     //------------------------------------------------------------------------
     // Members

--- a/src/genn/genn/customUpdate.cc
+++ b/src/genn/genn/customUpdate.cc
@@ -266,10 +266,15 @@ boost::uuids::detail::sha1::digest_type CustomUpdateWU::getHashDigest() const
     Utils::updateHash(getSynapseMatrixConnectivity(getSynapseGroup()->getMatrixType()), hash);
     Utils::updateHash(getSynapseGroup()->getSparseIndType(), hash);
 
-    // Update hash with whether variable references require transpose
+    // Loop through variable references
     for(const auto &v : getVarReferences()) {
+        // Update hash with whether variable references require transpose
         Utils::updateHash((v.getTransposeSynapseGroup() == nullptr), hash);
+
+        // Update hash with duplication mode of target variable as this effects indexing code
+        Utils::updateHash(getVarAccessDuplication(v.getVar().access), hash);
     }
+
     return hash.get_digest();
 }
 //----------------------------------------------------------------------------

--- a/src/genn/genn/customUpdate.cc
+++ b/src/genn/genn/customUpdate.cc
@@ -156,9 +156,13 @@ boost::uuids::detail::sha1::digest_type CustomUpdate::getHashDigest() const
         Utils::updateHash(getDelayNeuronGroup()->getNumDelaySlots(), hash);
     }
 
-    // Update hash with whether variable references require delay
+    // Loop through variable references
     for(const auto &v : getVarReferences()) {
+        // Update hash with whether variable references require dela
         Utils::updateHash((v.getDelayNeuronGroup() == nullptr), hash);
+
+        // Update hash with duplication mode of target variable as this effects indexing code
+        Utils::updateHash(getVarAccessDuplication(v.getVar().access), hash);
     }
     return hash.get_digest();
 }

--- a/src/genn/genn/models.cc
+++ b/src/genn/genn/models.cc
@@ -56,7 +56,7 @@ VarReference VarReference::createPSMVarRef(const SynapseGroup *sg, const std::st
     return VarReference(sgInternal->getTrgNeuronGroup()->getNumNeurons(),
                         []() { return nullptr; },
                         psm->getVarIndex(varName), psm->getVars(),
-                        [sgInternal]() { return sgInternal->getFusedPSVarSuffix(); });
+                        [sgInternal]() { return sgInternal->getFusedPSVarSuffix(); }, []() { return true; });
 }
 //----------------------------------------------------------------------------
 VarReference VarReference::createWUPreVarRef(const SynapseGroup *sg, const std::string &varName)
@@ -66,7 +66,7 @@ VarReference VarReference::createWUPreVarRef(const SynapseGroup *sg, const std::
     auto getDelayNG = [sgInternal]() { return (sgInternal->getDelaySteps() > 0) ? sgInternal->getSrcNeuronGroup() : nullptr; };
     return VarReference(sgInternal->getSrcNeuronGroup()->getNumNeurons(), getDelayNG,
                         wum->getPreVarIndex(varName), wum->getPreVars(),
-                        [sgInternal]() { return sgInternal->getName(); });
+                        [sgInternal]() { return sgInternal->getName(); }, []() { return true; });
 }
 //----------------------------------------------------------------------------
 VarReference VarReference::createWUPostVarRef(const SynapseGroup *sg, const std::string &varName)
@@ -76,32 +76,36 @@ VarReference VarReference::createWUPostVarRef(const SynapseGroup *sg, const std:
     auto getDelayNG = [sgInternal]() { return (sgInternal->getBackPropDelaySteps() > 0) ? sgInternal->getTrgNeuronGroup() : nullptr; };
     return VarReference(sgInternal->getTrgNeuronGroup()->getNumNeurons(), getDelayNG,
                         wum->getPostVarIndex(varName), wum->getPostVars(),
-                        [sgInternal]() { return sgInternal->getName(); });
+                        [sgInternal]() { return sgInternal->getName(); }, []() { return true; });
 }
 //----------------------------------------------------------------------------
 VarReference::VarReference(const NeuronGroupInternal *ng, const std::string &varName)
-:   VarReferenceBase(ng->getNeuronModel()->getVarIndex(varName), ng->getNeuronModel()->getVars(), [ng](){ return ng->getName(); }),
+:   VarReferenceBase(ng->getNeuronModel()->getVarIndex(varName), ng->getNeuronModel()->getVars(),
+                     [ng](){ return ng->getName(); }, []() { return true; }),
     m_Size(ng->getNumNeurons()), m_GetDelayNeuronGroup([ng, varName]() { return (ng->isDelayRequired() && ng->isVarQueueRequired(varName)) ? ng : nullptr; })
 {
 }
 //----------------------------------------------------------------------------
 VarReference::VarReference(const CurrentSourceInternal *cs, const std::string &varName)
-:   VarReferenceBase(cs->getCurrentSourceModel()->getVarIndex(varName), cs->getCurrentSourceModel()->getVars(), [cs]() { return cs->getName(); }),
+:   VarReferenceBase(cs->getCurrentSourceModel()->getVarIndex(varName), cs->getCurrentSourceModel()->getVars(),
+                     [cs]() { return cs->getName(); }, []() { return true; }),
     m_Size(cs->getTrgNeuronGroup()->getNumNeurons()), m_GetDelayNeuronGroup([]() { return nullptr; })
 {
 
 }
 //----------------------------------------------------------------------------
 VarReference::VarReference(const CustomUpdate *cu, const std::string &varName)
-:   VarReferenceBase(cu->getCustomUpdateModel()->getVarIndex(varName), cu->getCustomUpdateModel()->getVars(), [cu]() { return cu->getName(); }),
+:   VarReferenceBase(cu->getCustomUpdateModel()->getVarIndex(varName), cu->getCustomUpdateModel()->getVars(), 
+                     [cu]() { return cu->getName(); }, [cu]() { return static_cast<const CustomUpdateInternal*>(cu)->isBatched(); }),
     m_Size(cu->getSize()), m_GetDelayNeuronGroup([]() { return nullptr; })
 {
 
 }
 //----------------------------------------------------------------------------
 VarReference::VarReference(unsigned int size, GetDelayNeuronGroupFn getDelayNeuronGroup,
-                           size_t varIndex, const Models::Base::VarVec &varVec, GetTargetNameFn getTargetNameFn)
-:   VarReferenceBase(varIndex, varVec, getTargetNameFn), m_Size(size), m_GetDelayNeuronGroup(getDelayNeuronGroup)
+                           size_t varIndex, const Models::Base::VarVec &varVec, 
+                           GetTargetNameFn getTargetName, IsBatchedFn isBatched)
+:   VarReferenceBase(varIndex, varVec, getTargetName, isBatched), m_Size(size), m_GetDelayNeuronGroup(getDelayNeuronGroup)
 {}
 
 //----------------------------------------------------------------------------
@@ -109,7 +113,8 @@ VarReference::VarReference(unsigned int size, GetDelayNeuronGroupFn getDelayNeur
 //----------------------------------------------------------------------------
 WUVarReference::WUVarReference(const SynapseGroup *sg, const std::string &varName,
                                const SynapseGroup *transposeSG, const std::string &transposeVarName)
-:   VarReferenceBase(sg->getWUModel()->getVarIndex(varName), sg->getWUModel()->getVars(), [sg]() { return sg->getName(); }),
+:   VarReferenceBase(sg->getWUModel()->getVarIndex(varName), sg->getWUModel()->getVars(),
+                     [sg]() { return sg->getName(); }, []() { return true; }),
     m_SG(static_cast<const SynapseGroupInternal*>(sg)), m_TransposeSG(static_cast<const SynapseGroupInternal*>(transposeSG)),
     m_TransposeVarIndex((transposeSG == nullptr) ? 0 : transposeSG->getWUModel()->getVarIndex(transposeVarName)),
     m_TransposeVar((transposeSG == nullptr) ? Models::Base::Var() : transposeSG->getWUModel()->getVars().at(m_TransposeVarIndex)),
@@ -155,7 +160,8 @@ WUVarReference::WUVarReference(const SynapseGroup *sg, const std::string &varNam
 }
 //----------------------------------------------------------------------------
 WUVarReference::WUVarReference(const CustomUpdateWU *cu, const std::string &varName)
-:   VarReferenceBase(cu->getCustomUpdateModel()->getVarIndex(varName), cu->getCustomUpdateModel()->getVars(), [cu]() { return cu->getName(); }),
+:   VarReferenceBase(cu->getCustomUpdateModel()->getVarIndex(varName), cu->getCustomUpdateModel()->getVars(),
+                     [cu]() { return cu->getName(); }, [cu]() { return static_cast<const CustomUpdateWUInternal*>(cu)->isBatched(); }),
     m_SG(static_cast<const CustomUpdateWUInternal*>(cu)->getSynapseGroup()), m_TransposeSG(nullptr),
     m_TransposeVarIndex(0)
 {

--- a/tests/unit/customUpdate.cc
+++ b/tests/unit/customUpdate.cc
@@ -416,22 +416,29 @@ TEST(CustomUpdates, BatchingVars)
     
 
     // Create updates where variable is shared and references vary
-    Sum2::VarValues sum2VarValues(1.0);
-    Sum2::VarReferences sum2VarReferences1(createVarRef(pop, "V"), createVarRef(pop, "U"));
-    Sum2::VarReferences sum2VarReferences2(createVarRef(pop, "a"), createVarRef(pop, "b"));
-    Sum2::VarReferences sum2VarReferences3(createVarRef(pop, "V"), createVarRef(pop, "a"));
+    Sum::VarValues sumVarValues(0.0);
+    Sum::VarReferences sumVarReferences1(createVarRef(pop, "V"), createVarRef(pop, "U"));
+    Sum::VarReferences sumVarReferences2(createVarRef(pop, "a"), createVarRef(pop, "b"));
+    Sum::VarReferences sumVarReferences3(createVarRef(pop, "V"), createVarRef(pop, "a"));
 
-    auto *sum1 = model.addCustomUpdate<Sum2>("Sum1", "CustomUpdate",
-                                             {}, sum2VarValues, sum2VarReferences1);
-    auto *sum2 = model.addCustomUpdate<Sum2>("Sum2", "CustomUpdate",
-                                             {}, sum2VarValues, sum2VarReferences2);
-    auto *sum3 = model.addCustomUpdate<Sum2>("Sum3", "CustomUpdate",
-                                             {}, sum2VarValues, sum2VarReferences3);
+    auto *sum1 = model.addCustomUpdate<Sum>("Sum1", "CustomUpdate",
+                                            {}, sumVarValues, sumVarReferences1);
+    auto *sum2 = model.addCustomUpdate<Sum>("Sum2", "CustomUpdate",
+                                            {}, sumVarValues, sumVarReferences2);
+    auto *sum3 = model.addCustomUpdate<Sum>("Sum3", "CustomUpdate",
+                                            {}, sumVarValues, sumVarReferences3);
+    
+    // Create one more update which references two variables in the non-batched sum2
+    Sum::VarReferences sumVarReferences4(createVarRef(sum2, "sum"), createVarRef(sum2, "sum"));
+    auto *sum4 = model.addCustomUpdate<Sum>("Sum4", "CustomUpdate",
+                                            {}, sumVarValues, sumVarReferences4);
+    
     model.finalize();
 
     EXPECT_TRUE(static_cast<CustomUpdateInternal*>(sum1)->isBatched());
     EXPECT_FALSE(static_cast<CustomUpdateInternal*>(sum2)->isBatched());
     EXPECT_TRUE(static_cast<CustomUpdateInternal*>(sum3)->isBatched());
+    EXPECT_FALSE(static_cast<CustomUpdateInternal*>(sum4)->isBatched());
 }
 //--------------------------------------------------------------------------
 TEST(CustomUpdates, BatchingWriteShared)

--- a/tests/unit/customUpdate.cc
+++ b/tests/unit/customUpdate.cc
@@ -27,6 +27,19 @@ public:
 };
 IMPLEMENT_MODEL(IzhikevichVariableShared);
 
+class StaticPulseDendriticDelaySplit : public WeightUpdateModels::Base
+{
+public:
+    DECLARE_WEIGHT_UPDATE_MODEL(StaticPulseDendriticDelaySplit, 0, 4, 0, 0);
+
+    SET_VARS({{"gCommon", "scalar", VarAccess::READ_ONLY}, 
+              {"g", "scalar", VarAccess::READ_ONLY_DUPLICATE}, 
+              {"dCommon", "scalar", VarAccess::READ_ONLY},
+              {"d", "scalar", VarAccess::READ_ONLY_DUPLICATE}});
+
+    SET_SIM_CODE("$(addToInSynDelay, $(gCommon) + $(g), $(dCommon) + $(d));\n");
+};
+IMPLEMENT_MODEL(StaticPulseDendriticDelaySplit);
 
 class Sum : public CustomUpdateModels::Base
 {
@@ -141,7 +154,6 @@ IMPLEMENT_MODEL(ReduceNeuronSharedVar);
 //--------------------------------------------------------------------------
 // Tests
 //--------------------------------------------------------------------------
-
 TEST(CustomUpdates, ConstantVarSum)
 {
     ModelSpecInternal model;
@@ -170,7 +182,7 @@ TEST(CustomUpdates, ConstantVarSum)
 
     ASSERT_FALSE(backend.isGlobalHostRNGRequired(modelSpecMerged));
 }
-
+//--------------------------------------------------------------------------
 TEST(CustomUpdates, UninitialisedVarSum)
 {
     ModelSpecInternal model;
@@ -199,7 +211,7 @@ TEST(CustomUpdates, UninitialisedVarSum)
 
     ASSERT_FALSE(backend.isGlobalHostRNGRequired(modelSpecMerged));
 }
-
+//--------------------------------------------------------------------------
 TEST(CustomUpdates, RandVarSum)
 {
     ModelSpecInternal model;
@@ -229,6 +241,7 @@ TEST(CustomUpdates, RandVarSum)
 
     ASSERT_TRUE(backend.isGlobalHostRNGRequired(modelSpecMerged));
 }
+//--------------------------------------------------------------------------
 TEST(CustomUpdates, VarReferenceTypeChecks)
 {
     ModelSpecInternal model;
@@ -924,6 +937,66 @@ TEST(CustomUpdates, CompareDifferentWUConnectivity)
     ASSERT_TRUE(modelSpecMerged.getMergedCustomUpdateWUGroups().size() == 2);
     ASSERT_TRUE(modelSpecMerged.getMergedCustomWUUpdateInitGroups().size() == 1);
     ASSERT_TRUE(modelSpecMerged.getMergedCustomWUUpdateSparseInitGroups().size() == 1);
+}
+//--------------------------------------------------------------------------
+TEST(CustomUpdates, CompareDifferentWUBatched)
+{
+    ModelSpecInternal model;
+    model.setBatchSize(5);
+
+    // Add two neuron group to model
+    NeuronModels::Izhikevich::ParamValues paramVals(0.02, 0.2, -65.0, 8.0);
+    NeuronModels::Izhikevich::VarValues varVals(0.0, 0.0);
+    model.addNeuronPopulation<NeuronModels::Izhikevich>("Pre", 10, paramVals, varVals);
+    model.addNeuronPopulation<NeuronModels::Izhikevich>("Post", 25, paramVals, varVals);
+
+    // Add synapse group 
+    StaticPulseDendriticDelaySplit::VarValues synVarInit(1.0, 1.0, 1.0, 1.0);
+    auto *sg1 = model.addSynapsePopulation<StaticPulseDendriticDelaySplit, PostsynapticModels::DeltaCurr>(
+        "Synapses", SynapseMatrixType::DENSE_INDIVIDUALG, NO_DELAY,
+        "Pre", "Post",
+        {}, synVarInit,
+        {}, {});
+
+    // Add one custom update which sums duplicated variables (g and d), another which sums shared variables (gCommon and dCommon) and another which sums one of each
+    Sum::WUVarReferences sumVarReferences1(createWUVarRef(sg1, "g"), createWUVarRef(sg1, "d"));
+    Sum::WUVarReferences sumVarReferences2(createWUVarRef(sg1, "gCommon"), createWUVarRef(sg1, "dCommon"));
+    Sum::WUVarReferences sumVarReferences3(createWUVarRef(sg1, "g"), createWUVarRef(sg1, "dCommon"));
+    auto *sum1 = model.addCustomUpdate<Sum>("Sum1", "CustomUpdate",
+                                            {}, {0.0}, sumVarReferences1);
+    auto *sum2 = model.addCustomUpdate<Sum>("Sum2", "CustomUpdate",
+                                            {}, {0.0}, sumVarReferences2);
+    auto *sum3 = model.addCustomUpdate<Sum>("Sum3", "CustomUpdate",
+                                            {}, {0.0}, sumVarReferences3);
+    model.finalize();
+
+    // Check that sum1 and sum3 are batched and sum2 is not
+    CustomUpdateWUInternal *sum1Internal = static_cast<CustomUpdateWUInternal*>(sum1);
+    CustomUpdateWUInternal *sum2Internal = static_cast<CustomUpdateWUInternal*>(sum2);
+    CustomUpdateWUInternal *sum3Internal = static_cast<CustomUpdateWUInternal*>(sum3);
+    ASSERT_TRUE(sum1Internal->isBatched());
+    ASSERT_FALSE(sum2Internal->isBatched());
+    ASSERT_TRUE(sum3Internal->isBatched());
+
+    // Check that neither initialisation nor update of batched and unbatched can be merged
+    ASSERT_NE(sum1Internal->getHashDigest(), sum2Internal->getHashDigest());
+    ASSERT_NE(sum1Internal->getInitHashDigest(), sum2Internal->getInitHashDigest());
+    
+    // Check that initialisation of batched and mixed can be merged but not update
+    ASSERT_EQ(sum1Internal->getInitHashDigest(), sum3Internal->getInitHashDigest());
+    ASSERT_NE(sum1Internal->getHashDigest(), sum3Internal->getHashDigest());
+
+    // Create a backend
+    CodeGenerator::SingleThreadedCPU::Preferences preferences;
+    CodeGenerator::SingleThreadedCPU::Backend backend(model.getPrecision(), preferences);
+
+    // Merge model
+    CodeGenerator::ModelSpecMerged modelSpecMerged(model, backend);
+
+    // Check correct groups are merged
+    // **NOTE** delay groups don't matter for initialization
+    ASSERT_TRUE(modelSpecMerged.getMergedCustomUpdateWUGroups().size() == 3);
+    ASSERT_TRUE(modelSpecMerged.getMergedCustomWUUpdateInitGroups().size() == 2);
 }
 //--------------------------------------------------------------------------
 TEST(CustomUpdates, InvalidName)


### PR DESCRIPTION
In the course of my structural plasticity implementing, I found not one but two bugs in the variable reference/custom update stuff!

### Merging
In general, when merging together custom updates, what the variable references _target_ doesn't really matter - they're just pointers. However, whether variable references point to variables  with ``VarAccessDuplication::DUPLICATE``, ``VarAccessDuplication::SHARED`` etc changes the required index calculating code so this needs to be considered. This PR includes the variable duplication mode in the hashes used for merging groups and extends the unit tests to better cover corner cases in this area.

### References to custom update variables
Unlike synapses and neurons which are always batched if the model is, if custom updates are batched or not depends on whether they are attached to ``VarAccessDuplication::DUPLICATE`` variables (and whether the model is batched). This means if you make references to these variables from other custom updates whether these 'downstream' custom updates should be batched should depend on whether the upstream custom update was batched as well as the mode of the variables. This PR adds a ``isBatched`` method to each variable reference and extends the unit tests to cover this.