### PR TITLE
Extra global parameter references

### DIFF
--- a/include/genn/genn/code_generator/groupMerged.h
+++ b/include/genn/genn/code_generator/groupMerged.h
@@ -267,14 +267,15 @@ protected:
         }
     }
 
-    void addEGPRefs(const Models::Base::EGPRefVec &egpRefs, const std::string &arrayPrefix)
+    template<typename E>
+    void addEGPReferences(const Models::Base::EGPRefVec &egpRefs, const std::string &arrayPrefix, E getEGPRefFn)
     {
         for(size_t i = 0; i < egpRefs.size(); i++) {
             const auto &e = egpRefs.at(i);
             addField(e.type, e.name,
-                     [arrayPrefix, e, i](const G &g, size_t)
+                     [arrayPrefix, e, getEGPRefFn, i](const G &g, size_t)
                      { 
-                         const auto egpRef = g.getEGPReferences().at(i);
+                         const auto egpRef = getEGPRefFn(g).at(i);
                          return arrayPrefix + egpRef.getEGP().name + egpRef.getTargetName(); 
                      },
                      FieldType::PointerEGP);

--- a/include/genn/genn/code_generator/groupMerged.h
+++ b/include/genn/genn/code_generator/groupMerged.h
@@ -267,6 +267,20 @@ protected:
         }
     }
 
+    void addEGPRefs(const Models::Base::EGPRefVec &egpRefs, const std::string &arrayPrefix)
+    {
+        for(size_t i = 0; i < egpRefs.size(); i++) {
+            const auto &e = egpRefs.at(i);
+            addField(e.type, e.name,
+                     [arrayPrefix, e, i](const G &g, size_t)
+                     { 
+                         const auto egpRef = g.getEGPReferences().at(i);
+                         return arrayPrefix + egpRef.getEGP().name + egpRef.getTargetName(); 
+                     },
+                     FieldType::PointerEGP);
+        }
+    }
+
     template<typename T, typename P, typename H>
     void addHeterogeneousParams(const Snippet::Base::StringVec &paramNames, const std::string &suffix,
                                 P getParamValues, H isHeterogeneous)
@@ -437,7 +451,7 @@ protected:
 
         // Loop through fields again to generate any EGP pushing functions that are require
         for(const auto &f : sortedFields) {
-            // If this field is for a pointer EGP, also declare function to push it
+            // If this field is for a pointer EGP (or reference to one), also declare function to push it
             if(std::get<3>(f) == FieldType::PointerEGP) {
                 definitionsInternalFunc << "EXPORT_FUNC void pushMerged" << name << getIndex() << std::get<1>(f) << "ToDevice(unsigned int idx, ";
                 definitionsInternalFunc << backend.getMergedGroupFieldHostType(std::get<0>(f)) << " value);" << std::endl;

--- a/include/genn/genn/code_generator/modelSpecMerged.h
+++ b/include/genn/genn/code_generator/modelSpecMerged.h
@@ -326,12 +326,15 @@ private:
             // Loop through fields
             for(const auto &f : mergedGroups.back().getFields()) {
                 // If field is an EGP, add record to merged EGPS
-                if(std::get<3>(f) == MergedGroup::FieldType::PointerEGP || std::get<3>(f) == MergedGroup::FieldType::ScalarEGP) {
+                if(std::get<3>(f) == MergedGroup::FieldType::PointerEGP || std::get<3>(f) == MergedGroup::FieldType::ScalarEGP)
+                {
                     // Loop through groups within newly-created merged group
                     for(size_t groupIndex = 0; groupIndex < mergedGroups.back().getGroups().size(); groupIndex++) {
                         const auto &g = mergedGroups.back().getGroups()[groupIndex];
 
                         // Add reference to this group's variable to data structure
+                        // **NOTE** this works fine with EGP references because the function to
+                        // get their value will just return the name of the referenced EGP
                         m_MergedEGPs[std::get<2>(f)(g, groupIndex)].emplace(
                             std::piecewise_construct,
                             std::forward_as_tuple(MergedGroup::name),

--- a/include/genn/genn/customUpdate.h
+++ b/include/genn/genn/customUpdate.h
@@ -38,6 +38,8 @@ public:
     const std::vector<double> &getParams() const{ return m_Params; }
     const std::vector<Models::VarInit> &getVarInitialisers() const{ return m_VarInitialisers; }
 
+    const std::vector<Models::EGPReference> &getEGPReferences() const{ return m_EGPReferences;  }
+
     //! Get variable location for custom update model state variable
     VarLocation getVarLocation(const std::string &varName) const;
 
@@ -50,18 +52,8 @@ public:
 protected:
     CustomUpdateBase(const std::string &name, const std::string &updateGroupName,
                      const CustomUpdateModels::Base *customUpdateModel, const std::vector<double> &params,
-                     const std::vector<Models::VarInit> &varInitialisers,
-                     VarLocation defaultVarLocation, VarLocation defaultExtraGlobalParamLocation)
-    :   m_Name(name), m_UpdateGroupName(updateGroupName), m_CustomUpdateModel(customUpdateModel), m_Params(params), 
-        m_VarInitialisers(varInitialisers), m_VarLocation(varInitialisers.size(), defaultVarLocation),
-        m_ExtraGlobalParamLocation(customUpdateModel->getExtraGlobalParams().size(), defaultExtraGlobalParamLocation),
-        m_Batched(false)
-    {
-        // Validate names
-        Utils::validatePopName(name, "Custom update");
-        Utils::validatePopName(updateGroupName, "Custom update group name");
-        getCustomUpdateModel()->validate();
-    }
+                     const std::vector<Models::VarInit> &varInitialisers, const std::vector<Models::EGPReference> &egpReferences,
+                     VarLocation defaultVarLocation, VarLocation defaultExtraGlobalParamLocation);
 
     //------------------------------------------------------------------------
     // Protected methods
@@ -189,6 +181,8 @@ private:
     std::vector<double> m_DerivedParams;
     std::vector<Models::VarInit> m_VarInitialisers;
 
+    std::vector<Models::EGPReference> m_EGPReferences;
+
     //! Location of individual state variables
     std::vector<VarLocation> m_VarLocation;
 
@@ -215,7 +209,8 @@ protected:
     CustomUpdate(const std::string &name, const std::string &updateGroupName,
                  const CustomUpdateModels::Base *customUpdateModel, const std::vector<double> &params,
                  const std::vector<Models::VarInit> &varInitialisers, const std::vector<Models::VarReference> &varReferences,
-                 VarLocation defaultVarLocation, VarLocation defaultExtraGlobalParamLocation);
+                 const std::vector<Models::EGPReference> &egpReferences, VarLocation defaultVarLocation, 
+                 VarLocation defaultExtraGlobalParamLocation);
 
     //------------------------------------------------------------------------
     // Protected methods
@@ -266,7 +261,8 @@ protected:
     CustomUpdateWU(const std::string &name, const std::string &updateGroupName,
                    const CustomUpdateModels::Base *customUpdateModel, const std::vector<double> &params,
                    const std::vector<Models::VarInit> &varInitialisers, const std::vector<Models::WUVarReference> &varReferences,
-                   VarLocation defaultVarLocation, VarLocation defaultExtraGlobalParamLocation);
+                   const std::vector<Models::EGPReference> &egpReferences, VarLocation defaultVarLocation, 
+                   VarLocation defaultExtraGlobalParamLocation);
 
     //------------------------------------------------------------------------
     // Protected methods

--- a/include/genn/genn/customUpdateInternal.h
+++ b/include/genn/genn/customUpdateInternal.h
@@ -12,9 +12,10 @@ public:
     CustomUpdateInternal(const std::string &name, const std::string &updateGroupName,
                          const CustomUpdateModels::Base *customUpdateModel, const std::vector<double> &params, 
                          const std::vector<Models::VarInit> &varInitialisers, const std::vector<Models::VarReference> &varReferences, 
-                         VarLocation defaultVarLocation, VarLocation defaultExtraGlobalParamLocation)
+                         const std::vector<Models::EGPReference> &egpReferences, VarLocation defaultVarLocation, 
+                         VarLocation defaultExtraGlobalParamLocation)
     :   CustomUpdate(name, updateGroupName, customUpdateModel, params, varInitialisers, varReferences, 
-                     defaultVarLocation, defaultExtraGlobalParamLocation)
+                     egpReferences, defaultVarLocation, defaultExtraGlobalParamLocation)
     {
     }
 
@@ -43,9 +44,10 @@ public:
     CustomUpdateWUInternal(const std::string &name, const std::string &updateGroupName,
                            const CustomUpdateModels::Base *customUpdateModel, const std::vector<double> &params, 
                            const std::vector<Models::VarInit> &varInitialisers, const std::vector<Models::WUVarReference> &varReferences, 
-                           VarLocation defaultVarLocation, VarLocation defaultExtraGlobalParamLocation)
+                           const std::vector<Models::EGPReference> &egpReferences, VarLocation defaultVarLocation, 
+                           VarLocation defaultExtraGlobalParamLocation)
     :   CustomUpdateWU(name, updateGroupName, customUpdateModel, params, varInitialisers, varReferences, 
-                       defaultVarLocation, defaultExtraGlobalParamLocation)
+                       egpReferences, defaultVarLocation, defaultExtraGlobalParamLocation)
     {
     }
 

