### PR TITLE
Batched prev spike time

### DIFF
--- a/src/genn/genn/code_generator/backendSIMT.cc
+++ b/src/genn/genn/code_generator/backendSIMT.cc
@@ -368,11 +368,14 @@ void BackendSIMT::genNeuronPrevSpikeTimeUpdateKernel(CodeStream &os, const Subst
                     os << "if(" << popSubs["id"] << " < group->spkCnt[" << ((batchSize == 1) ? "0" : "batch") << "])";
                     {
                         CodeStream::Scope b(os);
-                        os << "group->prevST[group->spk[";
-                        if(batchSize > 1) {
-                            os << "batchOffset + ";
+                        os << "group->prevST[";
+                        if (batchSize == 1) {
+                            os << "group->spk[" << popSubs["id"] << "]";
                         }
-                        os << popSubs["id"] << "]] = " << popSubs["t"] << " - DT;" << std::endl;
+                        else {
+                            os << "batchOffset + group->spk[batchOffset + " << popSubs["id"] << "]";
+                        }
+                        os << "] = " << popSubs["t"] << " - DT;" << std::endl;
                     }
                 }
                 if(ng.getArchetype().isPrevSpikeEventTimeRequired()) {
@@ -380,11 +383,14 @@ void BackendSIMT::genNeuronPrevSpikeTimeUpdateKernel(CodeStream &os, const Subst
                     os << "if(" << popSubs["id"] << " < group->spkCntEvnt[" << ((batchSize == 1) ? "0" : "batch") << "])";
                     {
                         CodeStream::Scope b(os);
-                        os << "group->prevSET[group->spkEvnt[";
-                        if(batchSize > 1) {
-                            os << "batchOffset + ";
+                        os << "group->prevSET[";
+                        if (batchSize == 1) {
+                            os << "group->spkEvnt[" << popSubs["id"] << "]";
                         }
-                        os << popSubs["id"] << "]] = " << popSubs["t"] << " - DT;" << std::endl;
+                        else {
+                            os << "batchOffset + group->spkEvnt[batchOffset + " << popSubs["id"] << "]";
+                        }
+                        os << "] = " << popSubs["t"] << " - DT;" << std::endl;
                     }
                 }
             }

--- a/src/genn/genn/code_generator/groupMerged.cc
+++ b/src/genn/genn/code_generator/groupMerged.cc
@@ -69,6 +69,9 @@ NeuronPrevSpikeTimeUpdateGroupMerged::NeuronPrevSpikeTimeUpdateGroupMerged(size_
                                                                            const std::vector<std::reference_wrapper<const NeuronGroupInternal>> &groups)
 :   GroupMerged<NeuronGroupInternal>(index, precision, groups)
 {
+    addField("unsigned int", "numNeurons",
+             [](const NeuronGroupInternal &ng, size_t) { return std::to_string(ng.getNumNeurons()); });
+
     if(getArchetype().isDelayRequired()) {
         addPointerField("unsigned int", "spkQuePtr", backend.getScalarAddressPrefix() + "spkQuePtr");
     } 
@@ -86,11 +89,6 @@ NeuronPrevSpikeTimeUpdateGroupMerged::NeuronPrevSpikeTimeUpdateGroupMerged(size_
     if(getArchetype().isPrevSpikeEventTimeRequired()) {
         addPointerField("unsigned int", "spkEvnt", backend.getDeviceVarPrefix() + "glbSpkEvnt");
         addPointerField(timePrecision, "prevSET", backend.getDeviceVarPrefix() + "prevSET");
-    }
-
-    if(getArchetype().isDelayRequired()) {
-        addField("unsigned int", "numNeurons",
-                 [](const NeuronGroupInternal &ng, size_t) { return std::to_string(ng.getNumNeurons()); });
     }
 }
 

--- a/tests/features/batch_prev_pre_spike_time_in_sim/model.cc
+++ b/tests/features/batch_prev_pre_spike_time_in_sim/model.cc
@@ -66,13 +66,20 @@ void modelDefinition(ModelSpec &model)
     model.setBatchSize(2);
     
     model.addNeuronPopulation<PreNeuron>("pre", 10, {}, {});
+    model.addNeuronPopulation<PreNeuron>("preDelay", 10, {}, {});
     model.addNeuronPopulation<PostNeuron>("post", 10, {}, {});
+    model.addNeuronPopulation<PostNeuron>("postDelay", 10, {}, {});
 
     model.addSynapsePopulation<WeightUpdateModel, PostsynapticModels::DeltaCurr>(
-        "syn", SynapseMatrixType::SPARSE_INDIVIDUALG, 20, "pre", "post",
+        "syn", SynapseMatrixType::SPARSE_INDIVIDUALG, NO_DELAY, "pre", "post",
         {}, WeightUpdateModel::VarValues(-std::numeric_limits<float>::max()),
         {}, {},
         initConnectivity<InitSparseConnectivitySnippet::OneToOne>({}));
-
+    
+    model.addSynapsePopulation<WeightUpdateModel, PostsynapticModels::DeltaCurr>(
+        "synDelay", SynapseMatrixType::SPARSE_INDIVIDUALG, 20, "preDelay", "postDelay",
+        {}, WeightUpdateModel::VarValues(-std::numeric_limits<float>::max()),
+        {}, {},
+        initConnectivity<InitSparseConnectivitySnippet::OneToOne>({}));
     model.setPrecision(GENN_FLOAT);
 }

--- a/tests/features/batch_prev_pre_spike_time_in_sim/test.cc
+++ b/tests/features/batch_prev_pre_spike_time_in_sim/test.cc
@@ -37,9 +37,16 @@ public:
                     // 2) PREVIOUS spike occurred (-)20 timesteps before
                     // 3) t is incremented one timestep at the end of StepGeNN
                     const float delayedLastSpikeTime = (scalar)i + 1.0f + (20.0f * std::floor((t - 22.0f - (scalar)i) / 20.0f));
-                    
-                    // If, theoretically, spike would have arrived before delay it's impossible so time should be a very large negative number
+
+                    // Check wsyn read from delayed population
                     if(delayedLastSpikeTime < 21.0f) {
+                        ASSERT_LT(wsynDelay[i], -1.0E6);
+                    }
+                    else {
+                        ASSERT_FLOAT_EQ(wsynDelay[i], delayedLastSpikeTime);
+                    }
+                    // Check wsyn read from non-delayed population
+                    if(delayedLastSpikeTime < 1.0f) {
                         ASSERT_LT(wsyn[i], -1.0E6);
                     }
                     else {


### PR DESCRIPTION
Two fixes here:
1. Missing ``numNeurons`` field in ``NeuronPrevSpikeTimeUpdateGroupMerged`` required when model has batch size > 1. Not 100% sure why batch size isn't readily available in this constructor but unconditionally including the number of neurons is fine
2. Indexing when updating previous spike times was incorrect when model is batched but there are no delays (both ``group->prevST`` and ``group->spk`` are ``num_batches * num_neurons`` size arrays so indices into both need to have ``batchOffset`` adding to them)

I have also updated the feature test which _nearly_ covered this to actually do so!

Fixes #564 