### PR TITLE
Small constant cache fix

### DIFF
--- a/src/genn/backends/cuda/backend.cc
+++ b/src/genn/backends/cuda/backend.cc
@@ -1992,6 +1992,7 @@ Backend::MemorySpaces Backend::getMergedGroupMemorySpaces(const ModelSpecMerged 
 {
     // Get size of update group start ids (constant cache is precious so don't use for init groups
     const size_t groupStartIDSize = (getGroupStartIDSize(modelMerged.getMergedNeuronUpdateGroups()) +
+                                     getGroupStartIDSize(modelMerged.getMergedNeuronPrevSpikeTimeUpdateGroups()) +
                                      getGroupStartIDSize(modelMerged.getMergedPresynapticUpdateGroups()) +
                                      getGroupStartIDSize(modelMerged.getMergedPostsynapticUpdateGroups()) +
                                      getGroupStartIDSize(modelMerged.getMergedSynapseDynamicsGroups()) +


### PR DESCRIPTION
When I fixed a race condition in the system for tracking neuron's _previous_ spike time in #414, I added a new kernel which had an associated new array of indices used for the binary search amongst merged groups.  Because of the memory access pattern of the binary search, these take first priority when the 64KB of constant cache is handed out. However, I forgot to take these indices into account, meaning that models with lots of neuron and synapse groups and learning rules using previous spike times could overrun the constant cache.

Fixes #588