--- a/include/genn/genn/customUpdateModels.h
+++ b/include/genn/genn/customUpdateModels.h
@@ -11,8 +11,8 @@
     DECLARE_SNIPPET(TYPE, NUM_PARAMS);                                          \
     typedef Models::VarInitContainerBase<NUM_VARS> VarValues;                   \
     typedef Models::VarReferenceContainerBase<NUM_VAR_REFS> VarReferences;      \
-    typedef Models::WUVarReferenceContainerBase<NUM_VAR_REFS> WUVarReferences
-    
+    typedef Models::WUVarReferenceContainerBase<NUM_VAR_REFS> WUVarReferences;  \
+    typedef Models::EGPReferenceContainerBase<0> EGPReferences
 
 #define SET_VAR_REFS(...) virtual VarRefVec getVarRefs() const override{ return __VA_ARGS__; }
 #define SET_UPDATE_CODE(UPDATE_CODE) virtual std::string getUpdateCode() const override{ return UPDATE_CODE; }
@@ -32,6 +32,9 @@ public:
     //----------------------------------------------------------------------------
     //! Gets names and types (as strings) of model variable references
     virtual VarRefVec getVarRefs() const{ return {}; }
+
+    //! Gets names and types (as strings) of model extra global parameter references
+    virtual EGPRefVec getEGPRefs() const { return {}; }
 
     //! Gets the code that performs the custom update 
     virtual std::string getUpdateCode() const{ return ""; }

--- a/include/genn/genn/customUpdateModels.h
+++ b/include/genn/genn/customUpdateModels.h
@@ -7,12 +7,15 @@
 //----------------------------------------------------------------------------
 // Macros
 //----------------------------------------------------------------------------
+#define DECLARE_CUSTOM_UPDATE_MODEL_EGP_REF(TYPE, NUM_PARAMS, NUM_VARS, NUM_VAR_REFS, NUM_EGP_REFS) \
+    DECLARE_SNIPPET(TYPE, NUM_PARAMS);                                                              \
+    typedef Models::VarInitContainerBase<NUM_VARS> VarValues;                                       \
+    typedef Models::VarReferenceContainerBase<NUM_VAR_REFS> VarReferences;                          \
+    typedef Models::WUVarReferenceContainerBase<NUM_VAR_REFS> WUVarReferences;                      \
+    typedef Models::EGPReferenceContainerBase<NUM_EGP_REFS> EGPReferences
+
 #define DECLARE_CUSTOM_UPDATE_MODEL(TYPE, NUM_PARAMS, NUM_VARS, NUM_VAR_REFS)   \
