### PR TITLE
Setuptools fix

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -235,7 +235,6 @@ for(b = 0; b < builderNodes.size(); b++) {
 
                             python setup.py clean --all
                             python setup.py bdist_wheel -d . 1>> "${uniqueMsg}" 2>> "${uniqueMsg}"
-                            python setup.py bdist_wheel -d . 1>> "${uniqueMsg}" 2>> "${uniqueMsg}"
                             """
 
                             def wheelStatusCode = sh script:script, returnStatus:true


### PR DESCRIPTION
First of all, massive thanks to @erolm-a for this one! The problem was that the standard setuptools build step collects python modules to include _before_ building extensions which is bad because SWIG generates python modules as part of building extensions! This solves this by simply re-ordering the sub-commands within the setuptools build command. I have fixed this for GeNN 5 by getting rid of SWIG but GeNN 4 seems to be malingering so this is very helpful!

Fixes #590 
Fixed #310
