### PR TITLE
Fix PyGeNN shared neuron

### DIFF
--- a/include/genn/genn/customUpdate.h
+++ b/include/genn/genn/customUpdate.h
@@ -149,12 +149,12 @@ protected:
     template<typename V>
     void checkVarReferenceBatching(const std::vector<V>& varRefs, unsigned int batchSize)
     {
-        // If target of any variable references is duplicated, custom update should be batched
+        // If target of any variable references is not shared across batches, custom update should be batched
         if(batchSize > 1) {
             m_Batched = std::any_of(varRefs.cbegin(), varRefs.cend(),
                                     [](const V& v) 
                                     {
-                                        return (v.isBatched() && (v.getVar().access & VarAccessDuplication::DUPLICATE)); 
+                                        return (v.isBatched() && !(v.getVar().access & VarAccessDuplication::SHARED)); 
                                     });
         }
         else {

--- a/include/genn/genn/customUpdate.h
+++ b/include/genn/genn/customUpdate.h
@@ -167,7 +167,7 @@ protected:
             const auto varRef = varRefs.at(i);
             const auto modelVarRef = modelVarRefs.at(i);
 
-             // If custom update is batched, check that any variable references to shared variables are read-only
+            // If custom update is batched, check that any variable references to shared variables are read-only
             // **NOTE** if custom update isn't batched, it's totally fine to write to shared variables
             if(m_Batched && (varRef.getVar().access & VarAccessDuplication::SHARED)
                && (modelVarRef.access == VarAccessMode::READ_WRITE))
@@ -227,6 +227,7 @@ protected:
     //------------------------------------------------------------------------
     bool isBatchReduction() const { return isReduction(getVarReferences(), VarAccessDuplication::SHARED); }
     bool isNeuronReduction() const { return isReduction(getVarReferences(), VarAccessDuplication::SHARED_NEURON); }
+    bool isPerNeuron() const{ return m_PerNeuron; }
 
      //! Updates hash with custom update
     /*! NOTE: this can only be called after model is finalized */
@@ -245,6 +246,9 @@ private:
     const std::vector<Models::VarReference> m_VarReferences;
     const unsigned int m_Size;
     const NeuronGroup *m_DelayNeuronGroup;
+
+    //! Is this custom update per-neuron i.e. run in parallel across all neurons
+    bool m_PerNeuron;
 };
 
 //------------------------------------------------------------------------

--- a/include/genn/genn/customUpdateInternal.h
+++ b/include/genn/genn/customUpdateInternal.h
@@ -23,6 +23,7 @@ public:
     using CustomUpdateBase::isInitRNGRequired;
     using CustomUpdateBase::isZeroCopyEnabled;
     using CustomUpdateBase::isBatched;
+    using CustomUpdate::isPerNeuron;
     using CustomUpdateBase::getVarLocationHashDigest;
 
     using CustomUpdate::finalize;

--- a/pygenn/genn_groups.py
+++ b/pygenn/genn_groups.py
@@ -871,8 +871,11 @@ class SynapseGroup(Group):
     @matrix_type.setter
     def matrix_type(self, matrix_type):
         if self.weight_sharing_master is None:
-            self._matrix_type = getattr(genn_wrapper,
-                                        "SynapseMatrixType_" + matrix_type)
+            if isinstance(matrix_type, str):
+                self._matrix_type = getattr(
+                    genn_wrapper, "SynapseMatrixType_" + matrix_type)
+            else:
+                self._matrix_type = matrix_type
         else:
             raise Exception("when weight sharing is used, matrix_type"
                             "can only be set on the 'master' population")

--- a/pygenn/genn_groups.py
+++ b/pygenn/genn_groups.py
@@ -838,7 +838,7 @@ class SynapseGroup(Group):
         else:
             var_view = self.vars[var_name].view
 
-            if self.is_dense:
+            if self.is_dense or self.has_kernel_synapse_vars:
                 return np.copy(var_view)
             elif self.is_ragged:
                 max_rl = self.max_row_length

--- a/src/genn/backends/single_threaded_cpu/backend.cc
+++ b/src/genn/backends/single_threaded_cpu/backend.cc
@@ -587,12 +587,16 @@ void Backend::genCustomUpdate(CodeStream &os, const ModelSpecMerged &modelMerged
                         }
                         else {
                             // Loop through group members
-                            os << "for(unsigned int i = 0; i < group->size; i++)";
+                            Substitutions popSubs(&funcSubs);
+                            if (c.getArchetype().isPerNeuron()) {
+                                os << "for(unsigned int i = 0; i < group->size; i++)";
+                                popSubs.addVarSubstitution("id", "i");
+                            }
+                            else {
+                                popSubs.addVarSubstitution("id", "0");
+                            }
                             {
                                 CodeStream::Scope b(os);
-
-                                Substitutions popSubs(&funcSubs);
-                                popSubs.addVarSubstitution("id", "i");
 
                                 // Generate custom update
                                 c.generateCustomUpdate(*this, os, modelMerged, popSubs);

--- a/src/genn/genn/code_generator/backendSIMT.cc
+++ b/src/genn/genn/code_generator/backendSIMT.cc
@@ -1016,8 +1016,9 @@ void BackendSIMT::genCustomUpdateKernel(CodeStream &os, const Substitutions &ker
             // Otherwise, if this update isn't per-neuron
             else if (!cg.getArchetype().isPerNeuron()) {
                 if(cg.getArchetype().isBatched()) {
+                    os << "const unsigned int batch = " << cuSubs["id"] << ";" << std::endl;
                     cuSubs.addVarSubstitution("id", "0", true);
-                    cuSubs.addVarSubstitution("batch", cuSubs["id"]);
+                    cuSubs.addVarSubstitution("batch", "batch");
                 }
                 // Otherwise, just substitute "batch" for 0
                 else {

--- a/src/genn/genn/code_generator/backendSIMT.cc
+++ b/src/genn/genn/code_generator/backendSIMT.cc
@@ -219,9 +219,11 @@ size_t BackendSIMT::getPaddedNumCustomUpdateThreads(const CustomUpdateInternal &
     if (cg.isNeuronReduction()) {
         return padKernelSize(32 * numCopies, KernelCustomUpdate);
     }
+    else if (cg.isPerNeuron()) {
+        return numCopies * padKernelSize(cg.getSize(), KernelCustomUpdate);
+    }
     else {
-        const size_t numElements = cg.isPerNeuron() ? cg.getSize() : 1;
-        return numCopies * padKernelSize(numElements, KernelCustomUpdate);
+        return padKernelSize(numCopies, KernelCustomUpdate);
     }
 }
 //--------------------------------------------------------------------------

--- a/tests/features/custom_update/test.cc
+++ b/tests/features/custom_update/test.cc
@@ -39,16 +39,24 @@ TEST_F(SimTest, CustomUpdate)
             // Pull variables
             pullVNeuronSetTimeFromDevice();
             pullVNeuronFromDevice();
+            pullVSharedNeuronFromDevice();
+
             pullVCurrentSourceSetTimeFromDevice();
             pullCCurrentSourceFromDevice();
+            pullCSharedCurrentSourceFromDevice();
+
             pullVCustomUpdateSetTimeFromDevice();
             pullCCustomUpdateFromDevice();
+
             pullVPSMSetTimeFromDevice();
             pullPDenseFromDevice();
+            pullPSharedDenseFromDevice();
             pullVWUPreSetTimeFromDevice();
             pullPreDenseFromDevice();
+            pullPreSharedDenseFromDevice();
             pullVWUPostSetTimeFromDevice();
             pullPostSparseFromDevice();
+            pullPostSharedSparseFromDevice();
             pullVWUDenseSetTimeFromDevice();
             pullgDenseFromDevice();
             pullVWUSparseSetTimeFromDevice();
@@ -64,12 +72,14 @@ TEST_F(SimTest, CustomUpdate)
                         [](scalar v) { return v == t; }));
             EXPECT_TRUE(std::all_of(&VNeuronSetTime[0], &VNeuronSetTime[100],
                         [](scalar v) { return v == t; }));
+            EXPECT_EQ(VSharedNeuron[0], t);
 
             EXPECT_TRUE(std::all_of(&VCurrentSourceSetTime[0], &VCurrentSourceSetTime[100],
                         [](scalar v) { return v == t; }));
             EXPECT_TRUE(std::all_of(&CCurrentSource[0], &CCurrentSource[100],
                         [](scalar v) { return v == t; }));
-            
+            EXPECT_EQ(CSharedCurrentSource[0], t);
+
             EXPECT_TRUE(std::all_of(&VCustomUpdateSetTime[0], &VCustomUpdateSetTime[100],
                         [](scalar v) { return v == t; }));
             EXPECT_TRUE(std::all_of(&CCustomUpdate[0], &CCustomUpdate[100],
@@ -79,21 +89,19 @@ TEST_F(SimTest, CustomUpdate)
                         [](scalar v) { return v == t; }));
             EXPECT_TRUE(std::all_of(&PDense[0], &PDense[100],
                         [](scalar v) { return v == t; }));
+            EXPECT_EQ(PSharedDense[0], t);
 
             EXPECT_TRUE(std::all_of(&VWUPreSetTime[0], &VWUPreSetTime[100],
                         [](scalar v) { return v == t; }));
             EXPECT_TRUE(std::all_of(&PreDense[0], &PreDense[100],
                         [](scalar v) { return v == t; }));
+            EXPECT_EQ(PreSharedDense[0], t);
 
             EXPECT_TRUE(std::all_of(&VWUPostSetTime[0], &VWUPostSetTime[100],
                         [](scalar v) { return v == t; }));
             EXPECT_TRUE(std::all_of(&PostSparse[0], &PostSparse[100],
                         [](scalar v) { return v == t; }));
-
-            EXPECT_TRUE(std::all_of(&VPSMSetTime[0], &VPSMSetTime[100],
-                        [](scalar v) { return v == t; }));
-            EXPECT_TRUE(std::all_of(&PDense[0], &PDense[100],
-                        [](scalar v) { return v == t; }));
+            EXPECT_EQ(PostSharedSparse[0], t);
 
             EXPECT_TRUE(std::all_of(&VWUDenseSetTime[0], &VWUDenseSetTime[100 * 100],
                         [](scalar v) { return v == t; }));

--- a/tests/features/custom_update_batch/test.cc
+++ b/tests/features/custom_update_batch/test.cc
@@ -55,6 +55,7 @@ TEST_F(SimTest, CustomUpdateBatch)
             pullVWUMKernelDuplicateSetTimeFromDevice();
             pullVNeuronFromDevice();
             pullUNeuronFromDevice();
+            pullSNeuronFromDevice();
             pullVDenseFromDevice();
             pullUDenseFromDevice();
             pullVSparseFromDevice();
@@ -82,6 +83,7 @@ TEST_F(SimTest, CustomUpdateBatch)
                 const unsigned int startSparseSynIdx = b * (50 * maxRowLengthSparse);
                 const float batchOffset = b * 1000.0f;
                 
+                ASSERT_EQ(SNeuron[b], batchOffset + t);
                 // Check batched variables match expectations
                 ASSERT_TRUE(std::all_of(&VNeuronDuplicateSetTime[startNeuronIdx], &VNeuronDuplicateSetTime[endNeuronIdx],
                             [batchOffset](scalar v) { return v == (batchOffset + t); }));

--- a/tests/unit/customUpdate.cc
+++ b/tests/unit/customUpdate.cc
@@ -77,6 +77,17 @@ class Sum3 : public CustomUpdateModels::Base
 };
 IMPLEMENT_MODEL(Sum3);
 
+class Copy : public CustomUpdateModels::Base
+{
+    DECLARE_CUSTOM_UPDATE_MODEL(Copy, 0, 0, 2);
+
+    SET_UPDATE_CODE("$(a) = $(b);\n");
+
+    SET_VAR_REFS({{"a", "scalar", VarAccessMode::READ_ONLY}, 
+                  {"b", "scalar", VarAccessMode::READ_ONLY}});
+};
+IMPLEMENT_MODEL(Copy);
+
 class Cont : public WeightUpdateModels::Base
 {
 public:
@@ -413,7 +424,6 @@ TEST(CustomUpdates, BatchingVars)
     // Add neuron and spike source (arbitrary choice of model with read_only variables) to model
     NeuronModels::IzhikevichVariable::VarValues izkVarVals(0.0, 0.0, 0.02, 0.2, -65.0, 8.);
     auto *pop = model.addNeuronPopulation<NeuronModels::IzhikevichVariable>("Pop", 10, {}, izkVarVals);
-    
 
     // Create updates where variable is shared and references vary
     Sum::VarValues sumVarValues(0.0);
@@ -436,9 +446,32 @@ TEST(CustomUpdates, BatchingVars)
     model.finalize();
 
     EXPECT_TRUE(static_cast<CustomUpdateInternal*>(sum1)->isBatched());
+    EXPECT_TRUE(static_cast<CustomUpdateInternal*>(sum1)->isPerNeuron());
     EXPECT_FALSE(static_cast<CustomUpdateInternal*>(sum2)->isBatched());
+    EXPECT_TRUE(static_cast<CustomUpdateInternal*>(sum2)->isPerNeuron());
     EXPECT_TRUE(static_cast<CustomUpdateInternal*>(sum3)->isBatched());
+    EXPECT_TRUE(static_cast<CustomUpdateInternal*>(sum3)->isPerNeuron());
     EXPECT_FALSE(static_cast<CustomUpdateInternal*>(sum4)->isBatched());
+    EXPECT_TRUE(static_cast<CustomUpdateInternal*>(sum4)->isPerNeuron());
+}
+//--------------------------------------------------------------------------
+TEST(CustomUpdates, NeuronSharedVars)
+{
+    ModelSpecInternal model;
+    model.setBatchSize(5);
+
+    // Add neuron and spike source (arbitrary choice of model with read-only neuron shared variables) to model
+    IzhikevichVariableShared::VarValues izkVarVals(0.0, 0.0, 0.02, 0.2, -65.0, 8.);
+    auto *pop = model.addNeuronPopulation<IzhikevichVariableShared>("Pop", 10, {}, izkVarVals);
+
+    Copy::VarReferences copyVarReferences1(createVarRef(pop, "a"), createVarRef(pop, "b"));
+    CustomUpdate *cu = model.addCustomUpdate<Copy>("Copy", "CustomUpdate",
+                                                   {}, {}, copyVarReferences1);
+    model.finalize();
+
+    auto *cuInternal = static_cast<CustomUpdateInternal *>(cu);
+    EXPECT_TRUE(cuInternal->isBatched());
+    EXPECT_FALSE(cuInternal->isPerNeuron());
 }
 //--------------------------------------------------------------------------
 TEST(CustomUpdates, BatchingWriteShared)
@@ -446,7 +479,7 @@ TEST(CustomUpdates, BatchingWriteShared)
     ModelSpecInternal model;
     model.setBatchSize(5);
 
-    // Add neuron and spike source (arbitrary choice of model with read_only variables) to model
+    // Add neuron and spike source (arbitrary choice of model with read-only batch shared variables) to model
     NeuronModels::IzhikevichVariable::VarValues izkVarVals(0.0, 0.0, 0.02, 0.2, -65.0, 8.);
     auto *pop = model.addNeuronPopulation<NeuronModels::IzhikevichVariable>("Pop", 10, {}, izkVarVals);
     
@@ -461,7 +494,28 @@ TEST(CustomUpdates, BatchingWriteShared)
     }
 }
 //--------------------------------------------------------------------------
-TEST(CustomUpdates, ReduceDuplicate)
+TEST(CustomUpdates, WriteNeuronShared)
+{
+    ModelSpecInternal model;
+    model.setBatchSize(5);
+
+    // Add neuron and spike source (arbitrary choice of model with read-only neuron shared variables) to model
+    IzhikevichVariableShared::VarValues izkVarVals(0.0, 0.0, 0.02, 0.2, -65.0, 8.);
+    auto *pop = model.addNeuronPopulation<IzhikevichVariableShared>("Pop", 10, {}, izkVarVals);
+    
+    // Create custom update which tries to create a read-write reference to a (which isn't per-neuron)
+    Sum2::VarValues sum2VarValues(1.0);
+    Sum2::VarReferences sum2VarReferences(createVarRef(pop, "a"), createVarRef(pop, "V"));
+    try {
+        model.addCustomUpdate<Sum2>("Sum1", "CustomUpdate",
+                                {}, sum2VarValues, sum2VarReferences);
+        FAIL();
+    }
+    catch(const std::runtime_error &) {
+    }
+}
+//--------------------------------------------------------------------------
+TEST(CustomUpdates, WriteBatchShared)
 {
     ModelSpecInternal model;
     model.setBatchSize(5);
@@ -501,7 +555,7 @@ TEST(CustomUpdates, ReductionTypeDuplicateNeuron)
     ASSERT_TRUE(cuInternal->isBatched());
     ASSERT_FALSE(cuInternal->isBatchReduction());
     ASSERT_TRUE(cuInternal->isNeuronReduction());
-    ASSERT_EQ(cuInternal->getSize(), 10);
+    ASSERT_TRUE(cuInternal->isPerNeuron());
 }
 //--------------------------------------------------------------------------
 TEST(CustomUpdates, ReductionTypeDuplicateNeuronInternal)
@@ -523,6 +577,7 @@ TEST(CustomUpdates, ReductionTypeDuplicateNeuronInternal)
     ASSERT_TRUE(cuInternal->isBatched());
     ASSERT_FALSE(cuInternal->isBatchReduction());
     ASSERT_TRUE(cuInternal->isNeuronReduction());
+    ASSERT_TRUE(cuInternal->isPerNeuron());
 }
 //--------------------------------------------------------------------------
 TEST(CustomUpdates, ReductionTypeSharedNeuronInternal)