-    DECLARE_SNIPPET(TYPE, NUM_PARAMS);                                          \
-    typedef Models::VarInitContainerBase<NUM_VARS> VarValues;                   \
-    typedef Models::VarReferenceContainerBase<NUM_VAR_REFS> VarReferences;      \
-    typedef Models::WUVarReferenceContainerBase<NUM_VAR_REFS> WUVarReferences;  \
-    typedef Models::EGPReferenceContainerBase<0> EGPReferences
+    DECLARE_CUSTOM_UPDATE_MODEL_EGP_REF(TYPE, NUM_PARAMS, NUM_VARS, NUM_VAR_REFS, 0)
 
 #define SET_VAR_REFS(...) virtual VarRefVec getVarRefs() const override{ return __VA_ARGS__; }
 #define SET_UPDATE_CODE(UPDATE_CODE) virtual std::string getUpdateCode() const override{ return UPDATE_CODE; }

--- a/include/genn/genn/customUpdateModels.h
+++ b/include/genn/genn/customUpdateModels.h
@@ -37,7 +37,7 @@ public:
     virtual VarRefVec getVarRefs() const{ return {}; }
 
     //! Gets names and types (as strings) of model extra global parameter references
-    virtual EGPRefVec getEGPRefs() const { return {}; }
+    virtual EGPRefVec getExtraGlobalParamRefs() const { return {}; }
 
     //! Gets the code that performs the custom update 
     virtual std::string getUpdateCode() const{ return ""; }

--- a/include/genn/genn/modelSpec.h
+++ b/include/genn/genn/modelSpec.h
@@ -177,6 +177,42 @@ inline Models::WUVarReference createWUVarRef(const CustomUpdateWU *cu, const std
     return Models::WUVarReference(cu, varName);
 }
 
+//! Creates a reference to a neuron group extra global parameter
+inline Models::EGPReference createEGPRef(const NeuronGroup *ng, const std::string &egpName)
+{
+    return Models::EGPReference::createEGPRef(ng, egpName);
+}
+
+//! Creates a reference to a current source extra global parameter
+inline Models::EGPReference createEGPRef(const CurrentSource *cs, const std::string &egpName)
+{
+    return Models::EGPReference::createEGPRef(cs, egpName);
+}
+
+//! Creates a reference to a custom update extra global parameter
+inline Models::EGPReference createEGPRef(const CustomUpdate *cu, const std::string &egpName)
+{
+    return Models::EGPReference::createEGPRef(cu, egpName);
+}
+
+//! Creates a reference to a custom weight update extra global parameter
+inline Models::EGPReference createEGPRef(const CustomUpdateWU *cu, const std::string &egpName)
+{
+    return Models::EGPReference::createEGPRef(cu, egpName);
+}
+
+//! Creates a reference to a postsynaptic model extra global parameter
+inline Models::EGPReference createPSMEGPRef(const SynapseGroup *sg, const std::string &egpName)
+{
+    return Models::EGPReference::createPSMEGPRef(sg, egpName);
+}
+
+//! Creates a reference to a weight update model extra global parameter
+inline Models::EGPReference createWUEGPRef(const SynapseGroup *sg, const std::string &egpName)
+{
+    return Models::EGPReference::createWUEGPRef(sg, egpName);
+}
+
 //----------------------------------------------------------------------------
 // ModelSpec
 //----------------------------------------------------------------------------

--- a/include/genn/genn/modelSpec.h
+++ b/include/genn/genn/modelSpec.h
@@ -666,14 +666,15 @@ public:
     CustomUpdate *addCustomUpdate(const std::string &name, const std::string &updateGroupName, const CustomUpdateModel *model,
                                   const typename CustomUpdateModel::ParamValues &paramValues,
                                   const typename CustomUpdateModel::VarValues &varInitialisers,
-                                  const typename CustomUpdateModel::VarReferences &varReferences)
+                                  const typename CustomUpdateModel::VarReferences &varReferences,
+                                  const typename CustomUpdateModel::EGPReferences &egpReferences = {})
     {
          // Add neuron group to map
         auto result = m_CustomUpdates.emplace(std::piecewise_construct,
             std::forward_as_tuple(name),
             std::forward_as_tuple(name, updateGroupName, model,
                                   paramValues.getInitialisers(), varInitialisers.getInitialisers(), varReferences.getInitialisers(),
-                                  m_DefaultVarLocation, m_DefaultExtraGlobalParamLocation));
+                                  egpReferences.getInitialisers(), m_DefaultVarLocation, m_DefaultExtraGlobalParamLocation));
 
         if(!result.second) {
             throw std::runtime_error("Cannot add a custom update with duplicate name:" + name);
@@ -698,14 +699,15 @@ public:
     CustomUpdateWU *addCustomUpdate(const std::string &name, const std::string &updateGroupName,
                                     const CustomUpdateModel *model, const typename CustomUpdateModel::ParamValues &paramValues,
                                     const typename CustomUpdateModel::VarValues &varInitialisers,
-                                    const typename CustomUpdateModel::WUVarReferences &varReferences)
+                                    const typename CustomUpdateModel::WUVarReferences &varReferences,
+                                    const typename CustomUpdateModel::EGPReferences &egpReferences = {})
     {
         // Add neuron group to map
         auto result = m_CustomWUUpdates.emplace(std::piecewise_construct,
             std::forward_as_tuple(name),
             std::forward_as_tuple(name, updateGroupName, model,
                                   paramValues.getInitialisers(), varInitialisers.getInitialisers(), varReferences.getInitialisers(),
-                                  m_DefaultVarLocation, m_DefaultExtraGlobalParamLocation));
+                                  egpReferences.getInitialisers(), m_DefaultVarLocation, m_DefaultExtraGlobalParamLocation));
 
         if(!result.second) {
             throw std::runtime_error("Cannot add a custom update with duplicate name:" + name);
@@ -728,10 +730,11 @@ public:
     CustomUpdate *addCustomUpdate(const std::string &name, const std::string &updateGroupName,
                                   const typename CustomUpdateModel::ParamValues &paramValues,
                                   const typename CustomUpdateModel::VarValues &varInitialisers,
-                                   const typename CustomUpdateModel::VarReferences &varReferences)
+                                  const typename CustomUpdateModel::VarReferences &varReferences,
+                                  const typename CustomUpdateModel::EGPReferences &egpReferences = {})
     {
         return addCustomUpdate<CustomUpdateModel>(name, updateGroupName, CustomUpdateModel::getInstance(),
-                                                  paramValues, varInitialisers, varReferences);
+                                                  paramValues, varInitialisers, varReferences, egpReferences);
     }
 
 
