### PR TITLE
Create Docker wheel builder

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,8 +17,8 @@ ENV CUDA_PATH=/usr/local/cuda \
     GENN_PATH=/opt/genn
 
 # Upgrade pip itself and install numpy and jupyter
-RUN pip install --upgrade pip && \
-    pip install numpy jupyter matplotlib
+RUN python -m pip install --upgrade pip && \
+    python -m pip install numpy jupyter matplotlib
 
 # Copy GeNN into /opt
 COPY  . ${GENN_PATH}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,29 +1,24 @@
 ARG BASE=11.5.0-devel-ubuntu20.04
 FROM nvidia/cuda:${BASE}
 
-LABEL maintainer="J.C.Knight@sussex.ac.uk"
-LABEL version="4.8.0"
-LABEL org.opencontainers.image.documentation="https://genn-team.github.io/"
-LABEL org.opencontainers.image.source="https://github.com/genn-team/genn"
-LABEL org.opencontainers.image.title="GeNN Docker image"
+LABEL maintainer="J.C.Knight@sussex.ac.uk" \
+    version="4.8.0" \
+    org.opencontainers.image.documentation="https://genn-team.github.io/" \
+    org.opencontainers.image.source="https://github.com/genn-team/genn" \
+    org.opencontainers.image.title="GeNN Docker image"
 
-# Update APT database and upgrade any outdated packages
+# Update APT database and upgrade any outdated packages and install Python, pip and swig
 RUN apt-get update && \
-    apt-get upgrade -y
+    apt-get upgrade -y &&\
+    apt-get install -yq --no-install-recommends python3-dev python3-pip swig gosu nano
 
-# Install Python, pip and swig
-RUN apt-get install -yq --no-install-recommends python3-dev python3-pip swig gosu nano
+# Set environment variables
+ENV CUDA_PATH=/usr/local/cuda \
+    GENN_PATH=/opt/genn
 
-# Set CUDA environment variable
-ENV CUDA_PATH=/usr/local/cuda
-
-ENV GENN_PATH=/opt/genn
-
-# Upgrade pip itself
-RUN pip install --upgrade pip
-
-# Install numpy and jupyter
-RUN pip install numpy jupyter matplotlib
+# Upgrade pip itself and install numpy and jupyter
+RUN pip install --upgrade pip && \
+    pip install numpy jupyter matplotlib
 
 # Copy GeNN into /opt
 COPY  . ${GENN_PATH}
@@ -36,9 +31,9 @@ RUN make install -j `lscpu -p | egrep -v '^#' | sort -u -t, -k 2,4 | wc -l`
 RUN make DYNAMIC=1 LIBRARY_DIRECTORY=${GENN_PATH}/pygenn/genn_wrapper/ -j `lscpu -p | egrep -v '^#' | sort -u -t, -k 2,4 | wc -l`
 RUN python3 setup.py develop
 
-# Default command will be to launch bash
-CMD ["/bin/bash"]
-
 # Start entrypoint
 # **NOTE** in 'exec' mode shell arguments aren't expanded so can't use environment variables
 ENTRYPOINT ["/opt/genn/bin/genn-docker-entrypoint.sh"]