@@ -544,6 +599,7 @@ TEST(CustomUpdates, ReductionTypeSharedNeuronInternal)
     ASSERT_FALSE(cuInternal->isBatched());
     ASSERT_FALSE(cuInternal->isBatchReduction());
     ASSERT_TRUE(cuInternal->isNeuronReduction());
+    ASSERT_TRUE(cuInternal->isPerNeuron());
 }
 //--------------------------------------------------------------------------
 TEST(CustomUpdates, ReductionTypeDuplicateBatch)
@@ -564,6 +620,7 @@ TEST(CustomUpdates, ReductionTypeDuplicateBatch)
     ASSERT_TRUE(cuInternal->isBatched());
     ASSERT_TRUE(cuInternal->isBatchReduction());
     ASSERT_FALSE(cuInternal->isNeuronReduction());
+    ASSERT_TRUE(cuInternal->isPerNeuron());
 }
 //--------------------------------------------------------------------------
 TEST(CustomUpdates, ReductionTypeDuplicateBatchInternal)
@@ -585,6 +642,7 @@ TEST(CustomUpdates, ReductionTypeDuplicateBatchInternal)
     ASSERT_TRUE(cuInternal->isBatched());
     ASSERT_TRUE(cuInternal->isBatchReduction());
     ASSERT_FALSE(cuInternal->isNeuronReduction());