@@ -749,10 +752,11 @@ public:
     CustomUpdateWU *addCustomUpdate(const std::string &name, const std::string &updateGroupName,
                                     const typename CustomUpdateModel::ParamValues &paramValues,
                                     const typename CustomUpdateModel::VarValues &varInitialisers,
-                                    const typename CustomUpdateModel::WUVarReferences &varReferences)
+                                    const typename CustomUpdateModel::WUVarReferences &varReferences,
+                                    const typename CustomUpdateModel::EGPReferences &egpReferences = {})
     {
         return addCustomUpdate<CustomUpdateModel>(name, updateGroupName, CustomUpdateModel::getInstance(),
-                                                  paramValues, varInitialisers, varReferences);
+                                                  paramValues, varInitialisers, varReferences, egpReferences);
     }
 
 protected:

--- a/include/genn/genn/models.h
+++ b/include/genn/genn/models.h
@@ -93,11 +93,28 @@ public:
         VarAccessMode access;
     };
 
+    struct EGPRef
+    {
+        EGPRef(const std::string &n, const std::string &t) : name(n), type(t)
+        {}
+        EGPRef() : EGPRef("", "")
+        {}
+
+        bool operator == (const EGPRef &other) const
+        {
+            return ((name == other.name) && (type == other.type));
+        }
+
+        std::string name;
+        std::string type;
+    };
+
     //----------------------------------------------------------------------------
     // Typedefines
     //----------------------------------------------------------------------------
     typedef std::vector<Var> VarVec;
     typedef std::vector<VarRef> VarRefVec;
+    typedef std::vector<EGPRef> EGPRefVec;
 
     //----------------------------------------------------------------------------
     // Declared virtuals
@@ -273,10 +290,53 @@ template<size_t NumVars>
 using WUVarReferenceContainerBase = Snippet::InitialiserContainerBase<WUVarReference, NumVars>;
 
 //----------------------------------------------------------------------------
+// Models::EGPReference
+//----------------------------------------------------------------------------
+class GENN_EXPORT EGPReference
+{
+public:
+    //------------------------------------------------------------------------
+    // Public API
+    //------------------------------------------------------------------------
+    const Models::Base::EGP &getEGP() const { return m_EGP; }
+    size_t getEGPIndex() const { return m_EGPIndex; }
+    std::string getTargetName() const { return m_TargetName; }
+
+    //------------------------------------------------------------------------
+    // Static API
+    //------------------------------------------------------------------------
+    static EGPReference createEGPRef(const NeuronGroup *ng, const std::string &egpName);
+    static EGPReference createEGPRef(const CurrentSource *cs, const std::string &egpName);
+    static EGPReference createEGPRef(const CustomUpdate *cu, const std::string &egpName);
+    static EGPReference createEGPRef(const CustomUpdateWU *cu, const std::string &egpName);
+    static EGPReference createPSMEGPRef(const SynapseGroup *sg, const std::string &egpName);
+    static EGPReference createWUEGPRef(const SynapseGroup *sg, const std::string &egpName);
+
+private:
+    EGPReference(size_t egpIndex, const Models::Base::EGPVec &egpVec, 
+                 const std::string &targetName)
+    :   m_EGPIndex(egpIndex), m_EGP(egpVec.at(egpIndex)), m_TargetName(targetName)
+    {}
+    //------------------------------------------------------------------------
+    // Members
+    //------------------------------------------------------------------------
+    size_t m_EGPIndex;
+    Models::Base::EGP m_EGP;
+    std::string m_TargetName;
+};
+
+//----------------------------------------------------------------------------
+// Models::EGPReferenceContainerBase
+//----------------------------------------------------------------------------
+template<size_t NumEGPs>
+using EGPReferenceContainerBase = Snippet::InitialiserContainerBase<EGPReference, NumEGPs>;
+
+//----------------------------------------------------------------------------
 // updateHash overrides
 //----------------------------------------------------------------------------
 GENN_EXPORT void updateHash(const Base::Var &v, boost::uuids::detail::sha1 &hash);
 GENN_EXPORT void updateHash(const Base::VarRef &v, boost::uuids::detail::sha1 &hash);
+GENN_EXPORT void updateHash(const Base::EGPRef &e, boost::uuids::detail::sha1 &hash);
 GENN_EXPORT void updateHash(const VarReference &v, boost::uuids::detail::sha1 &hash);
 GENN_EXPORT void updateHash(const WUVarReference &v, boost::uuids::detail::sha1 &hash);
 } // Models

--- a/include/genn/genn/models.h
+++ b/include/genn/genn/models.h
@@ -339,4 +339,5 @@ GENN_EXPORT void updateHash(const Base::VarRef &v, boost::uuids::detail::sha1 &h
 GENN_EXPORT void updateHash(const Base::EGPRef &e, boost::uuids::detail::sha1 &hash);
 GENN_EXPORT void updateHash(const VarReference &v, boost::uuids::detail::sha1 &hash);
 GENN_EXPORT void updateHash(const WUVarReference &v, boost::uuids::detail::sha1 &hash);
+GENN_EXPORT void updateHash(const EGPReference &v, boost::uuids::detail::sha1 &hash);
 } // Models