+
+# Default command will be to launch bash
+CMD ["/bin/bash"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,19 +9,22 @@ LABEL maintainer="J.C.Knight@sussex.ac.uk" \
 
 # Update APT database and upgrade any outdated packages and install Python, pip and swig
 RUN apt-get update && \
-    apt-get upgrade -y &&\
+    apt-get upgrade -y && \
     apt-get install -yq --no-install-recommends python3-dev python3-pip swig gosu nano
 
 # Set environment variables
 ENV CUDA_PATH=/usr/local/cuda \
     GENN_PATH=/opt/genn
 
+# Set python3 to be the dfault version of python
+RUN update-alternatives --install /usr/bin/python python /usr/bin/python3 1
+
 # Upgrade pip itself and install numpy and jupyter
 RUN python -m pip install --upgrade pip && \
     python -m pip install numpy jupyter matplotlib
 
 # Copy GeNN into /opt
-COPY  . ${GENN_PATH}
+COPY . ${GENN_PATH}
 
 # Use this as working directory
 WORKDIR ${GENN_PATH}
@@ -29,7 +32,7 @@ WORKDIR ${GENN_PATH}
 # Install GeNN and PyGeNN
 RUN make install -j `lscpu -p | egrep -v '^#' | sort -u -t, -k 2,4 | wc -l`
 RUN make DYNAMIC=1 LIBRARY_DIRECTORY=${GENN_PATH}/pygenn/genn_wrapper/ -j `lscpu -p | egrep -v '^#' | sort -u -t, -k 2,4 | wc -l`
-RUN python3 setup.py develop
+RUN python setup.py develop
 
 # Start entrypoint
 # **NOTE** in 'exec' mode shell arguments aren't expanded so can't use environment variables

--- a/Dockerfile.builder
+++ b/Dockerfile.builder
@@ -7,17 +7,18 @@ LABEL maintainer="J.C.Knight@sussex.ac.uk" \
     org.opencontainers.image.source="https://github.com/genn-team/genn" \
     org.opencontainers.image.title="GeNN Docker image"
 
+ARG PY_VER=3.11
 # Update APT database and upgrade any outdated packages and install Python, pip and swig
 RUN apt-get update && \
     apt-get upgrade -y &&\
-    apt-get install -yq --no-install-recommends python3-dev python3-pip swig
+    apt-get install -yq --no-install-recommends python${PY_VER}-dev python{PY_VER}-pip swig
 
 # Set environment variables
 ENV CUDA_PATH=/usr/local/cuda \
     GENN_PATH=/opt/genn
 
 # Set python3 to be the dfault version of python
-RUN update-alternatives --install /usr/bin/python python /usr/bin/python3 1
+RUN update-alternatives --install /usr/bin/python python /usr/bin/python${PY_VER} 1
 
 # Upgrade pip itself and install numpy
 RUN python -m pip install --upgrade pip && \

--- a/Dockerfile.builder
+++ b/Dockerfile.builder
@@ -7,12 +7,11 @@ LABEL maintainer="J.C.Knight@sussex.ac.uk" \
     org.opencontainers.image.source="https://github.com/genn-team/genn" \
     org.opencontainers.image.title="GeNN Docker image"
 
-RUN add-apt-repository ppa:deadsnakes/ppa
 ARG PY_VER=3.11
 # Update APT database and upgrade any outdated packages and install Python, pip and swig
 RUN apt-get update && \
-    apt-get upgrade -y &&\
-    apt-get install -yq --no-install-recommends python${PY_VER}-dev python{PY_VER}-pip swig
+    apt-get upgrade -y && \
+    apt-get install -yq --no-install-recommends python${PY_VER}-dev python3-pip swig
 
 # Set environment variables
 ENV CUDA_PATH=/usr/local/cuda \
@@ -21,13 +20,12 @@ ENV CUDA_PATH=/usr/local/cuda \
 # Set python3 to be the dfault version of python
 RUN update-alternatives --install /usr/bin/python python /usr/bin/python${PY_VER} 1
 
-RUN python -m ensurepip
 # Upgrade pip itself and install numpy
 RUN python -m pip install --upgrade pip && \
     python -m pip install numpy
 
 # Copy GeNN into /opt
-COPY  . ${GENN_PATH}
+COPY . ${GENN_PATH}
 
 # Use this as working directory
 WORKDIR ${GENN_PATH}

--- a/Dockerfile.builder
+++ b/Dockerfile.builder
@@ -1,0 +1,38 @@
+ARG BASE=12.2.0-devel-ubuntu22.04
+FROM nvidia/cuda:${BASE} AS build
+
+LABEL maintainer="J.C.Knight@sussex.ac.uk" \
+    version="4.8.1" \
+    org.opencontainers.image.documentation="https://genn-team.github.io/" \
+    org.opencontainers.image.source="https://github.com/genn-team/genn" \
+    org.opencontainers.image.title="GeNN Docker image"
+
+# Update APT database and upgrade any outdated packages and install Python, pip and swig
+RUN apt-get update && \
+    apt-get upgrade -y &&\
+    apt-get install -yq --no-install-recommends python3-dev python3-pip swig
+
+# Set environment variables
+ENV CUDA_PATH=/usr/local/cuda \
+    GENN_PATH=/opt/genn
+
+# Upgrade pip itself and install numpy and jupyter
+RUN python -m pip install --upgrade pip
+    # pip install numpy
+
+# Copy GeNN into /opt
+COPY  . ${GENN_PATH}
+
+# Use this as working directory
+WORKDIR ${GENN_PATH}
+
+# Install GeNN and PyGeNN
+RUN make install -j `lscpu -p | egrep -v '^#' | sort -u -t, -k 2,4 | wc -l`
+RUN make DYNAMIC=1 LIBRARY_DIRECTORY=${GENN_PATH}/pygenn/genn_wrapper/ -j `lscpu -p | egrep -v '^#' | sort -u -t, -k 2,4 | wc -l`
+# RUN python3 setup.py develop
+RUN python setup.py bdist_wheel
+RUN python setup.py bdist_wheel
+
+# Copy the wheel to a new image for extraction
+FROM scratch AS output
+COPY --from=build $(GENN_PATH)/dist/*.whl /

--- a/Dockerfile.builder
+++ b/Dockerfile.builder
@@ -7,6 +7,7 @@ LABEL maintainer="J.C.Knight@sussex.ac.uk" \
     org.opencontainers.image.source="https://github.com/genn-team/genn" \
     org.opencontainers.image.title="GeNN Docker image"
 
+RUN add-apt-repository ppa:deadsnakes/ppa
 ARG PY_VER=3.11
 # Update APT database and upgrade any outdated packages and install Python, pip and swig
 RUN apt-get update && \
@@ -20,6 +21,7 @@ ENV CUDA_PATH=/usr/local/cuda \
 # Set python3 to be the dfault version of python
 RUN update-alternatives --install /usr/bin/python python /usr/bin/python${PY_VER} 1
 
+RUN python -m ensurepip
 # Upgrade pip itself and install numpy
 RUN python -m pip install --upgrade pip && \
     python -m pip install numpy

--- a/Dockerfile.builder
+++ b/Dockerfile.builder
@@ -16,9 +16,12 @@ RUN apt-get update && \
 ENV CUDA_PATH=/usr/local/cuda \
     GENN_PATH=/opt/genn
 
-# Upgrade pip itself and install numpy and jupyter
-RUN python -m pip install --upgrade pip
-    # pip install numpy
+# Set python3 to be the dfault version of python
+RUN update-alternatives --install /usr/bin/python python /usr/bin/python3 1
+
+# Upgrade pip itself and install numpy
+RUN python -m pip install --upgrade pip && \
+    python -m pip install numpy
 
 # Copy GeNN into /opt
 COPY  . ${GENN_PATH}
@@ -33,6 +36,10 @@ RUN make DYNAMIC=1 LIBRARY_DIRECTORY=${GENN_PATH}/pygenn/genn_wrapper/ -j `lscpu
 RUN python setup.py bdist_wheel
 RUN python setup.py bdist_wheel
 
+RUN echo ${GENN_PATH}
 # Copy the wheel to a new image for extraction
 FROM scratch AS output
-COPY --from=build $(GENN_PATH)/dist/*.whl /
+# TODO: Find a workaround for broken variable expansion
+#ARG GENN_PATH
+#COPY --from=build ${GENN_PATH}/dist/*.whl /
+COPY --from=build /opt/genn/dist/*.whl /

--- a/Makefile
+++ b/Makefile
@@ -76,6 +76,7 @@ docker-build:
 
 # pygenn-4.8.1-cp311-cp311-linux_x86_64.whl
 BASE := 12.2.0-devel-ubuntu22.04
+.PHONY wheel:
 # wheel:
 # 	@docker build -t genn:builder --build-arg BASE=$(BASE) -f Dockerfile.builder .
 # 	@docker create --name output genn:builder
@@ -83,4 +84,4 @@ BASE := 12.2.0-devel-ubuntu22.04
 
 wheel:
 	@docker build --build-arg BASE=$(BASE) -f Dockerfile.builder \
-		--target=output --output type=local,dest=$(pwd)/dist/ .
+		--target=output --output type=local,dest=dist/ .

--- a/Makefile
+++ b/Makefile
@@ -76,6 +76,7 @@ docker-build:
 
 # pygenn-4.8.1-cp311-cp311-linux_x86_64.whl
 BASE := 12.2.0-devel-ubuntu22.04
+PY_VER := 3.11
 .PHONY wheel:
 # wheel:
 # 	@docker build -t genn:builder --build-arg BASE=$(BASE) -f Dockerfile.builder .
@@ -83,5 +84,7 @@ BASE := 12.2.0-devel-ubuntu22.04
 # 	@docker cp output:$(GENN_DIR)/dist/pygenn-*.whl .
 
 wheel:
-	@docker build --build-arg BASE=$(BASE) -f Dockerfile.builder \
+	@docker build -f Dockerfile.builder \
+		--build-arg BASE=$(BASE) \
+		--build-arg PY_VER=$(PY_VER) \
 		--target=output --output type=local,dest=dist/ .

--- a/Makefile
+++ b/Makefile
@@ -73,3 +73,14 @@ clean:
 .PHONY docker-build:
 docker-build:
 	@docker build -t genn:latest .
+
+# pygenn-4.8.1-cp311-cp311-linux_x86_64.whl
+BASE := 12.2.0-devel-ubuntu22.04
+# wheel:
+# 	@docker build -t genn:builder --build-arg BASE=$(BASE) -f Dockerfile.builder .
+# 	@docker create --name output genn:builder
+# 	@docker cp output:$(GENN_DIR)/dist/pygenn-*.whl .
+
+wheel:
+	@docker build --build-arg BASE=$(BASE) -f Dockerfile.builder \
+		--target=output --output type=local,dest=$(pwd)/dist/ .


### PR DESCRIPTION
This adds `Dockerfile.builder` and a Makefile target (`make wheel`) to cleanly build python wheels within a Docker container. The versions of CUDA and Python can be specified by passing build arguments. 