+    ASSERT_TRUE(cuInternal->isPerNeuron());
 }
 //--------------------------------------------------------------------------
 TEST(CustomUpdates, NeuronSharedCustomUpdateWU)
@@ -635,30 +693,6 @@ TEST(CustomUpdates, NeuronBatchReduction)
     }
     catch (const std::runtime_error &) {
     }
-}
-//--------------------------------------------------------------------------
-TEST(CustomUpdates, SharedNeuronVariable)
-{
-    ModelSpecInternal model;
-    model.setBatchSize(5);
-
-    // Add neuron (copy of izhikevich model where a, b, c and d are shared_neuron) to model
-    IzhikevichVariableShared::VarValues izkVarVals(0.0, 0.0, 0.02, 0.2, -65.0, 8.);
-    auto *pop = model.addNeuronPopulation<IzhikevichVariableShared>("Pop", 10, {}, izkVarVals);
-
-    // Add custom update to sum A and B
-    Sum::VarReferences sumVarReferences(createVarRef(pop, "a"), createVarRef(pop, "b"));
-    auto *cu = model.addCustomUpdate<Sum>("Sum", "CustomUpdate",
-                                          {}, {0.0}, sumVarReferences);
-
-    // Finalize model
-    model.finalize();
-    
-    auto *cuInternal = static_cast<CustomUpdateInternal *>(cu);
-    ASSERT_TRUE(cuInternal->isBatched());
-    ASSERT_FALSE(cuInternal->isBatchReduction());
-    ASSERT_FALSE(cuInternal->isNeuronReduction());
-    ASSERT_EQ(cuInternal->getSize(), 1);
 }
 //--------------------------------------------------------------------------
 TEST(CustomUpdates, CompareDifferentModel)


### PR DESCRIPTION
Clearly #539 left a whole bunch of corner cases unhandled involving custom updates actually operating directly (rather than reducing into) ``SHARED_NEURON`` variables (i.e. duplicated across batches but shared across neurons) which I encountered when trying to use these in mlGeNN:

1. Added ``CustomUpdate::isPerNeuron`` - this is set if any custom update variables or variable reference targets _aren't_ ``SHARED_NEURON``
2. If Custom updates _are_ per-neuron then they can only read from ``SHARED_NEURON`` variables
3. Added SIMT and single-threaded CPU code generation for custom updates which _aren't_ per-neuron.
4. PyGeNN now makes correctly-sized views for accessing ``SHARED_NEURON`` variables

And, as ever, I extended some feature tests to cover this behaviour as well as adding a couple of unit tests to check the  ``CustomUpdate::isPerNeuron`` logic. On a similarly typical vein, there are also a couple of unrelated small fixes:

1. ``SynapseGroup.matrix_type`` can now be set from enumeration as well as by string (useful for mlGeNN connectivity type checking)
2. You can now use ``SynapseGroup.get_var_values`` on ``KERNEL`` connectivity (useful when attempting to learn convolutions)