--- a/pygenn/genn_model.py
+++ b/pygenn/genn_model.py
@@ -58,8 +58,9 @@ from six import iteritems, itervalues, string_types
 # pygenn imports
 from . import genn_wrapper
 from .genn_wrapper import SharedLibraryModelNumpy as slm
-from .genn_wrapper.Models import (Var, VarRef, VarInit, VarReference, 
-                                  WUVarReference, VarVector, VarRefVector)
+from .genn_wrapper.Models import (EGPRef, EGPRefVector, Var, VarRef,
+                                  VarInit, VarReference, VarVector,
+                                  VarRefVector, WUVarReference)
 from .genn_wrapper.InitSparseConnectivitySnippet import Init as InitSparse
 from .genn_wrapper.InitToeplitzConnectivitySnippet import Init as InitToeplitz
 from .genn_wrapper.Snippet import (make_dpf, EGP, ParamVal, DerivedParam,
@@ -1454,6 +1455,7 @@ def create_custom_custom_update_class(class_name, param_names=None,
                                       var_refs=None,
                                       update_code=None,
                                       extra_global_params=None,
+                                      extra_global_param_refs=None,
                                       custom_body=None):
     """This helper function creates a custom CustomUpdate class.
     See also:
@@ -1464,22 +1466,24 @@ def create_custom_custom_update_class(class_name, param_names=None,
     create_custom_sparse_connect_init_snippet_class
 
     Args:
-    class_name          --  name of the new class
+    class_name              --  name of the new class
 
     Keyword args:
-    param_names         --  list of strings with param names of the model
-    var_name_types      --  list of tuples of strings with varible names and
-                            types of the variable
-    derived_params      --  list of tuples, where the first member is string
-                            with name of the derived parameter and the second
-                            should be a functor returned by create_dpf_class
-    var_refs            --  list of tuples of strings with varible names and
-                            types of variabled variable
-    update_code         --  string with the current injection code
-    extra_global_params --  list of pairs of strings with names and types of
-                            additional parameters
-    custom_body         --  dictionary with additional attributes and methods
-                            of the new class
+    param_names             --  list of strings with param names of the model
+    var_name_types          --  list of tuples of strings with varible names and
+                                types of the variable
+    derived_params          --  list of tuples, where the first member is string
+                                with name of the derived parameter and the second
+                                should be a functor returned by create_dpf_class
+    var_refs                --  list of tuples of strings with varible names and
+                                types of variabled variable
+    update_code             --  string with the current injection code
+    extra_global_params     --  list of pairs of strings with names and types of
+                                additional parameters
+    extra_global_param_refs --  list of pairs of strings with names and types of
+                                extra global parameter references
+    custom_body             --  dictionary with additional attributes and methods
+                                of the new class
     """
     if not isinstance(custom_body, dict) and custom_body is not None:
         raise ValueError("custom_body must be an instance of dict or None")
@@ -1493,6 +1497,11 @@ def create_custom_custom_update_class(class_name, param_names=None,
         body["get_var_refs"] = \
             lambda self: VarRefVector([VarRef(*v)
                                        for v in var_refs])
+    
+    if extra_global_param_refs is not None:
+        body["get_extra_global_param_refs"] = \
+            lambda self: EGPRefVector([EGPRef(*e)
+                                       for e in extra_global_param_refs])
     if custom_body is not None:
         body.update(custom_body)
 

--- a/pygenn/genn_model.py
+++ b/pygenn/genn_model.py
@@ -537,7 +537,7 @@ class GeNNModel(object):
         return c_source
     
     def add_custom_update(self, cu_name, group_name, custom_update_model,
-                          param_space, var_space, var_ref_space):
+                          param_space, var_space, var_ref_space, egp_ref_space={}):
         """Add a current source to the GeNN model
 
         Args:
@@ -554,6 +554,8 @@ class GeNNModel(object):
                                    CustomUpdateModel class
         var_ref_space           -- dict with variable references for the
                                    CustomUpdateModel class
+        egp_ref_space           -- dict with extra global parameter references 
+                                   for the CustomUpdateModel class
         """
         if self._built:
             raise Exception("GeNN model already built")
@@ -565,7 +567,7 @@ class GeNNModel(object):
         c_update = CustomUpdate(cu_name, self)
         c_update.set_custom_update_model(custom_update_model,
                                          param_space, var_space, 
-                                         var_ref_space)
+                                         var_ref_space, egp_ref_space)
         c_update.add_to(group_name)
 
         self.custom_updates[cu_name] = c_update
@@ -1062,7 +1064,41 @@ def create_wu_var_ref(g, var_name, tp_sg=None, tp_var_name=None):
     else:
         return (genn_wrapper.create_wuvar_ref(g.pop, var_name,
                                               tp_sg.pop, tp_var_name), sg)
+
+def create_egp_ref(pop, egp_name):
+    """This helper function creates a Models::EGPReference
+    pointing to a neuron, current source or custom update 
+    extra global parameter for initialising references.
+
+    Args:
+    pop         -- population, either a NeuronGroup or CurrentSource object
+    egp_name    -- name of extra global parameter in population to reference
+    """
+    return genn_wrapper.create_egpref(pop.pop, egp_name)
     
