### PR TITLE
Increase constant cache estimate

### DIFF
--- a/include/genn/backends/cuda/backend.h
+++ b/include/genn/backends/cuda/backend.h
@@ -97,10 +97,10 @@ struct Preferences : public PreferencesBase
     KernelBlockSize manualBlockSizes;
 
     //! How much constant cache is already used and therefore can't be used by GeNN?
-    /*! Each of the four modules which includes CUDA headers(neuronUpdate, synapseUpdate, init and runner)
+    /*! Each of the four modules which includes CUDA headers(neuronUpdate, synapseUpdate, custom update, init and runner)
         Takes 72 bytes of constant memory for a lookup table used by cuRAND. If your application requires
         additional constant cache, increase this */
-    size_t constantCacheOverhead = 72 * 4;
+    size_t constantCacheOverhead = 72 * 5;
 
     //! NVCC compiler options for all GPU code
     std::string userNvccFlags = "";


### PR DESCRIPTION
Very small change but, I was unlucky enough to hit an unlucky model size which lead me to realize that we hadn't updated the calculation of how much constant cache is used by CUDA itself gets used since adding an additional module.