### PR TITLE
Ability to unload PyGeNN models

### DIFF
--- a/pygenn/genn_model.py
+++ b/pygenn/genn_model.py
@@ -646,7 +646,7 @@ class GeNNModel(object):
             # Allocate recording buffers
             self._slm.allocate_recording_buffers(num_recording_timesteps)
 
-        # Loop through synapse populations and load any 
+        # Loop through neuron populations and load any
         # extra global parameters required for initialization
         for pop_data in itervalues(self.neuron_populations):
             pop_data.load_init_egps()
@@ -689,6 +689,29 @@ class GeNNModel(object):
         # Set loaded flag and built flag
         self._loaded = True
         self._built = True
+
+    def unload(self):
+        # Loop through custom updates and unload
+        for cu_data in itervalues(self.custom_updates):
+            cu_data.unload()
+
+        # Loop through current sources and unload
+        for src_data in itervalues(self.current_sources):
+            src_data.unload()
+
+        # Loop through synapse populations and unload
+        for pop_data in itervalues(self.synapse_populations):
+            pop_data.unload()
+
+        # Loop through neuron populations and unload
+        for pop_data in itervalues(self.neuron_populations):
+            pop_data.unload()
+
+        # Close shared library model
+        self._slm.close()
+
+        # Clear loaded flag
+        self._loaded = False
 
     def reinitialise(self):
         """reinitialise model to its original state without re-loading"""

--- a/userproject/include/sharedLibraryModel.h
+++ b/userproject/include/sharedLibraryModel.h
@@ -50,15 +50,8 @@ public:
 
     virtual ~SharedLibraryModel()
     {
-        // Close model library if loaded successfully
-        if(m_Library) {
-            freeMem();
-#ifdef _WIN32
-            FreeLibrary(m_Library);
-#else
-            dlclose(m_Library);
-#endif
-        }
+        // Close model library
+        close();
     }
 
     //----------------------------------------------------------------------------
@@ -110,6 +103,40 @@ public:
 #endif
             return false;
         }
+    }
+
+    void close()
+    {
+        if(m_Library) {
+            freeMem();
+#ifdef _WIN32
+            FreeLibrary(m_Library);
+#else
+            dlclose(m_Library);
+#endif
+            m_Library = nullptr;
+        }
+
+        // Null all pointers
+        m_AllocateMem = nullptr;
+        m_AllocateRecordingBuffers = nullptr;
+        m_FreeMem = nullptr;
+        m_GetFreeDeviceMemBytes = nullptr;
+        m_Initialize = nullptr;
+        m_InitializeSparse = nullptr;
+        m_StepTime = nullptr;
+        m_PullRecordingBuffersFromDevice = nullptr;
+        m_NCCLGenerateUniqueID = nullptr;
+        m_NCCLGetUniqueID = nullptr;
+        m_NCCLInitCommunicator = nullptr;
+        m_NCCLUniqueIDBytes = nullptr;
+        m_T = nullptr;
+        m_Timestep = nullptr;
+
+        // Empty all dictionaries
+        m_PopulationVars.clear();
+        m_PopulationEPGs.clear();
+        m_CustomUpdates.clear();
     }
 
     void allocateExtraGlobalParam(const std::string &popName, const std::string &egpName, unsigned int count)


### PR DESCRIPTION
PyGeNN ``GeNNModel`` objects wrap both a ``ModelSpec`` holding the model description and a ``SharedLibraryModel`` for loading the dynamic library created from the generated code and executing it. This PR lets you 'unload' the ``SharedLibraryModel`` component, freeing memory but allowing it to be easily re-loaded if required. This entails:
- In PyGeNN, resetting all views to ``None`` to prevent freed memory being accessed
- Adding a ``close`` method to ``SharedLibraryModel`` which sets all pointers to variables etc to ``nullptr``, empties the cache used to speed up access to functions and unloads the shared library.