+def create_psm_egp_ref(sg, egp_name):
+    """This helper function creates a Models::EGPReference
+    pointing to a postsynaptic model extra global parameter
+    for initialising references.
+
+    Args:
+    sg          -- SynapseGroup object
+    egp_name    -- name of postsynaptic model extra global
+                   parameter in synapse group to reference
+    """
+    return genn_wrapper.create_psmegpref(sg.pop, egp_name)
+
+def create_wu_egp_ref(sg, egp_name):
+    """This helper function creates a Models::EGPReference
+    pointing to a weight update model extra global parameter
+    for initialising references.
+
+    Args:
+    sg          -- SynapseGroup object
+    egp_name    -- name of weight update model extra global
+                   parameter in synapse group to reference
+    """
+    return genn_wrapper.create_wuegpref(sg.pop, var_name)
 
 def create_custom_neuron_class(class_name, param_names=None,
                                var_name_types=None, derived_params=None,

--- a/pygenn/genn_wrapper/include/customEGPReferences.h
+++ b/pygenn/genn_wrapper/include/customEGPReferences.h
@@ -1,0 +1,41 @@
+#pragma once
+
+namespace CustomValues
+{
+//------------------------------------------------------------------------
+// EGPReferences
+//------------------------------------------------------------------------
+class EGPReferences
+{
+public:
+    EGPReferences()
+    {
+    }
+    
+    EGPReferences( const std::vector<Models::EGPReference> &initialisers ) :
+      m_Initialisers(initialisers.begin(), initialisers.end()){}
+
+    //----------------------------------------------------------------------------
+    // Public API
+    //----------------------------------------------------------------------------
+    //! Gets initialisers as a vector of Values
+    const std::vector<Models::EGPReference> &getInitialisers() const
+    {
+        return m_Initialisers;
+    }
+
+    //----------------------------------------------------------------------------
+    // Operators
+    //----------------------------------------------------------------------------
+    const Models::EGPReference &operator[](size_t pos) const
+    {
+        return m_Initialisers[pos];
+    }
+
+private:
+    //----------------------------------------------------------------------------
+    // Members
+    //----------------------------------------------------------------------------
+    std::vector<Models::EGPReference> m_Initialisers;
+};
+}

--- a/pygenn/genn_wrapper/swig/Models.i
+++ b/pygenn/genn_wrapper/swig/Models.i
@@ -3,7 +3,7 @@
   
    Institute: Center for Computational Neuroscience and Robotics
               University of Sussex
-	      Falmer, Brighton BN1 9QJ, UK 
+              Falmer, Brighton BN1 9QJ, UK 
   
    email to:  T.Nowotny@sussex.ac.uk
   
@@ -18,6 +18,7 @@
 #include "models.h"
 
 // PyGenn includes
+#include "customEGPReferences.h"
 #include "customParamValues.h"
 #include "customVarValues.h"
 #include "customVarReferences.h"
@@ -43,14 +44,17 @@
 %nodefaultctor Models::VarInit;
 %nodefaultctor Models::VarReference;
 %nodefaultctor Models::WUVarReference;
+%nodefaultctor Models::EGPReference;
 
 // flatten nested classes
 %rename (Var) Models::Base::Var;
 %rename (VarRef) Models::Base::VarRef;
+%rename (EGPRef) Models::Base::EGPRef;
 
 // add vector overrides for them
 %template(VarVector) std::vector<Models::Base::Var>;
 %template(VarRefVector) std::vector<Models::Base::VarRef>;
+%template(EGPRefVector) std::vector<Models::Base::EGPRef>;
 
 // Add standard exception handler
 %exception {
@@ -74,6 +78,8 @@
 %include "customWUVarReferences.h"
 %nodefaultctor CustomValues::ParamValues;
 %include "customParamValues.h"
+%nodefaultctor CustomValues::EGPReferences;
+%include "customEGPReferences.h"
 
 %template(CustomVarValues) CustomValues::VarValues::VarValues<double>;
 %template(CustomVarValues) CustomValues::VarValues::VarValues<Models::VarInit>;
@@ -91,3 +97,7 @@
 %ignore std::vector<Models::WUVarReference>::vector(size_type);
 %ignore std::vector<Models::WUVarReference>::resize;
 %template(WUVarReferenceVector) std::vector<Models::WUVarReference>;
+
+%ignore std::vector<Models::EGPReference>::vector(size_type);
+%ignore std::vector<Models::EGPReference>::resize;
+%template(EGPReferenceVector) std::vector<Models::EGPReference>;

--- a/pygenn/model_preprocessor.py
+++ b/pygenn/model_preprocessor.py
@@ -8,9 +8,10 @@ from weakref import proxy, ProxyTypes
 import numpy as np
 from six import iterkeys, itervalues
 from . import genn_wrapper
-from .genn_wrapper.Models import (VarInit, VarReference, WUVarReference,
-                                  VarInitVector, VarRefVector,
-                                  VarReferenceVector, WUVarReferenceVector)
+from .genn_wrapper.Models import (EGPReferenceVector, VarInit, VarReference,
+                                  VarInitVector, VarRefVector, 
+                                  VarReferenceVector, WUVarReference,
+                                  WUVarReferenceVector)
 from .genn_wrapper.StlContainers import DoubleVector
 
 def prepare_model(model, group, param_space, var_space, model_family):
@@ -182,12 +183,26 @@ def var_ref_space_to_wu_var_refs(model, var_ref_space):
     var_space   -- dict with Variables
 
     Returns:
-    native model's VarValues
+    native model's VarReferences
     """
     return model.make_wuvar_references(
         WUVarReferenceVector([var_ref_space[v.name][0]
                               for v in model.get_var_refs()]))
 
+def egp_ref_space_to_egp_refs(model, egp_ref_space):
+    """Convert a egp_ref_space dict to EGPReferences
+
+    Args:
+    model           -- instance of the model
+    egp_ref_space   -- dict with extra global parameter references
+
+    Returns:
+    native model's EGPReferences
+    """
+    return model.make_egpreferences(
+        EGPReferenceVector([egp_ref_space[v.name][0]
+                            for v in model.get_extra_global_param_refs()]))
+                            
 def pre_var_space_to_vals(model, var_space):
     """Convert a var_space dict to PreVarValues
 

--- a/pygenn/model_preprocessor.py
+++ b/pygenn/model_preprocessor.py
@@ -200,7 +200,7 @@ def egp_ref_space_to_egp_refs(model, egp_ref_space):
     native model's EGPReferences
     """
     return model.make_egpreferences(
-        EGPReferenceVector([egp_ref_space[v.name][0]
+        EGPReferenceVector([egp_ref_space[v.name]
                             for v in model.get_extra_global_param_refs()]))
                             
 def pre_var_space_to_vals(model, var_space):

--- a/src/genn/genn/code_generator/customUpdateGroupMerged.cc
+++ b/src/genn/genn/code_generator/customUpdateGroupMerged.cc
@@ -68,6 +68,7 @@ void genCustomUpdate(CodeStream &os, Substitutions &baseSubs, const C &cg,
                                        [&cg](size_t i) { return cg.isDerivedParamHeterogeneous(i);  },
                                        "", "group->");
     updateSubs.addVarNameSubstitution(cm->getExtraGlobalParams(), "", "group->");
+    updateSubs.addVarNameSubstitution(cm->getExtraGlobalParamRefs(), "", "group->");
 
     std::string code = cm->getUpdateCode();
     updateSubs.applyCheckUnreplaced(code, "custom update : merged" + std::to_string(cg.getIndex()));
@@ -137,8 +138,9 @@ CustomUpdateGroupMerged::CustomUpdateGroupMerged(size_t index, const std::string
     addVarReferences(cm->getVarRefs(), backend.getDeviceVarPrefix(),
                     [](const CustomUpdateInternal &cg) { return cg.getVarReferences(); });
 
-    // Add EGPs to struct
+    // Add EGPs and EGP references to struct
     this->addEGPs(cm->getExtraGlobalParams(), backend.getDeviceVarPrefix());
+    this->addEGPRefs(cm->getExtraGlobalParamRefs(), backend.getDeviceVarPrefix());
 }
 //----------------------------------------------------------------------------
 bool CustomUpdateGroupMerged::isParamHeterogeneous(size_t index) const
@@ -165,6 +167,7 @@ boost::uuids::detail::sha1::digest_type CustomUpdateGroupMerged::getHashDigest()
     updateHash([](const CustomUpdateInternal &cg) { return cg.getParams(); }, hash);
     updateHash([](const CustomUpdateInternal &cg) { return cg.getDerivedParams(); }, hash);
     updateHash([](const CustomUpdateInternal &cg) { return cg.getVarReferences(); }, hash);
+    updateHash([](const CustomUpdateInternal &cg) { return cg.getEGPReferences(); }, hash);
 
     return hash.get_digest();
 }
@@ -255,6 +258,7 @@ boost::uuids::detail::sha1::digest_type CustomUpdateWUGroupMergedBase::getHashDi
     updateHash([](const CustomUpdateWUInternal &cg) { return cg.getParams(); }, hash);
     updateHash([](const CustomUpdateWUInternal &cg) { return cg.getDerivedParams(); }, hash);
     updateHash([](const CustomUpdateWUInternal &cg) { return cg.getVarReferences(); }, hash);
+    updateHash([](const CustomUpdateWUInternal &cg) { return cg.getEGPReferences(); }, hash);
 
     return hash.get_digest();
 }
@@ -362,8 +366,9 @@ CustomUpdateWUGroupMergedBase::CustomUpdateWUGroupMergedBase(size_t index, const
                      });
             }
     }
-    // Add EGPs to struct
+    // Add EGPs and EGP references to struct
     this->addEGPs(cm->getExtraGlobalParams(), backend.getDeviceVarPrefix());
+    this->addEGPRefs(cm->getExtraGlobalParamRefs(), backend.getDeviceVarPrefix());
 }
 
 // ----------------------------------------------------------------------------

--- a/src/genn/genn/code_generator/customUpdateGroupMerged.cc
+++ b/src/genn/genn/code_generator/customUpdateGroupMerged.cc
@@ -140,7 +140,8 @@ CustomUpdateGroupMerged::CustomUpdateGroupMerged(size_t index, const std::string
 
     // Add EGPs and EGP references to struct
     this->addEGPs(cm->getExtraGlobalParams(), backend.getDeviceVarPrefix());
-    this->addEGPRefs(cm->getExtraGlobalParamRefs(), backend.getDeviceVarPrefix());
+    addEGPReferences(cm->getExtraGlobalParamRefs(), backend.getDeviceVarPrefix(),
+                     [](const CustomUpdateInternal &cg) { return cg.getEGPReferences(); });
 }
 //----------------------------------------------------------------------------
 bool CustomUpdateGroupMerged::isParamHeterogeneous(size_t index) const
@@ -368,7 +369,8 @@ CustomUpdateWUGroupMergedBase::CustomUpdateWUGroupMergedBase(size_t index, const
     }
     // Add EGPs and EGP references to struct
     this->addEGPs(cm->getExtraGlobalParams(), backend.getDeviceVarPrefix());
-    this->addEGPRefs(cm->getExtraGlobalParamRefs(), backend.getDeviceVarPrefix());
+    addEGPReferences(cm->getExtraGlobalParamRefs(), backend.getDeviceVarPrefix(),
+                     [](const CustomUpdateWUInternal &cg) { return cg.getEGPReferences(); });
 }
 
 // ----------------------------------------------------------------------------

--- a/src/genn/genn/customUpdateModels.cc
+++ b/src/genn/genn/customUpdateModels.cc
@@ -15,6 +15,7 @@ boost::uuids::detail::sha1::digest_type CustomUpdateModels::Base::getHashDigest(
 
     Utils::updateHash(getUpdateCode(), hash);
     Utils::updateHash(getVarRefs(), hash);
+    Utils::updateHash(getEGPRefs(), hash);
     return hash.get_digest();
 }
 //----------------------------------------------------------------------------
@@ -24,4 +25,5 @@ void CustomUpdateModels::Base::validate() const
     Models::Base::validate();
 
     Utils::validateVecNames(getVarRefs(), "Variable reference");
+    Utils::validateVecNames(getEGPRefs(), "Extra global parameter reference");
 }

--- a/src/genn/genn/customUpdateModels.cc
+++ b/src/genn/genn/customUpdateModels.cc
@@ -24,6 +24,14 @@ void CustomUpdateModels::Base::validate() const
     // Superclass
     Models::Base::validate();
 
+    const auto egpRefs = getEGPRefs();
     Utils::validateVecNames(getVarRefs(), "Variable reference");
-    Utils::validateVecNames(getEGPRefs(), "Extra global parameter reference");
+    Utils::validateVecNames(egpRefs, "Extra global parameter reference");
+
+    // If any EGP references have non-pointer type, give error
+    if (std::any_of(egpRefs.cbegin(), egpRefs.cend(),
+                    [](const Models::Base::EGPRef &e) { return !Utils::isTypePointer(e.type); }))
+    {
+        throw std::runtime_error("Extra global parameter references can only be used with pointer EGPs");
+    }
 }

--- a/src/genn/genn/customUpdateModels.cc
+++ b/src/genn/genn/customUpdateModels.cc
@@ -15,7 +15,7 @@ boost::uuids::detail::sha1::digest_type CustomUpdateModels::Base::getHashDigest(
 
     Utils::updateHash(getUpdateCode(), hash);
     Utils::updateHash(getVarRefs(), hash);
-    Utils::updateHash(getEGPRefs(), hash);
+    Utils::updateHash(getExtraGlobalParamRefs(), hash);
     return hash.get_digest();
 }
 //----------------------------------------------------------------------------
@@ -24,7 +24,7 @@ void CustomUpdateModels::Base::validate() const
     // Superclass
     Models::Base::validate();
 
-    const auto egpRefs = getEGPRefs();
+    const auto egpRefs = getExtraGlobalParamRefs();
     Utils::validateVecNames(getVarRefs(), "Variable reference");
     Utils::validateVecNames(egpRefs, "Extra global parameter reference");
 

--- a/src/genn/genn/models.cc
+++ b/src/genn/genn/models.cc
@@ -255,3 +255,9 @@ void Models::updateHash(const WUVarReference &v, boost::uuids::detail::sha1 &has
         Utils::updateHash(v.getTransposeVarIndex(), hash);
     }
 }
+//----------------------------------------------------------------------------
+void Models::updateHash(const EGPReference &v, boost::uuids::detail::sha1 &hash)
+{
+    Utils::updateHash(v.getTargetName(), hash);
+    Utils::updateHash(v.getEGPIndex(), hash);
+}

--- a/src/genn/genn/models.cc
+++ b/src/genn/genn/models.cc
@@ -177,6 +177,47 @@ const SynapseGroup *WUVarReference::getTransposeSynapseGroup() const
 { 
     return m_TransposeSG; 
 }
+
+//----------------------------------------------------------------------------
+// EGPReference
+//----------------------------------------------------------------------------
+EGPReference EGPReference::createEGPRef(const NeuronGroup *ng, const std::string &egpName)
+{
+    const auto *nm = ng->getNeuronModel();
+    return EGPReference(nm->getExtraGlobalParamIndex(egpName), nm->getExtraGlobalParams(), ng->getName());
+}
+//----------------------------------------------------------------------------
+EGPReference EGPReference::createEGPRef(const CurrentSource *cs, const std::string &egpName)
+{
+    const auto *cm = cs->getCurrentSourceModel();
+    return EGPReference(cm->getExtraGlobalParamIndex(egpName), cm->getExtraGlobalParams(), cs->getName());
+}
+//----------------------------------------------------------------------------
+EGPReference EGPReference::createEGPRef(const CustomUpdate *cu, const std::string &egpName)
+{
+    const auto *cm = cu->getCustomUpdateModel();
+    return EGPReference(cm->getExtraGlobalParamIndex(egpName), cm->getExtraGlobalParams(), cu->getName());
+}
+//----------------------------------------------------------------------------
+EGPReference EGPReference::createEGPRef(const CustomUpdateWU *cu, const std::string &egpName)
+{
+    const auto *cm = cu->getCustomUpdateModel();
+    return EGPReference(cm->getExtraGlobalParamIndex(egpName), cm->getExtraGlobalParams(), cu->getName());
+}
+//----------------------------------------------------------------------------
+EGPReference EGPReference::createPSMEGPRef(const SynapseGroup *sg, const std::string &egpName)
+{
+    const auto *psm = sg->getPSModel();
+    return EGPReference(psm->getExtraGlobalParamIndex(egpName), psm->getExtraGlobalParams(), sg->getName());
+}
+//----------------------------------------------------------------------------
+EGPReference EGPReference::createWUEGPRef(const SynapseGroup *sg, const std::string &egpName)
+{
+    const auto *wum = sg->getWUModel();
+    return EGPReference(wum->getExtraGlobalParamIndex(egpName), wum->getExtraGlobalParams(), sg->getName());
+}
+//----------------------------------------------------------------------------
+
 //----------------------------------------------------------------------------
 void Models::updateHash(const Base::Var &v, boost::uuids::detail::sha1 &hash)
 {
@@ -190,6 +231,12 @@ void Models::updateHash(const Base::VarRef &v, boost::uuids::detail::sha1 &hash)
     Utils::updateHash(v.name, hash);
     Utils::updateHash(v.type, hash);
     Utils::updateHash(v.access, hash);
+}
+//----------------------------------------------------------------------------
+void Models::updateHash(const Base::EGPRef &e, boost::uuids::detail::sha1 &hash)
+{
+    Utils::updateHash(e.name, hash);
+    Utils::updateHash(e.type, hash);
 }
 //----------------------------------------------------------------------------
 void Models::updateHash(const VarReference &v, boost::uuids::detail::sha1 &hash)


### PR DESCRIPTION
My per-timestep EventProp loss implementation required extra global parameters to be shared between a neuron group and a custom update which, as we have talked for a while, is not an uncommon requirement. However, all my attempts to design some sort of extra global parameter sharing system ended up looking very messy so, instead, here I added the ability to reference extra global parameters in custom updates. This is:
- Simple - the existing system for updating pointers in merged groups can handle it without modification so it's totally transparent to the lower levels of GeNN
- Familiar - the syntax is almost identical to variable references so 
- Safer - by forcing custom updates to be involved, it discourages users from trying to use these to connect neuron groups together in weird ways that will probably fail silently and not-deterministically

TODO: tests