### PR TITLE
Step 2 - Variable dimensions

### DIFF
--- a/include/genn/backends/cuda/backend.h
+++ b/include/genn/backends/cuda/backend.h
@@ -383,7 +383,7 @@ private:
             const auto *cm = cg.getArchetype().getCustomUpdateModel();
             for(const auto &v : cm->getVars()) {
                 // If variable is reduction target
-                if(v.access & VarAccessModeAttribute::REDUCE) {
+                if(v.getAccessMode() & VarAccessModeAttribute::REDUCE) {
                     // Add pointer field
                     const auto resolvedType = v.type.resolve(cg.getTypeContext());
                     groupEnv.addField(resolvedType.createPointer(), "_" + v.name, v.name,
@@ -394,7 +394,7 @@ private:
                     
                     // Add NCCL reduction
                     groupEnv.print("CHECK_NCCL_ERRORS(ncclAllReduce($(_" + v.name + "), $(_" + v.name + "), $(_size)");
-                    groupEnv.printLine(", " + getNCCLType(resolvedType) + ", " + getNCCLReductionType(getVarAccessMode(v.access)) + ", ncclCommunicator, 0));");
+                    groupEnv.printLine(", " + getNCCLType(resolvedType) + ", " + getNCCLReductionType(v.getAccessMode()) + ", ncclCommunicator, 0));");
                 }
             }
 

--- a/include/genn/backends/cuda/backend.h
+++ b/include/genn/backends/cuda/backend.h
@@ -383,7 +383,7 @@ private:
             const auto *cm = cg.getArchetype().getCustomUpdateModel();
             for(const auto &v : cm->getVars()) {
                 // If variable is reduction target
-                if(v.getAccessMode() & VarAccessModeAttribute::REDUCE) {
+                if(v.access & VarAccessModeAttribute::REDUCE) {
                     // Add pointer field
                     const auto resolvedType = v.type.resolve(cg.getTypeContext());
                     groupEnv.addField(resolvedType.createPointer(), "_" + v.name, v.name,
@@ -394,7 +394,7 @@ private:
                     
                     // Add NCCL reduction
                     groupEnv.print("CHECK_NCCL_ERRORS(ncclAllReduce($(_" + v.name + "), $(_" + v.name + "), $(_size)");
-                    groupEnv.printLine(", " + getNCCLType(resolvedType) + ", " + getNCCLReductionType(v.getAccessMode()) + ", ncclCommunicator, 0));");
+                    groupEnv.printLine(", " + getNCCLType(resolvedType) + ", " + getNCCLReductionType(v.access) + ", ncclCommunicator, 0));");
                 }
             }
 

--- a/include/genn/backends/single_threaded_cpu/backend.h
+++ b/include/genn/backends/single_threaded_cpu/backend.h
@@ -246,7 +246,7 @@ private:
     /*! Because reduction operations are unnecessary in unbatched single-threaded CPU models so there's no need to actually reduce */
     void genWriteBackReductions(EnvironmentExternalBase &env, CustomUpdateWUGroupMergedBase &cg, const std::string &idxName) const;
 
-    template<typename A, typename G, typename R>
+    template<typename G, typename R>
     void genWriteBackReductions(EnvironmentExternalBase &env, G &cg, const std::string &idxName, R getVarRefIndexFn) const
     {
         const auto *cm = cg.getArchetype().getCustomUpdateModel();
@@ -254,7 +254,9 @@ private:
             // If variable is a reduction target, copy value from register straight back into global memory
             if(v.access & VarAccessModeAttribute::REDUCE) {
                 const std::string idx = env.getName(idxName);
-                env.getStream() << "group->" << v.name << "[" << cg.getVarIndex(1, v.access.template getDims<A>(), idx) << "] = " << env[v.name] << ";" << std::endl;
+                const VarAccessDim varAccessDim = clearDim(cg.getArchetype().getDims(), 
+                                                           v.access.template getDims<CustomUpdateVarAccess>());
+                env.getStream() << "group->" << v.name << "[" << cg.getVarIndex(1, varAccessDim, idx) << "] = " << env[v.name] << ";" << std::endl;
             }
         }
 

--- a/include/genn/backends/single_threaded_cpu/backend.h
+++ b/include/genn/backends/single_threaded_cpu/backend.h
@@ -252,9 +252,10 @@ private:
         const auto *cm = cg.getArchetype().getCustomUpdateModel();
         for(const auto &v : cm->getVars()) {
             // If variable is a reduction target, copy value from register straight back into global memory
-            if(v.access & VarAccessModeAttribute::REDUCE) {
+            const unsigned int varAccess = v.getAccess(VarAccess::READ_WRITE);
+            if(varAccess & VarAccessModeAttribute::REDUCE) {
                 const std::string idx = env.getName(idxName);
-                env.getStream() << "group->" << v.name << "[" << cg.getVarIndex(getVarAccessDuplication(v.access), idx) << "] = " << env[v.name] << ";" << std::endl;
+                env.getStream() << "group->" << v.name << "[" << cg.getVarIndex(getVarAccessDuplication(varAccess), idx) << "] = " << env[v.name] << ";" << std::endl;
             }
         }
 

--- a/include/genn/backends/single_threaded_cpu/backend.h
+++ b/include/genn/backends/single_threaded_cpu/backend.h
@@ -254,7 +254,7 @@ private:
             // If variable is a reduction target, copy value from register straight back into global memory
             if(v.access & VarAccessModeAttribute::REDUCE) {
                 const std::string idx = env.getName(idxName);
-                env.getStream() << "group->" << v.name << "[" << cg.getVarIndex(v.access.template getDims<A>(), idx) << "] = " << env[v.name] << ";" << std::endl;
+                env.getStream() << "group->" << v.name << "[" << cg.getVarIndex(1, v.access.template getDims<A>(), idx) << "] = " << env[v.name] << ";" << std::endl;
             }
         }
 

--- a/include/genn/backends/single_threaded_cpu/backend.h
+++ b/include/genn/backends/single_threaded_cpu/backend.h
@@ -255,7 +255,7 @@ private:
             const unsigned int varAccess = v.getAccess(VarAccess::READ_WRITE);
             if(varAccess & VarAccessModeAttribute::REDUCE) {
                 const std::string idx = env.getName(idxName);
-                env.getStream() << "group->" << v.name << "[" << cg.getVarIndex(getVarAccessDuplication(varAccess), idx) << "] = " << env[v.name] << ";" << std::endl;
+                env.getStream() << "group->" << v.name << "[" << cg.getVarIndex(getVarAccessDim(varAccess), idx) << "] = " << env[v.name] << ";" << std::endl;
             }
         }
 

--- a/include/genn/backends/single_threaded_cpu/backend.h
+++ b/include/genn/backends/single_threaded_cpu/backend.h
@@ -254,7 +254,7 @@ private:
             // If variable is a reduction target, copy value from register straight back into global memory
             if(v.access & VarAccessModeAttribute::REDUCE) {
                 const std::string idx = env.getName(idxName);
-                env.getStream() << "group->" << v.name << "[" << cg.getVarIndex(v.access.getDims<A>(), idx) << "] = " << env[v.name] << ";" << std::endl;
+                env.getStream() << "group->" << v.name << "[" << cg.getVarIndex(v.access.template getDims<A>(), idx) << "] = " << env[v.name] << ";" << std::endl;
             }
         }
 

--- a/include/genn/backends/single_threaded_cpu/backend.h
+++ b/include/genn/backends/single_threaded_cpu/backend.h
@@ -246,16 +246,15 @@ private:
     /*! Because reduction operations are unnecessary in unbatched single-threaded CPU models so there's no need to actually reduce */
     void genWriteBackReductions(EnvironmentExternalBase &env, CustomUpdateWUGroupMergedBase &cg, const std::string &idxName) const;
 
-    template<typename G, typename R>
+    template<typename A, typename G, typename R>
     void genWriteBackReductions(EnvironmentExternalBase &env, G &cg, const std::string &idxName, R getVarRefIndexFn) const
     {
         const auto *cm = cg.getArchetype().getCustomUpdateModel();
         for(const auto &v : cm->getVars()) {
             // If variable is a reduction target, copy value from register straight back into global memory
-            const unsigned int varAccess = v.getAccess(VarAccess::READ_WRITE);
-            if(varAccess & VarAccessModeAttribute::REDUCE) {
+            if(v.access & VarAccessModeAttribute::REDUCE) {
                 const std::string idx = env.getName(idxName);
-                env.getStream() << "group->" << v.name << "[" << cg.getVarIndex(getVarAccessDim(varAccess), idx) << "] = " << env[v.name] << ";" << std::endl;
+                env.getStream() << "group->" << v.name << "[" << cg.getVarIndex(v.access.getDims<A>(), idx) << "] = " << env[v.name] << ";" << std::endl;
             }
         }
 

--- a/include/genn/genn/code_generator/backendBase.h
+++ b/include/genn/genn/code_generator/backendBase.h
@@ -568,10 +568,10 @@ private:
         const auto *cm = cg.getArchetype().getCustomUpdateModel();
         for (const auto &v : cm->getVars()) {
             // If variable is a reduction target, define variable initialised to correct initial value for reduction
-            const unsigned int varAccess = v.access.value_or(static_cast<unsigned int>(VarAccess::READ_WRITE)); 
+            const unsigned int varAccess = v.getAccess(VarAccess::READ_WRITE); 
             if (varAccess & VarAccessModeAttribute::REDUCE) {
                 const auto resolvedType = v.type.resolve(cg.getTypeContext());
-                os << resolvedType.getName() << " _lr" << v.name << " = " << getReductionInitialValue(getVarAccessMode(v.access), resolvedType) << ";" << std::endl;
+                os << resolvedType.getName() << " _lr" << v.name << " = " << getReductionInitialValue(getVarAccessMode(varAccess), resolvedType) << ";" << std::endl;
                 reductionTargets.push_back({v.name, resolvedType, getVarAccessMode(varAccess),
                                             cg.getVarIndex(getVarAccessDuplication(varAccess), idx)});
             }

--- a/include/genn/genn/code_generator/backendBase.h
+++ b/include/genn/genn/code_generator/backendBase.h
@@ -573,7 +573,7 @@ private:
                 const auto resolvedType = v.type.resolve(cg.getTypeContext());
                 os << resolvedType.getName() << " _lr" << v.name << " = " << getReductionInitialValue(v.access, resolvedType) << ";" << std::endl;
                 reductionTargets.push_back({v.name, resolvedType, v.access,
-                                            cg.getVarIndex(v.access.getDims<A>(), idx)});
+                                            cg.getVarIndex(v.access.template getDims<A>(), idx)});
             }
         }
 

--- a/include/genn/genn/code_generator/backendBase.h
+++ b/include/genn/genn/code_generator/backendBase.h
@@ -495,16 +495,16 @@ public:
     void buildStandardEnvironment(EnvironmentGroupMergedField<PostsynapticUpdateGroupMerged> &env, unsigned int batchSize) const;
     void buildStandardEnvironment(EnvironmentGroupMergedField<SynapseDynamicsGroupMerged> &env, unsigned int batchSize) const;
     void buildStandardEnvironment(EnvironmentGroupMergedField<SynapseDendriticDelayUpdateGroupMerged> &env, unsigned int batchSize) const;
-    void buildStandardEnvironment(EnvironmentGroupMergedField<CustomUpdateGroupMerged> &env) const;
-    void buildStandardEnvironment(EnvironmentGroupMergedField<CustomUpdateWUGroupMerged> &env) const;
-    void buildStandardEnvironment(EnvironmentGroupMergedField<CustomUpdateTransposeWUGroupMerged> &env) const;
+    void buildStandardEnvironment(EnvironmentGroupMergedField<CustomUpdateGroupMerged> &env, unsigned int batchSize) const;
+    void buildStandardEnvironment(EnvironmentGroupMergedField<CustomUpdateWUGroupMerged> &env, unsigned int batchSize) const;
+    void buildStandardEnvironment(EnvironmentGroupMergedField<CustomUpdateTransposeWUGroupMerged> &env, unsigned int batchSize) const;
     void buildStandardEnvironment(EnvironmentGroupMergedField<CustomConnectivityUpdateGroupMerged> &env) const;
 
     void buildStandardEnvironment(EnvironmentGroupMergedField<NeuronInitGroupMerged> &env, unsigned int batchSize) const;
     void buildStandardEnvironment(EnvironmentGroupMergedField<SynapseInitGroupMerged> &env, unsigned int batchSize) const;
-    void buildStandardEnvironment(EnvironmentGroupMergedField<CustomUpdateInitGroupMerged> &env) const;
-    void buildStandardEnvironment(EnvironmentGroupMergedField<CustomWUUpdateInitGroupMerged> &env) const;
-    void buildStandardEnvironment(EnvironmentGroupMergedField<CustomWUUpdateSparseInitGroupMerged> &env) const;
+    void buildStandardEnvironment(EnvironmentGroupMergedField<CustomUpdateInitGroupMerged> &env, unsigned int batchSize) const;
+    void buildStandardEnvironment(EnvironmentGroupMergedField<CustomWUUpdateInitGroupMerged> &env, unsigned int batchSize) const;
+    void buildStandardEnvironment(EnvironmentGroupMergedField<CustomWUUpdateSparseInitGroupMerged> &env, unsigned int batchSize) const;
     void buildStandardEnvironment(EnvironmentGroupMergedField<CustomConnectivityUpdatePreInitGroupMerged> &env) const;
     void buildStandardEnvironment(EnvironmentGroupMergedField<CustomConnectivityUpdatePostInitGroupMerged> &env) const;
     void buildStandardEnvironment(EnvironmentGroupMergedField<SynapseSparseInitGroupMerged> &env, unsigned int batchSize) const;
@@ -550,19 +550,21 @@ protected:
 
     //! Helper function to generate initialisation code for any reduction operations carried out be custom update group.
     //! Returns vector of ReductionTarget structs, providing all information to write back reduction results to memory
-    std::vector<ReductionTarget> genInitReductionTargets(CodeStream &os, const CustomUpdateGroupMerged &cg, const std::string &idx = "") const;
+    std::vector<ReductionTarget> genInitReductionTargets(CodeStream &os, const CustomUpdateGroupMerged &cg, 
+                                                         unsigned int batchSize, const std::string &idx = "") const;
 
     //! Helper function to generate initialisation code for any reduction operations carried out be custom weight update group.
     //! //! Returns vector of ReductionTarget structs, providing all information to write back reduction results to memory
-    std::vector<ReductionTarget> genInitReductionTargets(CodeStream &os, const CustomUpdateWUGroupMerged &cg, const std::string &idx = "") const;
+    std::vector<ReductionTarget> genInitReductionTargets(CodeStream &os, const CustomUpdateWUGroupMerged &cg, 
+                                                         unsigned int batchSize, const std::string &idx = "") const;
 
 private:
     //--------------------------------------------------------------------------
     // Private API
     //--------------------------------------------------------------------------
     template<typename A, typename G, typename R>
-    std::vector<ReductionTarget> genInitReductionTargets(CodeStream &os, const G &cg, const std::string &idx, 
-                                                         R getVarRefIndexFn) const
+    std::vector<ReductionTarget> genInitReductionTargets(CodeStream &os, const G &cg, unsigned int batchSize, 
+                                                         const std::string &idx, R getVarRefIndexFn) const
     {
         // Loop through variables
         std::vector<ReductionTarget> reductionTargets;
@@ -573,7 +575,7 @@ private:
                 const auto resolvedType = v.type.resolve(cg.getTypeContext());
                 os << resolvedType.getName() << " _lr" << v.name << " = " << getReductionInitialValue(v.access, resolvedType) << ";" << std::endl;
                 reductionTargets.push_back({v.name, resolvedType, v.access,
-                                            cg.getVarIndex(v.access.template getDims<A>(), idx)});
+                                            cg.getVarIndex(batchSize, v.access.template getDims<A>(), idx)});
             }
         }
 

--- a/include/genn/genn/code_generator/backendBase.h
+++ b/include/genn/genn/code_generator/backendBase.h
@@ -574,8 +574,10 @@ private:
             if (v.access & VarAccessModeAttribute::REDUCE) {
                 const auto resolvedType = v.type.resolve(cg.getTypeContext());
                 os << resolvedType.getName() << " _lr" << v.name << " = " << getReductionInitialValue(v.access, resolvedType) << ";" << std::endl;
+                const VarAccessDim varAccessDim = clearDim(cg.getArchetype().getDims(), 
+                                                           v.access.template getDims<CustomUpdateVarAccess>());
                 reductionTargets.push_back({v.name, resolvedType, v.access,
-                                            cg.getVarIndex(batchSize, v.access.template getDims<A>(), idx)});
+                                            cg.getVarIndex(batchSize, varAccessDim, idx)});
             }
         }
 

--- a/include/genn/genn/code_generator/backendBase.h
+++ b/include/genn/genn/code_generator/backendBase.h
@@ -568,11 +568,12 @@ private:
         const auto *cm = cg.getArchetype().getCustomUpdateModel();
         for (const auto &v : cm->getVars()) {
             // If variable is a reduction target, define variable initialised to correct initial value for reduction
-            if (v.access & VarAccessModeAttribute::REDUCE) {
+            const unsigned int varAccess = v.access.value_or(static_cast<unsigned int>(VarAccess::READ_WRITE)); 
+            if (varAccess & VarAccessModeAttribute::REDUCE) {
                 const auto resolvedType = v.type.resolve(cg.getTypeContext());
                 os << resolvedType.getName() << " _lr" << v.name << " = " << getReductionInitialValue(getVarAccessMode(v.access), resolvedType) << ";" << std::endl;
-                reductionTargets.push_back({v.name, resolvedType, getVarAccessMode(v.access),
-                                            cg.getVarIndex(getVarAccessDuplication(v.access), idx)});
+                reductionTargets.push_back({v.name, resolvedType, getVarAccessMode(varAccess),
+                                            cg.getVarIndex(getVarAccessDuplication(varAccess), idx)});
             }
         }
 

--- a/include/genn/genn/code_generator/backendBase.h
+++ b/include/genn/genn/code_generator/backendBase.h
@@ -560,20 +560,20 @@ private:
     //--------------------------------------------------------------------------
     // Private API
     //--------------------------------------------------------------------------
-    template<typename G, typename R>
-    std::vector<ReductionTarget> genInitReductionTargets(CodeStream &os, const G &cg, const std::string &idx, R getVarRefIndexFn) const
+    template<typename A, typename G, typename R>
+    std::vector<ReductionTarget> genInitReductionTargets(CodeStream &os, const G &cg, const std::string &idx, 
+                                                         R getVarRefIndexFn) const
     {
         // Loop through variables
         std::vector<ReductionTarget> reductionTargets;
         const auto *cm = cg.getArchetype().getCustomUpdateModel();
         for (const auto &v : cm->getVars()) {
             // If variable is a reduction target, define variable initialised to correct initial value for reduction
-            const unsigned int varAccess = v.getAccess(VarAccess::READ_WRITE); 
-            if (varAccess & VarAccessModeAttribute::REDUCE) {
+            if (v.access & VarAccessModeAttribute::REDUCE) {
                 const auto resolvedType = v.type.resolve(cg.getTypeContext());
-                os << resolvedType.getName() << " _lr" << v.name << " = " << getReductionInitialValue(getVarAccessMode(varAccess), resolvedType) << ";" << std::endl;
-                reductionTargets.push_back({v.name, resolvedType, getVarAccessMode(varAccess),
-                                            cg.getVarIndex(varAccess), idx)});
+                os << resolvedType.getName() << " _lr" << v.name << " = " << getReductionInitialValue(v.access, resolvedType) << ";" << std::endl;
+                reductionTargets.push_back({v.name, resolvedType, v.access,
+                                            cg.getVarIndex(v.access.getDims<A>(), idx)});
             }
         }
 

--- a/include/genn/genn/code_generator/backendBase.h
+++ b/include/genn/genn/code_generator/backendBase.h
@@ -573,7 +573,7 @@ private:
                 const auto resolvedType = v.type.resolve(cg.getTypeContext());
                 os << resolvedType.getName() << " _lr" << v.name << " = " << getReductionInitialValue(getVarAccessMode(varAccess), resolvedType) << ";" << std::endl;
                 reductionTargets.push_back({v.name, resolvedType, getVarAccessMode(varAccess),
-                                            cg.getVarIndex(getVarAccessDuplication(varAccess), idx)});
+                                            cg.getVarIndex(varAccess), idx)});
             }
         }
 

--- a/include/genn/genn/code_generator/customConnectivityUpdateGroupMerged.h
+++ b/include/genn/genn/code_generator/customConnectivityUpdateGroupMerged.h
@@ -94,7 +94,7 @@ private:
         for(const auto &v : archetypeAdaptor.getDefs()) {
             // If model isn't batched or variable isn't duplicated
             const auto &varRef = archetypeAdaptor.getInitialisers().at(v.name);
-            if(batchSize == 1 || !varRef.isDuplicated()) {
+            if(batchSize == 1 || !(varRef.getDims() & VarAccessDim::BATCH)) {
                 // Add field with qualified type which indexes private pointer field
                 const auto resolvedType = v.type.resolve(getTypeContext());
                 const auto qualifiedType = (v.access & VarAccessModeAttribute::READ_ONLY) ? resolvedType.addConst() : resolvedType;

--- a/include/genn/genn/code_generator/customConnectivityUpdateGroupMerged.h
+++ b/include/genn/genn/code_generator/customConnectivityUpdateGroupMerged.h
@@ -129,7 +129,7 @@ private:
         // Loop through variables
         for(const auto &v : vars) {
             const auto resolvedType = v.type.resolve(getTypeContext());
-            const auto qualifiedType = (v.access & VarAccessModeAttribute::READ_ONLY) ? resolvedType.addConst() : resolvedType;
+            const auto qualifiedType = (v.getAccessMode() & VarAccessModeAttribute::READ_ONLY) ? resolvedType.addConst() : resolvedType;
             env.define(Transpiler::Token{Transpiler::Token::Type::IDENTIFIER, v.name, 0}, qualifiedType, errorHandler);
         }
     }

--- a/include/genn/genn/code_generator/customConnectivityUpdateGroupMerged.h
+++ b/include/genn/genn/code_generator/customConnectivityUpdateGroupMerged.h
@@ -129,7 +129,7 @@ private:
         // Loop through variables
         for(const auto &v : vars) {
             const auto resolvedType = v.type.resolve(getTypeContext());
-            const auto qualifiedType = (v.getAccessMode() & VarAccessModeAttribute::READ_ONLY) ? resolvedType.addConst() : resolvedType;
+            const auto qualifiedType = (v.access & VarAccessModeAttribute::READ_ONLY) ? resolvedType.addConst() : resolvedType;
             env.define(Transpiler::Token{Transpiler::Token::Type::IDENTIFIER, v.name, 0}, qualifiedType, errorHandler);
         }
     }

--- a/include/genn/genn/code_generator/customUpdateGroupMerged.h
+++ b/include/genn/genn/code_generator/customUpdateGroupMerged.h
@@ -29,11 +29,11 @@ public:
                            runnerVarDecl, runnerMergedStructAlloc, name);
     }
 
-    void generateCustomUpdate(const BackendBase &backend, EnvironmentExternalBase &env,
+    void generateCustomUpdate(const BackendBase &backend, EnvironmentExternalBase &env, unsigned int batchSize,
                               BackendBase::GroupHandlerEnv<CustomUpdateGroupMerged> genPostamble);
 
-    std::string getVarIndex(VarAccessDim varDims, const std::string &index) const;
-    std::string getVarRefIndex(bool delay, VarAccessDim varDims, const std::string &index) const;
+    std::string getVarIndex(unsigned int batchSize, VarAccessDim varDims, const std::string &index) const;
+    std::string getVarRefIndex(bool delay, unsigned int batchSize, VarAccessDim varDims, const std::string &index) const;
 
     //----------------------------------------------------------------------------
     // Static constants
@@ -64,11 +64,11 @@ public:
 
     boost::uuids::detail::sha1::digest_type getHashDigest() const;
 
-    void generateCustomUpdate(const BackendBase &backend, EnvironmentExternalBase &env,
+    void generateCustomUpdate(const BackendBase &backend, EnvironmentExternalBase &env, unsigned int batchSize,
                               BackendBase::GroupHandlerEnv<CustomUpdateWUGroupMergedBase> genPostamble);
 
-    std::string getVarIndex(VarAccessDim varDims, const std::string &index) const;
-    std::string getVarRefIndex(VarAccessDim varDims, const std::string &index) const;
+    std::string getVarIndex(unsigned int batchSize, VarAccessDim varDims, const std::string &index) const;
+    std::string getVarRefIndex(unsigned int batchSize, VarAccessDim varDims, const std::string &index) const;
 
 };
 

--- a/include/genn/genn/code_generator/customUpdateGroupMerged.h
+++ b/include/genn/genn/code_generator/customUpdateGroupMerged.h
@@ -32,8 +32,8 @@ public:
     void generateCustomUpdate(const BackendBase &backend, EnvironmentExternalBase &env,
                               BackendBase::GroupHandlerEnv<CustomUpdateGroupMerged> genPostamble);
 
-    std::string getVarIndex(VarAccessDuplication varDuplication, const std::string &index) const;
-    std::string getVarRefIndex(bool delay, VarAccessDuplication varDuplication, const std::string &index) const;
+    std::string getVarIndex(unsigned int varAccess, const std::string &index) const;
+    std::string getVarRefIndex(bool delay, unsigned int varAccess, const std::string &index) const;
 
     //----------------------------------------------------------------------------
     // Static constants
@@ -67,8 +67,8 @@ public:
     void generateCustomUpdate(const BackendBase &backend, EnvironmentExternalBase &env,
                               BackendBase::GroupHandlerEnv<CustomUpdateWUGroupMergedBase> genPostamble);
 
-    std::string getVarIndex(VarAccessDuplication varDuplication, const std::string &index) const;
-    std::string getVarRefIndex(VarAccessDuplication varDuplication, const std::string &index) const;
+    std::string getVarIndex(unsigned int varAccess, const std::string &index) const;
+    std::string getVarRefIndex(unsigned int varAccess, const std::string &index) const;
 
 };
 

--- a/include/genn/genn/code_generator/customUpdateGroupMerged.h
+++ b/include/genn/genn/code_generator/customUpdateGroupMerged.h
@@ -141,7 +141,7 @@ protected:
         // Loop through variables and add pointers if they are reduction targets
         const auto *cm = this->getArchetype().getCustomUpdateModel();
         for(const auto &v : cm->getVars()) {
-            if(v.access & VarAccessModeAttribute::REDUCE) {
+            if(v.getAccessMode() & VarAccessModeAttribute::REDUCE) {
                 const auto fieldType = v.type.resolve(this->getTypeContext()).createPointer();
                 env.addField(fieldType, v.name, v.name,
                              [&backend, v](const auto &g, size_t) 
@@ -153,7 +153,7 @@ protected:
 
         // Loop through variable references and add pointers if they are reduction targets
         for(const auto &v : cm->getVarRefs()) {
-            if(v.access & VarAccessModeAttribute::REDUCE) {
+            if(v.getAccessMode() & VarAccessModeAttribute::REDUCE) {
                 const auto fieldType = v.type.resolve(this->getTypeContext()).createPointer();
                 env.addField(fieldType, v.name, v.name,
                              [&backend, v](const auto &g, size_t) 

--- a/include/genn/genn/code_generator/customUpdateGroupMerged.h
+++ b/include/genn/genn/code_generator/customUpdateGroupMerged.h
@@ -32,8 +32,8 @@ public:
     void generateCustomUpdate(const BackendBase &backend, EnvironmentExternalBase &env,
                               BackendBase::GroupHandlerEnv<CustomUpdateGroupMerged> genPostamble);
 
-    std::string getVarIndex(unsigned int varAccess, const std::string &index) const;
-    std::string getVarRefIndex(bool delay, unsigned int varAccess, const std::string &index) const;
+    std::string getVarIndex(VarAccessDim varDims, const std::string &index) const;
+    std::string getVarRefIndex(bool delay, VarAccessDim varDims, const std::string &index) const;
 
     //----------------------------------------------------------------------------
     // Static constants
@@ -67,8 +67,8 @@ public:
     void generateCustomUpdate(const BackendBase &backend, EnvironmentExternalBase &env,
                               BackendBase::GroupHandlerEnv<CustomUpdateWUGroupMergedBase> genPostamble);
 
-    std::string getVarIndex(unsigned int varAccess, const std::string &index) const;
-    std::string getVarRefIndex(unsigned int varAccess, const std::string &index) const;
+    std::string getVarIndex(VarAccessDim varDims, const std::string &index) const;
+    std::string getVarRefIndex(VarAccessDim varDims, const std::string &index) const;
 
 };
 
@@ -141,7 +141,7 @@ protected:
         // Loop through variables and add pointers if they are reduction targets
         const auto *cm = this->getArchetype().getCustomUpdateModel();
         for(const auto &v : cm->getVars()) {
-            if(v.getAccessMode() & VarAccessModeAttribute::REDUCE) {
+            if(v.access & VarAccessModeAttribute::REDUCE) {
                 const auto fieldType = v.type.resolve(this->getTypeContext()).createPointer();
                 env.addField(fieldType, v.name, v.name,
                              [&backend, v](const auto &g, size_t) 
@@ -153,7 +153,7 @@ protected:
 
         // Loop through variable references and add pointers if they are reduction targets
         for(const auto &v : cm->getVarRefs()) {
-            if(v.getAccessMode() & VarAccessModeAttribute::REDUCE) {
+            if(v.access & VarAccessModeAttribute::REDUCE) {
                 const auto fieldType = v.type.resolve(this->getTypeContext()).createPointer();
                 env.addField(fieldType, v.name, v.name,
                              [&backend, v](const auto &g, size_t) 

--- a/include/genn/genn/code_generator/environment.h
+++ b/include/genn/genn/code_generator/environment.h
@@ -723,7 +723,12 @@ public:
     //------------------------------------------------------------------------
     bool shouldAlwaysCopy(G&, const Models::Base::Var &var) const
     {
-        return m_ShouldAlwaysCopy(var.name, var.access);
+        if(m_ShouldAlwaysCopy) {
+            return m_ShouldAlwaysCopy(var.name, var.access);
+        }
+        else {
+            return false;
+        }
     }
 
     std::string getReadIndex(G&, const Models::Base::Var &var) const

--- a/include/genn/genn/code_generator/environment.h
+++ b/include/genn/genn/code_generator/environment.h
@@ -405,7 +405,7 @@ class EnvironmentGroupMergedField : public EnvironmentExternalDynamicBase<Enviro
     using IsHeterogeneousFn = bool (G::*)(const std::string&) const;
     using IsVarInitHeterogeneousFn = bool (G::*)(const std::string&, const std::string&) const;
     using GetParamValuesFn = const std::unordered_map<std::string, double> &(GroupInternal::*)(void) const;
-    using GetVarIndexFn = std::function<std::string(unsigned int, const std::string&)>;
+    using GetVarIndexFn = std::function<std::string(VarAccess, const std::string&)>;
 
     template<typename A>
     using GetVarRefIndexFn = std::function<std::string(VarAccessMode, const typename A::RefType&)>;
@@ -639,14 +639,14 @@ public:
         const A archetypeAdaptor(this->getGroup().getArchetype());
         for(const auto &v : archetypeAdaptor.getDefs()) {
             const auto resolvedType = v.type.resolve(this->getGroup().getTypeContext());
-            const auto qualifiedType = (readOnly || (v.getAccessMode() & VarAccessModeAttribute::READ_ONLY)) ? resolvedType.addConst() : resolvedType;
+            const auto qualifiedType = (readOnly || (v.access & VarAccessModeAttribute::READ_ONLY)) ? resolvedType.addConst() : resolvedType;
             addField(qualifiedType, v.name,
                      resolvedType.createPointer(), v.name + fieldSuffix, 
                      [arrayPrefix, v](const auto &g, size_t) 
                      { 
                          return arrayPrefix + v.name + A(g).getNameSuffix();
                      },
-                     getIndexFn(v.getAccess(VarAccess::READ_WRITE), v.name));
+                     getIndexFn(v.access, v.name));
         }
     }
 
@@ -654,7 +654,7 @@ public:
     void addVars(const std::string &arrayPrefix, const std::string &indexSuffix, 
                  const std::string &fieldSuffix = "", bool readOnly = false)
     {
-        addVars<A>(arrayPrefix, [&indexSuffix](unsigned int, const std::string &) { return indexSuffix; }, 
+        addVars<A>(arrayPrefix, [&indexSuffix](VarAccess, const std::string &) { return indexSuffix; }, 
                    fieldSuffix, readOnly);
     }
 
@@ -704,8 +704,8 @@ class VarCachePolicy
 {
 public:
     using GroupInternal = typename G::GroupInternal;
-    using GetIndexFn = std::function<std::string(const std::string&, unsigned int)>;
-    using ShouldAlwaysCopyFn = std::function<bool(const std::string&, unsigned int)>;
+    using GetIndexFn = std::function<std::string(const std::string&, VarAccess)>;
+    using ShouldAlwaysCopyFn = std::function<bool(const std::string&, VarAccess)>;
 
     VarCachePolicy(GetIndexFn getReadIndex, GetIndexFn getWriteIndex,
                    ShouldAlwaysCopyFn shouldAlwaysCopy = ShouldAlwaysCopyFn())
@@ -723,20 +723,17 @@ public:
     //------------------------------------------------------------------------
     bool shouldAlwaysCopy(G&, const Models::Base::Var &var) const
     {
-        // **TODO** default from InitModel class
-        return m_ShouldAlwaysCopy(var.name, getVarAccessDuplication(var.getAccess(VarAccess::READ_WRITE)));
+        return m_ShouldAlwaysCopy(var.name, var.access);
     }
 
     std::string getReadIndex(G&, const Models::Base::Var &var) const
     {
-        // **TODO** default from InitModel class
-        return m_GetReadIndex(var.name, getVarAccessDuplication(var.getAccess(VarAccess::READ_WRITE)));
+        return m_GetReadIndex(var.name, var.access);
     }
 
     std::string getWriteIndex(G&, const Models::Base::Var &var) const
     {
-        // **TODO** default from InitModel class
-        return m_GetWriteIndex(var.name, getVarAccessDuplication(var.getAccess(VarAccess::READ_WRITE)));
+        return m_GetWriteIndex(var.name, var.access);
     }
 
     std::string getTargetName(const GroupInternal &g, const Models::Base::Var &var) const
@@ -860,7 +857,7 @@ public:
                                             return arrayPrefix + this->getTargetName(group.getGroups().at(i), v);
                                         });
 
-            if(v.getAccessMode() & VarAccessMode::READ_ONLY) {
+            if(v.access == VarAccessMode::READ_ONLY) {
                 getContextStream() << "const ";
             }
             getContextStream() << resolvedType.getName() << " _" << m_LocalPrefix << v.name;
@@ -868,7 +865,7 @@ public:
             // If this isn't a reduction, read value from memory
             // **NOTE** by not initialising these variables for reductions, 
             // compilers SHOULD emit a warning if user code doesn't set it to something
-            if(!(v.getAccessMode() & VarAccessModeAttribute::REDUCE)) {
+            if(!(v.access & VarAccessModeAttribute::REDUCE)) {
                 getContextStream() << " = group->" << v.name << m_FieldSuffix << "[" << printSubs(this->getReadIndex(m_Group.get(), v), *this) << "]";
             }
             getContextStream() << ";" << std::endl;
@@ -880,7 +877,7 @@ public:
         // Loop through referenced definitions again
         for(const auto &v : referencedDefs) {
             // If we should always copy variable or variable is read-write
-            if(this->shouldAlwaysCopy(m_Group.get(), v) || v.getAccessMode() & VarAccessMode::READ_WRITE) {
+            if(this->shouldAlwaysCopy(m_Group.get(), v) || (v.access == VarAccessMode::READ_WRITE)) {
                 getContextStream() << "group->" << v.name << m_FieldSuffix << "[" << printSubs(this->getWriteIndex(m_Group.get(), v), *this) << "]";
                 getContextStream() << " = _" << m_LocalPrefix << v.name << ";" << std::endl;
             }
@@ -904,7 +901,7 @@ public:
 
             // Resolve type, add qualifier if required and return
             const auto resolvedType = var->second.second.type.resolve(m_Context.get());
-            const auto qualifiedType = (var->second.second.getAccessMode() & VarAccessModeAttribute::READ_ONLY) ? resolvedType.addConst() : resolvedType;
+            const auto qualifiedType = (var->second.second.access & VarAccessModeAttribute::READ_ONLY) ? resolvedType.addConst() : resolvedType;
             return {qualifiedType};
         }
     }

--- a/include/genn/genn/code_generator/environment.h
+++ b/include/genn/genn/code_generator/environment.h
@@ -704,8 +704,8 @@ class VarCachePolicy
 {
 public:
     using GroupInternal = typename G::GroupInternal;
-    using GetIndexFn = std::function<std::string(const std::string&, VarAccessDuplication)>;
-    using ShouldAlwaysCopyFn = std::function<bool(const std::string&, VarAccessDuplication)>;
+    using GetIndexFn = std::function<std::string(const std::string&, unsigned int)>;
+    using ShouldAlwaysCopyFn = std::function<bool(const std::string&, unsigned int)>;
 
     VarCachePolicy(GetIndexFn getReadIndex, GetIndexFn getWriteIndex,
                    ShouldAlwaysCopyFn shouldAlwaysCopy = ShouldAlwaysCopyFn())

--- a/include/genn/genn/code_generator/environment.h
+++ b/include/genn/genn/code_generator/environment.h
@@ -405,7 +405,7 @@ class EnvironmentGroupMergedField : public EnvironmentExternalDynamicBase<Enviro
     using IsHeterogeneousFn = bool (G::*)(const std::string&) const;
     using IsVarInitHeterogeneousFn = bool (G::*)(const std::string&, const std::string&) const;
     using GetParamValuesFn = const std::unordered_map<std::string, double> &(GroupInternal::*)(void) const;
-    using GetVarIndexFn = std::function<std::string(VarAccess, const std::string&)>;
+    using GetVarIndexFn = std::function<std::string(std::optional<unsigned int>, const std::string&)>;
 
     template<typename A>
     using GetVarRefIndexFn = std::function<std::string(VarAccessMode, const typename A::RefType&)>;
@@ -653,7 +653,7 @@ public:
     void addVars(const std::string &arrayPrefix, const std::string &indexSuffix, 
                  const std::string &fieldSuffix = "", bool readOnly = false)
     {
-        addVars<A>(arrayPrefix, [&indexSuffix](VarAccess, const std::string &) { return indexSuffix; }, 
+        addVars<A>(arrayPrefix, [&indexSuffix](std::optional<unsigned int>, const std::string &) { return indexSuffix; }, 
                    fieldSuffix, readOnly);
     }
 
@@ -682,7 +682,7 @@ public:
     void addVarRefs(const std::string &arrayPrefix, const std::string &indexSuffix, 
                     const std::string &fieldSuffix = "", bool readOnly = false)
     {
-        addVarRefs<A>(arrayPrefix, [&indexSuffix](VarAccess a, auto &) { return indexSuffix; }, 
+        addVarRefs<A>(arrayPrefix, [&indexSuffix](std::optional<unsigned int>, auto &) { return indexSuffix; }, 
                       fieldSuffix);
     }
 
@@ -722,22 +722,23 @@ public:
     //------------------------------------------------------------------------
     bool shouldAlwaysCopy(G&, const Models::Base::Var &var) const
     {
-        if(m_ShouldAlwaysCopy) {
-            return m_ShouldAlwaysCopy(var.name, getVarAccessDuplication(var.access));
-        }
-        else {
-            return false;
-        }
+        // **TODO** default from InitModel class
+        const unsigned int varAccess = var.access.value_or(static_cast<unsigned int>(VarAccess::READ_WRITE));
+        return m_ShouldAlwaysCopy(var.name, getVarAccessDuplication(varAccess));
     }
 
     std::string getReadIndex(G&, const Models::Base::Var &var) const
     {
-        return m_GetReadIndex(var.name, getVarAccessDuplication(var.access));
+        // **TODO** default from InitModel class
+        const unsigned int varAccess = var.access.value_or(static_cast<unsigned int>(VarAccess::READ_WRITE));
+        return m_GetReadIndex(var.name, getVarAccessDuplication(varAccess));
     }
 
     std::string getWriteIndex(G&, const Models::Base::Var &var) const
     {
-        return m_GetWriteIndex(var.name, getVarAccessDuplication(var.access));
+        // **TODO** default from InitModel class
+        const unsigned int varAccess = var.access.value_or(static_cast<unsigned int>(VarAccess::READ_WRITE));
+        return m_GetWriteIndex(var.name, getVarAccessDuplication(varAccess));
     }
 
     std::string getTargetName(const GroupInternal &g, const Models::Base::Var &var) const

--- a/include/genn/genn/code_generator/environment.h
+++ b/include/genn/genn/code_generator/environment.h
@@ -772,7 +772,7 @@ protected:
     //------------------------------------------------------------------------
     // Public API
     //------------------------------------------------------------------------
-    bool shouldAlwaysCopy(G&, const Models::Base::VarRef &var) const
+    bool shouldAlwaysCopy(G&, const Models::Base::VarRef&) const
     {
         // **NOTE** something else is managing the actual variables
         // and is therefore responsible for copying between delay slots etc

--- a/include/genn/genn/code_generator/neuronUpdateGroupMerged.h
+++ b/include/genn/genn/code_generator/neuronUpdateGroupMerged.h
@@ -185,9 +185,9 @@ public:
     
     void generateWUVarUpdate(const BackendBase &backend, EnvironmentExternalBase &env, unsigned int batchSize);
     
-    std::string getVarIndex(unsigned int batchSize, VarAccessDuplication varDuplication, const std::string &index) const;
-    std::string getReadVarIndex(bool delay, unsigned int batchSize, VarAccessDuplication varDuplication, const std::string &index) const;
-    std::string getWriteVarIndex(bool delay, unsigned int batchSize, VarAccessDuplication varDuplication, const std::string &index) const;
+    std::string getVarIndex(unsigned int batchSize, unsigned int varAccess, const std::string &index) const;
+    std::string getReadVarIndex(bool delay, unsigned int batchSize, unsigned int varAccess, const std::string &index) const;
+    std::string getWriteVarIndex(bool delay, unsigned int batchSize, unsigned int varAccess, const std::string &index) const;
 
     const std::vector<CurrentSource> &getMergedCurrentSourceGroups() const { return m_MergedCurrentSourceGroups; }
     const std::vector<InSynPSM> &getMergedInSynPSMGroups() const { return m_MergedInSynPSMGroups; }

--- a/include/genn/genn/code_generator/neuronUpdateGroupMerged.h
+++ b/include/genn/genn/code_generator/neuronUpdateGroupMerged.h
@@ -185,9 +185,9 @@ public:
     
     void generateWUVarUpdate(const BackendBase &backend, EnvironmentExternalBase &env, unsigned int batchSize);
     
-    std::string getVarIndex(unsigned int batchSize, unsigned int varAccess, const std::string &index) const;
-    std::string getReadVarIndex(bool delay, unsigned int batchSize, unsigned int varAccess, const std::string &index) const;
-    std::string getWriteVarIndex(bool delay, unsigned int batchSize, unsigned int varAccess, const std::string &index) const;
+    std::string getVarIndex(unsigned int batchSize, VarAccessDim varDims, const std::string &index) const;
+    std::string getReadVarIndex(bool delay, unsigned int batchSize, VarAccessDim varDims, const std::string &index) const;
+    std::string getWriteVarIndex(bool delay, unsigned int batchSize, VarAccessDim varDims, const std::string &index) const;
 
     const std::vector<CurrentSource> &getMergedCurrentSourceGroups() const { return m_MergedCurrentSourceGroups; }
     const std::vector<InSynPSM> &getMergedInSynPSMGroups() const { return m_MergedInSynPSMGroups; }

--- a/include/genn/genn/code_generator/synapseUpdateGroupMerged.h
+++ b/include/genn/genn/code_generator/synapseUpdateGroupMerged.h
@@ -44,33 +44,33 @@ public:
     std::string getPreSlot(unsigned int batchSize) const;
     std::string getPostSlot(unsigned int batchSize) const;
 
-    std::string getPreVarIndex(unsigned int batchSize, VarAccessDuplication varDuplication, const std::string &index) const
+    std::string getPreVarIndex(unsigned int batchSize, unsigned int varAccess, const std::string &index) const
     {
-        return getPreVarIndex(getArchetype().getSrcNeuronGroup()->isDelayRequired(), batchSize, varDuplication, index);
+        return getPreVarIndex(getArchetype().getSrcNeuronGroup()->isDelayRequired(), batchSize, varAccess, index);
     }
     
-    std::string getPostVarIndex(unsigned int batchSize, VarAccessDuplication varDuplication, const std::string &index) const
+    std::string getPostVarIndex(unsigned int batchSize, unsigned int varAccess, const std::string &index) const
     {
-        return getPostVarIndex(getArchetype().getTrgNeuronGroup()->isDelayRequired(), batchSize, varDuplication, index);
+        return getPostVarIndex(getArchetype().getTrgNeuronGroup()->isDelayRequired(), batchSize, varAccess, index);
     }
 
-    std::string getPreWUVarIndex(unsigned int batchSize, VarAccessDuplication varDuplication, const std::string &index) const
+    std::string getPreWUVarIndex(unsigned int batchSize, unsigned int varAccess, const std::string &index) const
     {
-        return getPreVarIndex(getArchetype().getDelaySteps() != 0, batchSize, varDuplication, index);
+        return getPreVarIndex(getArchetype().getDelaySteps() != 0, batchSize, varAccess, index);
     }
     
-    std::string getPostWUVarIndex(unsigned int batchSize, VarAccessDuplication varDuplication, const std::string &index) const
+    std::string getPostWUVarIndex(unsigned int batchSize, unsigned int varAccess, const std::string &index) const
     {
-        return getPostVarIndex(getArchetype().getBackPropDelaySteps() != 0, batchSize, varDuplication, index);
+        return getPostVarIndex(getArchetype().getBackPropDelaySteps() != 0, batchSize, varAccess, index);
     }
 
     std::string getPostDenDelayIndex(unsigned int batchSize, const std::string &index, const std::string &offset) const;
 
-    std::string getPreVarIndex(bool delay, unsigned int batchSize, VarAccessDuplication varDuplication, const std::string &index) const;
-    std::string getPostVarIndex(bool delay, unsigned int batchSize, VarAccessDuplication varDuplication, const std::string &index) const;
+    std::string getPreVarIndex(bool delay, unsigned int batchSize, unsigned int varAccess, const std::string &index) const;
+    std::string getPostVarIndex(bool delay, unsigned int batchSize, unsigned int varAccess, const std::string &index) const;
 
-    std::string getPrePrevSpikeTimeIndex(bool delay, unsigned int batchSize, VarAccessDuplication varDuplication, const std::string &index) const;
-    std::string getPostPrevSpikeTimeIndex(bool delay, unsigned int batchSize, VarAccessDuplication varDuplication, const std::string &index) const;
+    std::string getPrePrevSpikeTimeIndex(bool delay, unsigned int batchSize, unsigned int varAccess, const std::string &index) const;
+    std::string getPostPrevSpikeTimeIndex(bool delay, unsigned int batchSize, unsigned int varAccess, const std::string &index) const;
     
     std::string getPostISynIndex(unsigned int batchSize, const std::string &index) const
     {
@@ -82,8 +82,8 @@ public:
         return ((batchSize == 1) ? "" : "$(pre_batch_offset) + ") + index;
     }
 
-    std::string getSynVarIndex(unsigned int batchSize, VarAccessDuplication varDuplication, const std::string &index) const;
-    std::string getKernelVarIndex(unsigned int batchSize, VarAccessDuplication varDuplication, const std::string &index) const;
+    std::string getSynVarIndex(unsigned int batchSize, unsigned int varAccess, const std::string &index) const;
+    std::string getKernelVarIndex(unsigned int batchSize, unsigned int varAccess, const std::string &index) const;
     
     boost::uuids::detail::sha1::digest_type getHashDigest() const;
 
@@ -95,8 +95,8 @@ private:
     //------------------------------------------------------------------------
     // Private methods
     //------------------------------------------------------------------------
-    std::string getVarIndex(bool delay, unsigned int batchSize, VarAccessDuplication varDuplication,
-                            const std::string &index, const std::string &prefix) const;
+    std::string getVarIndex(bool delay, unsigned int batchSize, unsigned int varAccess,
+                            VarAccessDim neuruonAxis, const std::string &index, const std::string &prefix) const;
 };
 
 //----------------------------------------------------------------------------

--- a/include/genn/genn/code_generator/synapseUpdateGroupMerged.h
+++ b/include/genn/genn/code_generator/synapseUpdateGroupMerged.h
@@ -44,33 +44,40 @@ public:
     std::string getPreSlot(unsigned int batchSize) const;
     std::string getPostSlot(unsigned int batchSize) const;
 
-    std::string getPreVarIndex(unsigned int batchSize, unsigned int varAccess, const std::string &index) const
+    std::string getPreVarIndex(unsigned int batchSize, VarAccessDim varDims, const std::string &index) const
     {
-        return getPreVarIndex(getArchetype().getSrcNeuronGroup()->isDelayRequired(), batchSize, varAccess, index);
+        return getPreVarIndex(getArchetype().getSrcNeuronGroup()->isDelayRequired(), batchSize, varDims, index);
     }
     
-    std::string getPostVarIndex(unsigned int batchSize, unsigned int varAccess, const std::string &index) const
+    std::string getPostVarIndex(unsigned int batchSize, VarAccessDim varDims, const std::string &index) const
     {
-        return getPostVarIndex(getArchetype().getTrgNeuronGroup()->isDelayRequired(), batchSize, varAccess, index);
+        return getPostVarIndex(getArchetype().getTrgNeuronGroup()->isDelayRequired(), batchSize, varDims, index);
     }
 
-    std::string getPreWUVarIndex(unsigned int batchSize, unsigned int varAccess, const std::string &index) const
+    std::string getPreWUVarIndex(unsigned int batchSize, VarAccessDim varDims, const std::string &index) const
     {
-        return getPreVarIndex(getArchetype().getDelaySteps() != 0, batchSize, varAccess, index);
+        return getPreVarIndex(getArchetype().getDelaySteps() != 0, batchSize, varDims, index);
     }
     
-    std::string getPostWUVarIndex(unsigned int batchSize, unsigned int varAccess, const std::string &index) const
+    std::string getPostWUVarIndex(unsigned int batchSize, VarAccessDim varDims, const std::string &index) const
     {
-        return getPostVarIndex(getArchetype().getBackPropDelaySteps() != 0, batchSize, varAccess, index);
+        return getPostVarIndex(getArchetype().getBackPropDelaySteps() != 0, batchSize, varDims, index);
     }
 
     std::string getPostDenDelayIndex(unsigned int batchSize, const std::string &index, const std::string &offset) const;
 
-    std::string getPreVarIndex(bool delay, unsigned int batchSize, unsigned int varAccess, const std::string &index) const;
-    std::string getPostVarIndex(bool delay, unsigned int batchSize, unsigned int varAccess, const std::string &index) const;
+    std::string getPreVarIndex(bool delay, unsigned int batchSize, VarAccessDim varDims, const std::string &index) const
+    {
+        return getPrePostVarIndex(delay, batchSize, varDims, index, "pre");
+    }
 
-    std::string getPrePrevSpikeTimeIndex(bool delay, unsigned int batchSize, unsigned int varAccess, const std::string &index) const;
-    std::string getPostPrevSpikeTimeIndex(bool delay, unsigned int batchSize, unsigned int varAccess, const std::string &index) const;
+    std::string getPostVarIndex(bool delay, unsigned int batchSize, VarAccessDim varDims, const std::string &index) const
+    {
+        return getPrePostVarIndex(delay, batchSize, varDims, index, "post");
+    }
+
+    std::string getPrePrevSpikeTimeIndex(bool delay, unsigned int batchSize, VarAccessDim varDims, const std::string &index) const;
+    std::string getPostPrevSpikeTimeIndex(bool delay, unsigned int batchSize, VarAccessDim varDims, const std::string &index) const;
     
     std::string getPostISynIndex(unsigned int batchSize, const std::string &index) const
     {
@@ -82,8 +89,8 @@ public:
         return ((batchSize == 1) ? "" : "$(pre_batch_offset) + ") + index;
     }
 
-    std::string getSynVarIndex(unsigned int batchSize, unsigned int varAccess, const std::string &index) const;
-    std::string getKernelVarIndex(unsigned int batchSize, unsigned int varAccess, const std::string &index) const;
+    std::string getSynVarIndex(unsigned int batchSize, VarAccessDim varDims, const std::string &index) const;
+    std::string getKernelVarIndex(unsigned int batchSize, VarAccessDim varDims, const std::string &index) const;
     
     boost::uuids::detail::sha1::digest_type getHashDigest() const;
 
@@ -95,8 +102,8 @@ private:
     //------------------------------------------------------------------------
     // Private methods
     //------------------------------------------------------------------------
-    std::string getVarIndex(bool delay, unsigned int batchSize, unsigned int varAccess,
-                            VarAccessDim neuruonAxis, const std::string &index, const std::string &prefix) const;
+    std::string getPrePostVarIndex(bool delay, unsigned int batchSize, VarAccessDim varDims,
+                                   const std::string &index, const std::string &prefix) const;
 };
 
 //----------------------------------------------------------------------------

--- a/include/genn/genn/currentSourceInternal.h
+++ b/include/genn/genn/currentSourceInternal.h
@@ -54,6 +54,8 @@ public:
 
     const std::string &getNameSuffix() const{ return m_CS.getName(); }
 
+    VarAccessDim getVarDims(const Models::Base::Var &var) const{ return var.access.getDims<NeuronVarAccess>(); }
+
 private:
     //----------------------------------------------------------------------------
     // Members

--- a/include/genn/genn/customConnectivityUpdateInternal.h
+++ b/include/genn/genn/customConnectivityUpdateInternal.h
@@ -61,6 +61,8 @@ public:
 
     const std::string &getNameSuffix() const{ return m_CU.getName(); }
 
+    VarAccessDim getVarDims(const Models::Base::Var &var) const{ return var.access.getDims<SynapseVarAccess>(); }
+
 private:
     //----------------------------------------------------------------------------
     // Members
@@ -89,6 +91,8 @@ public:
     bool isVarDelayed(const std::string &) const { return false; }
 
     const std::string &getNameSuffix() const{ return m_CU.getName(); }
+
+    VarAccessDim getVarDims(const Models::Base::Var &var) const{ return var.access.getDims<NeuronVarAccess>(); }
 
 private:
     //----------------------------------------------------------------------------
@@ -119,6 +123,8 @@ public:
 
     const std::string &getNameSuffix() const{ return m_CU.getName(); }
 
+    VarAccessDim getVarDims(const Models::Base::Var &var) const{ return var.access.getDims<NeuronVarAccess>(); }
+    
 private:
     //----------------------------------------------------------------------------
     // Members

--- a/include/genn/genn/customUpdate.h
+++ b/include/genn/genn/customUpdate.h
@@ -93,7 +93,7 @@ protected:
         if(std::any_of(vars.cbegin(), vars.cend(),
                        [duplication](const Models::Base::Var &v)
                        { 
-                           const unsigned int access = v.access.value_or(static_cast<unsigned int>(VarAccess::READ_WRITE));
+                           const unsigned int access = v.getAccess(VarAccess::READ_WRITE);
                            return (access & VarAccessModeAttribute::REDUCE) && (access & duplication);
                        }))
         {
@@ -104,8 +104,9 @@ protected:
         for(const auto &modelVarRef : getCustomUpdateModel()->getVarRefs()) {
             // If custom update model reduces into this variable reference and the variable it targets has correct duplication flag
             const auto &varRef = varRefs.at(modelVarRef.name);
-            const unsigned int varAccess = varRef.getVar().access.value_or(static_cast<unsigned int>(VarAccess::READ_WRITE));
-            if ((modelVarRef.access & VarAccessModeAttribute::REDUCE) & (varAccess & duplication)) {
+            if ((modelVarRef.access & VarAccessModeAttribute::REDUCE) 
+                && (varRef.getVar().getAccess(VarAccess::READ_WRITE) & duplication)) 
+            {
                 return true;
             }
         }
@@ -132,8 +133,7 @@ protected:
 
             // If custom update is batched, check that any variable references to shared variables are read-only
             // **NOTE** if custom update isn't batched, it's totally fine to write to shared variables
-            const unsigned int varAccess = varRef.getVar().access.value_or(static_cast<unsigned int>(VarAccess::READ_WRITE));
-            if(m_Batched && (varAccess & VarAccessDuplication::SHARED)
+            if(m_Batched && (varRef.getVar().getAccess(VarAccess::READ_WRITE) & VarAccessDuplication::SHARED)
                && (modelVarRef.access == VarAccessMode::READ_WRITE))
             {
                 throw std::runtime_error("Variable references to SHARED variables in batched custom updates cannot be read-write.");

--- a/include/genn/genn/customUpdate.h
+++ b/include/genn/genn/customUpdate.h
@@ -89,13 +89,13 @@ protected:
     bool isReduction(const std::unordered_map<std::string, V> &varRefs, 
                      VarAccessDim reduceDim) const
     {
-        // Return true if any variables have REDUCE flag in their access mode and don't have reduction dimension
+        // Return true if any variables have REDUCE flag in their access mode and have reduction dimension
         const auto vars = getCustomUpdateModel()->getVars();
         if(std::any_of(vars.cbegin(), vars.cend(),
                        [reduceDim](const Models::Base::Var &v)
                        { 
                            return ((v.access & VarAccessModeAttribute::REDUCE) 
-                                   && !(v.access.template getDims<A>() & reduceDim));
+                                   && (v.access.template getDims<A>() & reduceDim));
                        }))
         {
             return true;
@@ -104,10 +104,10 @@ protected:
         // Loop through all variable references
         for(const auto &modelVarRef : getCustomUpdateModel()->getVarRefs()) {
             // If custom update model reduces into this variable reference 
-            // and the variable it targets doesn't have reduction dimension
+            // and the variable it targets has reduction dimension
             const auto &varRef = varRefs.at(modelVarRef.name);
             if ((modelVarRef.access & VarAccessModeAttribute::REDUCE) 
-                && !(varRef.getVar().access.template getDims<A>() & reduceDim)) 
+                && (varRef.getVar().access.template getDims<A>() & reduceDim)) 
             {
                 return true;
             }

--- a/include/genn/genn/customUpdate.h
+++ b/include/genn/genn/customUpdate.h
@@ -118,7 +118,7 @@ protected:
     }
 
     //! Helper function to check if variable reference types match those specified in model
-    template<typename A, typename V>
+    template<typename V>
     void checkVarReferenceDims(const std::unordered_map<std::string, V>& varRefs, unsigned int batchSize)
     {
         // Loop through variable references and or together their dimensions to get dimensionality of update
@@ -133,7 +133,7 @@ protected:
 
             // If the shape of the references variable doesn't match the dimensionality 
             // of the custom update, check its access mode isn't read-write
-            if((m_Dims != varRef.getVar().access.template getDims<A>())
+            if((m_Dims != varRef.getDims())
                && (modelVarRef.access == VarAccessMode::READ_WRITE))
             {
                 throw std::runtime_error("Variable references to lower-dimensional variables cannot be read-write.");

--- a/include/genn/genn/customUpdate.h
+++ b/include/genn/genn/customUpdate.h
@@ -95,7 +95,7 @@ protected:
                        [reduceDim](const Models::Base::Var &v)
                        { 
                            return ((v.access & VarAccessModeAttribute::REDUCE) 
-                                   && !(v.access.getDims<A>() & reduceDim));
+                                   && !(v.access.template getDims<A>() & reduceDim));
                        }))
         {
             return true;
@@ -107,7 +107,7 @@ protected:
             // and the variable it targets doesn't have reduction dimension
             const auto &varRef = varRefs.at(modelVarRef.name);
             if ((modelVarRef.access & VarAccessModeAttribute::REDUCE) 
-                && !(varRef.getVar().access.getDims<A>() & reduceDim)) 
+                && !(varRef.getVar().access.template getDims<A>() & reduceDim)) 
             {
                 return true;
             }
@@ -135,7 +135,7 @@ protected:
 
             // If custom update is batched, check that any variable references to variables that aren't batched are read-only
             // **NOTE** if custom update isn't batched, it's totally fine to write to shared variables
-            if(m_Batched && !(varRef.getVar().access.getDims<A>() & VarAccessDim::BATCH)
+            if(m_Batched && !(varRef.getVar().access.template getDims<A>() & VarAccessDim::BATCH)
                && (modelVarRef.access == VarAccessMode::READ_WRITE))
             {
                 throw std::runtime_error("Variable references to non-batched variables in batched custom updates cannot be read-write.");

--- a/include/genn/genn/customUpdate.h
+++ b/include/genn/genn/customUpdate.h
@@ -86,15 +86,15 @@ protected:
     const std::vector<Transpiler::Token> getUpdateCodeTokens() const{ return m_UpdateCodeTokens; }
 
     template<typename V>
-    bool isReduction(const std::unordered_map<std::string, V> &varRefs, VarAccessDuplication duplication) const
+    bool isReduction(const std::unordered_map<std::string, V> &varRefs, VarAccessDim reduceDim) const
     {
-        // Return true if any variables have REDUCE flag in their access mode and have correct duplication flag
+        // Return true if any variables have REDUCE flag in their access mode and doesn't have reduction dimension
         const auto vars = getCustomUpdateModel()->getVars();
         if(std::any_of(vars.cbegin(), vars.cend(),
-                       [duplication](const Models::Base::Var &v)
+                       [reduceDim](const Models::Base::Var &v)
                        { 
                            const unsigned int access = v.getAccess(VarAccess::READ_WRITE);
-                           return (access & VarAccessModeAttribute::REDUCE) && (access & duplication);
+                           return (access & VarAccessModeAttribute::REDUCE) && !(access & reduceDim);
                        }))
         {
             return true;
@@ -102,10 +102,11 @@ protected:
 
         // Loop through all variable references
         for(const auto &modelVarRef : getCustomUpdateModel()->getVarRefs()) {
-            // If custom update model reduces into this variable reference and the variable it targets has correct duplication flag
+            // If custom update model reduces into this variable reference 
+            // and the variable it targets doesn't have reduction dimension
             const auto &varRef = varRefs.at(modelVarRef.name);
             if ((modelVarRef.access & VarAccessModeAttribute::REDUCE) 
-                && (varRef.getVar().getAccess(VarAccess::READ_WRITE) & duplication)) 
+                && !(varRef.getVar().getAccess(VarAccess::READ_WRITE) & reduceDim)) 
             {
                 return true;
             }
@@ -131,12 +132,12 @@ protected:
         for(const auto &modelVarRef : getCustomUpdateModel()->getVarRefs()) {
             const auto varRef = varRefs.at(modelVarRef.name);
 
-            // If custom update is batched, check that any variable references to shared variables are read-only
+            // If custom update is batched, check that any variable references to variables that aren't batched are read-only
             // **NOTE** if custom update isn't batched, it's totally fine to write to shared variables
-            if(m_Batched && (varRef.getVar().getAccess(VarAccess::READ_WRITE) & VarAccessDuplication::SHARED)
+            if(m_Batched && !(varRef.getVar().getAccess(VarAccess::READ_WRITE) & VarAccessDim::BATCH)
                && (modelVarRef.access == VarAccessMode::READ_WRITE))
             {
-                throw std::runtime_error("Variable references to SHARED variables in batched custom updates cannot be read-write.");
+                throw std::runtime_error("Variable references to non-batched variables in batched custom updates cannot be read-write.");
             }
         }
     }
@@ -264,8 +265,8 @@ protected:
     //------------------------------------------------------------------------
     // Protected const methods
     //------------------------------------------------------------------------
-    bool isBatchReduction() const { return isReduction(getVarReferences(), VarAccessDuplication::SHARED); }
-    bool isNeuronReduction() const { return isReduction(getVarReferences(), VarAccessDuplication::SHARED_NEURON); }
+    bool isBatchReduction() const { return isReduction(getVarReferences(), VarAccessDim::BATCH); }
+    bool isNeuronReduction() const { return isReduction(getVarReferences(), VarAccessDim::NEURON); }
     bool isPerNeuron() const{ return m_PerNeuron; }
 
     const NeuronGroup *getDelayNeuronGroup() const { return m_DelayNeuronGroup; }
@@ -321,7 +322,7 @@ protected:
     //------------------------------------------------------------------------
     // Protected const methods
     //------------------------------------------------------------------------
-    bool isBatchReduction() const { return isReduction(getVarReferences(), VarAccessDuplication::SHARED); }
+    bool isBatchReduction() const { return isReduction(getVarReferences(), VarAccessDim::BATCH); }
     bool isTransposeOperation() const;
 
     SynapseGroupInternal *getSynapseGroup() const { return m_SynapseGroup; }

--- a/include/genn/genn/customUpdate.h
+++ b/include/genn/genn/customUpdate.h
@@ -50,6 +50,9 @@ public:
     //! Is var init code required for any variables in this custom update group's custom update model?
     bool isVarInitRequired() const;
 
+    //! Get dimensions of this custom update
+    VarAccessDim getDims() const{ return m_Dims; }
+
 protected:
     CustomUpdateBase(const std::string &name, const std::string &updateGroupName, const CustomUpdateModels::Base *customUpdateModel, 
                      const std::unordered_map<std::string, double> &params, const std::unordered_map<std::string, InitVarSnippet::Init> &varInitialisers,
@@ -69,9 +72,6 @@ protected:
     bool isInitRNGRequired() const;
 
     bool isZeroCopyEnabled() const;
-
-    //! Get dimensions of this custom update
-    VarAccessDim getDims() const{ return m_Dims; }
 
     //! Updates hash with custom update
     /*! NOTE: this can only be called after model is finalized */
@@ -207,6 +207,11 @@ public:
     bool isVarDelayed(const std::string &) const { return false; }
 
     const std::string &getNameSuffix() const{ return m_CU.getName(); }
+
+    VarAccessDim getVarDims(const Models::Base::Var &var) const
+    { 
+        return clearDim(m_CU.getDims(), var.access.getDims<CustomUpdateVarAccess>());
+    }
 
 private:
     //----------------------------------------------------------------------------

--- a/include/genn/genn/customUpdateInternal.h
+++ b/include/genn/genn/customUpdateInternal.h
@@ -26,8 +26,7 @@ public:
     using CustomUpdateBase::getDerivedParams;
     using CustomUpdateBase::isInitRNGRequired;
     using CustomUpdateBase::isZeroCopyEnabled;
-    using CustomUpdateBase::isBatched;
-    using CustomUpdate::isPerNeuron;
+    using CustomUpdateBase::getDims;
     using CustomUpdateBase::getVarLocationHashDigest;
     using CustomUpdateBase::getUpdateCodeTokens;
 
@@ -86,7 +85,7 @@ public:
     using CustomUpdateBase::getDerivedParams;
     using CustomUpdateBase::isInitRNGRequired;
     using CustomUpdateBase::isZeroCopyEnabled;
-    using CustomUpdateBase::isBatched;
+    using CustomUpdateBase::getDims;
     using CustomUpdateBase::isReduction;
     using CustomUpdateBase::getVarLocationHashDigest;
     using CustomUpdateBase::getUpdateCodeTokens;

--- a/include/genn/genn/models.h
+++ b/include/genn/genn/models.h
@@ -54,10 +54,26 @@ public:
         if not specified, this results in a -Wmissing-field-initializers warning on GCC and Clang*/
     struct GENN_EXPORT Var
     {
-        Var(const std::string &n, const Type::ResolvedType &t, VarAccess a = VarAccess::READ_WRITE) : name(n), type(t), access(a)
+        Var(const std::string &n, const Type::ResolvedType &t)
+        :   name(n), type(t)
         {}
-        Var(const std::string &n, const std::string &t, VarAccess a = VarAccess::READ_WRITE) : name(n), type(t), access(a)
+        Var(const std::string &n, const std::string &t)
+        :   name(n), type(t)
         {}
+
+        Var(const std::string &n, const Type::ResolvedType &t, VarAccess a)
+        :   name(n), type(t), access(static_cast<unsigned int>(a))
+        {}
+        Var(const std::string &n, const std::string &t, VarAccess a)
+        :   name(n), type(t), access(static_cast<unsigned int>(a))
+        {}
+
+        /*Var(const std::string &n, const Type::ResolvedType &t, NeuronVarAccess a)
+        :   name(n), type(t), access(static_cast<unsigned int>(a))
+        {}
+        Var(const std::string &n, const std::string &t, NeuronVarAccess a)
+        :   name(n), type(t), access(static_cast<unsigned int>(a))
+        {}*/
         
         bool operator == (const Var &other) const
         {
@@ -66,7 +82,7 @@ public:
 
         std::string name;
         Type::UnresolvedType type;
-        VarAccess access;
+        std::optional<unsigned int> access;
     };
 
     struct GENN_EXPORT VarRef
@@ -389,7 +405,9 @@ void checkVarReferences(const std::unordered_map<std::string, V> &varRefs, const
         }
 
         // Check that no reduction targets reference duplicated variables
-        if((varRef.getVar().access & VarAccessDuplication::DUPLICATE) 
+        // **TODO** default from InitModel class
+        const unsigned int varAccess = varRef.getVar().access.value_or(static_cast<unsigned int>(VarAccess::READ_WRITE));
+        if((varAccess & VarAccessDuplication::DUPLICATE) 
             && (modelVarRef.access & VarAccessModeAttribute::REDUCE))
         {
             throw std::runtime_error("Reduction target variable reference must be to SHARED or SHARED_NEURON variables.");

--- a/include/genn/genn/models.h
+++ b/include/genn/genn/models.h
@@ -271,12 +271,15 @@ public:
     std::string getTargetName() const;
     
     //! Get dimensions of variable being referenced
-    VarAccessDim getDims() const;
+    VarAccessDim getDims() const{ return getVarDims(getVar()); }
 
     SynapseGroup *getSynapseGroup() const;
 
     SynapseGroup *getTransposeSynapseGroup() const;
     std::string getTransposeTargetName() const;
+
+    //! Get dimensions of transpose variable being referenced
+    VarAccessDim getTransposeDims() const{ return getVarDims(getTransposeVar()); }
 
     //! If this reference points to another custom update, return pointer to it
     /*! This is used to detect circular dependencies */
@@ -321,13 +324,14 @@ private:
     //------------------------------------------------------------------------
     SynapseGroupInternal *getSynapseGroupInternal() const;
     SynapseGroupInternal *getTransposeSynapseGroupInternal() const;
+    VarAccessDim getVarDims(const Models::Base::Var &var) const;
 
     WUVarReference(size_t varIndex, const Models::Base::VarVec &varVec,
                    const DetailType &detail);
     WUVarReference(size_t varIndex, const Models::Base::VarVec &varVec,
                    size_t transposeVarIndex, const Models::Base::VarVec &transposeVarVec,
                    const DetailType &detail);
-    
+
     //------------------------------------------------------------------------
     // Members
     //------------------------------------------------------------------------

--- a/include/genn/genn/models.h
+++ b/include/genn/genn/models.h
@@ -385,7 +385,7 @@ GENN_EXPORT void updateHash(const EGPReference &v, boost::uuids::detail::sha1 &h
 
 //! Helper function to check if variable reference types match those specified in model
 template<typename V>
-void checkVarReferences(const std::unordered_map<std::string, V> &varRefs, const Base::VarRefVec &modelVarRefs)
+void checkVarReferenceTypes(const std::unordered_map<std::string, V> &varRefs, const Base::VarRefVec &modelVarRefs)
 {
     // Loop through all variable references
     for(const auto &modelVarRef : modelVarRefs) {
@@ -396,13 +396,6 @@ void checkVarReferences(const std::unordered_map<std::string, V> &varRefs, const
         if(varRef.getVar().type != modelVarRef.type) {
             throw std::runtime_error("Incompatible type for variable reference '" + modelVarRef.name + "'");
         }
-
-        // Check that no reduction targets reference duplicated variables
-        /*if((varRef.getVar().access.getDims<A>() & VarAccessDuplication::DUPLICATE) 
-            && (modelVarRef.access & VarAccessModeAttribute::REDUCE))
-        {
-            throw std::runtime_error("Reduction target variable reference must be to SHARED or SHARED_NEURON variables.");
-        }*/
     }
 }
 } // GeNN::Models

--- a/include/genn/genn/models.h
+++ b/include/genn/genn/models.h
@@ -80,6 +80,21 @@ public:
             return (std::tie(name, type, access) == std::tie(other.name, other.type, other.access));
         }
 
+        unsigned int getAccess(VarAccess defaultAccess) const
+        {
+            return access.value_or(static_cast<unsigned int>(defaultAccess)); 
+        }
+
+        VarAccessMode getAccessMode() const
+        {
+            if(access) {
+                return getVarAccessMode(access.value());
+            }
+            else {
+                return VarAccessMode::READ_WRITE;
+            }
+        }
+
         std::string name;
         Type::UnresolvedType type;
         std::optional<unsigned int> access;
@@ -95,6 +110,11 @@ public:
         bool operator == (const VarRef &other) const
         {
             return (std::tie(name, type, access) == std::tie(other.name, other.type, other.access));
+        }
+
+        VarAccessMode getAccessMode() const
+        {
+            return access;
         }
 
         std::string name;
@@ -406,8 +426,7 @@ void checkVarReferences(const std::unordered_map<std::string, V> &varRefs, const
 
         // Check that no reduction targets reference duplicated variables
         // **TODO** default from InitModel class
-        const unsigned int varAccess = varRef.getVar().access.value_or(static_cast<unsigned int>(VarAccess::READ_WRITE));
-        if((varAccess & VarAccessDuplication::DUPLICATE) 
+        if((varRef.getVar().getAccess(VarAccess::READ_WRITE) & VarAccessDuplication::DUPLICATE) 
             && (modelVarRef.access & VarAccessModeAttribute::REDUCE))
         {
             throw std::runtime_error("Reduction target variable reference must be to SHARED or SHARED_NEURON variables.");

--- a/include/genn/genn/models.h
+++ b/include/genn/genn/models.h
@@ -62,42 +62,20 @@ public:
         {}
 
         Var(const std::string &n, const Type::ResolvedType &t, VarAccess a)
-        :   name(n), type(t), access(static_cast<unsigned int>(a))
+        :   name(n), type(t), access(a)
         {}
         Var(const std::string &n, const std::string &t, VarAccess a)
-        :   name(n), type(t), access(static_cast<unsigned int>(a))
+        :   name(n), type(t), access(a)
         {}
-
-        /*Var(const std::string &n, const Type::ResolvedType &t, NeuronVarAccess a)
-        :   name(n), type(t), access(static_cast<unsigned int>(a))
-        {}
-        Var(const std::string &n, const std::string &t, NeuronVarAccess a)
-        :   name(n), type(t), access(static_cast<unsigned int>(a))
-        {}*/
         
         bool operator == (const Var &other) const
         {
             return (std::tie(name, type, access) == std::tie(other.name, other.type, other.access));
         }
 
-        unsigned int getAccess(VarAccess defaultAccess) const
-        {
-            return access.value_or(static_cast<unsigned int>(defaultAccess)); 
-        }
-
-        VarAccessMode getAccessMode() const
-        {
-            if(access) {
-                return getVarAccessMode(access.value());
-            }
-            else {
-                return VarAccessMode::READ_WRITE;
-            }
-        }
-
         std::string name;
         Type::UnresolvedType type;
-        std::optional<unsigned int> access;
+        VarAccess access;
     };
 
     struct GENN_EXPORT VarRef
@@ -110,11 +88,6 @@ public:
         bool operator == (const VarRef &other) const
         {
             return (std::tie(name, type, access) == std::tie(other.name, other.type, other.access));
-        }
-
-        VarAccessMode getAccessMode() const
-        {
-            return access;
         }
 
         std::string name;
@@ -425,12 +398,11 @@ void checkVarReferences(const std::unordered_map<std::string, V> &varRefs, const
         }
 
         // Check that no reduction targets reference duplicated variables
-        // **TODO** default from InitModel class
-        if((varRef.getVar().getAccess(VarAccess::READ_WRITE) & VarAccessDuplication::DUPLICATE) 
+        /*if((varRef.getVar().access.getDims<A>() & VarAccessDuplication::DUPLICATE) 
             && (modelVarRef.access & VarAccessModeAttribute::REDUCE))
         {
             throw std::runtime_error("Reduction target variable reference must be to SHARED or SHARED_NEURON variables.");
-        }
+        }*/
     }
 }
 } // GeNN::Models

--- a/include/genn/genn/models.h
+++ b/include/genn/genn/models.h
@@ -201,8 +201,8 @@ public:
     // **TODO** rename to getNameSuffix
     std::string getTargetName() const;
     
-    //! If model is batched, will the variable this is referencing be duplicated?
-    bool isDuplicated() const;
+    //! Get dimensions of variable being referenced
+    VarAccessDim getDims() const;
 
     //! If this reference points to another custom update, return pointer to it
     /*! This is used to detect circular dependencies */
@@ -270,8 +270,8 @@ public:
     // **TODO** rename to getNameSuffix
     std::string getTargetName() const;
     
-    //! If model is batched, will the variable this is referencing be duplicated?
-    bool isDuplicated() const;
+    //! Get dimensions of variable being referenced
+    VarAccessDim getDims() const;
 
     SynapseGroup *getSynapseGroup() const;
 

--- a/include/genn/genn/neuronGroupInternal.h
+++ b/include/genn/genn/neuronGroupInternal.h
@@ -78,6 +78,8 @@ public:
 
     const std::string &getNameSuffix() const{ return m_NG.getName(); }
 
+    VarAccessDim getVarDims(const Models::Base::Var &var) const{ return var.access.getDims<NeuronVarAccess>(); }
+    
 private:
     //----------------------------------------------------------------------------
     // Members

--- a/include/genn/genn/neuronModels.h
+++ b/include/genn/genn/neuronModels.h
@@ -197,8 +197,8 @@ public:
 
     SET_PARAM_NAMES({});
     SET_VARS({{"V","scalar"}, {"U", "scalar"},
-              {"a", "scalar", VarAccess::READ_ONLY}, {"b", "scalar", VarAccess::READ_ONLY},
-              {"c", "scalar", VarAccess::READ_ONLY}, {"d", "scalar", VarAccess::READ_ONLY}});
+              {"a", "scalar", NeuronVarAccess::READ_ONLY}, {"b", "scalar", NeuronVarAccess::READ_ONLY},
+              {"c", "scalar", NeuronVarAccess::READ_ONLY}, {"d", "scalar", NeuronVarAccess::READ_ONLY}});
 };
 
 //----------------------------------------------------------------------------
@@ -282,7 +282,7 @@ public:
         "$(startSpike) != $(endSpike) && "
         "$(t) >= $(spikeTimes)[$(startSpike)]" );
     SET_RESET_CODE( "$(startSpike)++;\n" );
-    SET_VARS( {{"startSpike", "unsigned int"}, {"endSpike", "unsigned int", VarAccess::READ_ONLY_DUPLICATE}} );
+    SET_VARS( {{"startSpike", "unsigned int"}, {"endSpike", "unsigned int", NeuronVarAccess::READ_ONLY_DUPLICATE}} );
     SET_EXTRA_GLOBAL_PARAMS( {{"spikeTimes", "scalar*"}} );
     SET_NEEDS_AUTO_REFRACTORY(false);
 };

--- a/include/genn/genn/synapseGroupInternal.h
+++ b/include/genn/genn/synapseGroupInternal.h
@@ -118,6 +118,8 @@ public:
 
     bool isVarDelayed(const std::string &) const { return false; }
 
+    VarAccessDim getVarDims(const Models::Base::Var &var) const{ return var.access.getDims<NeuronVarAccess>(); }
+
 private:
     //----------------------------------------------------------------------------
     // Members
@@ -167,6 +169,9 @@ public:
     const std::unordered_map<std::string, InitVarSnippet::Init> &getInitialisers() const{ return m_SG.getWUVarInitialisers(); }
 
     const std::string &getNameSuffix() const{ return m_SG.getName(); }
+
+    VarAccessDim getVarDims(const Models::Base::Var &var) const{ return var.access.getDims<SynapseVarAccess>(); }
+
 private:
     //----------------------------------------------------------------------------
     // Members
@@ -196,6 +201,8 @@ public:
 
     bool isVarDelayed(const std::string&) const{ return (m_SG.getDelaySteps() != 0); }
 
+    VarAccessDim getVarDims(const Models::Base::Var &var) const{ return var.access.getDims<NeuronVarAccess>(); }
+
 private:
     //----------------------------------------------------------------------------
     // Members
@@ -224,6 +231,8 @@ public:
     const std::string &getNameSuffix() const{ return m_SG.getFusedWUPostVarSuffix(); }
 
     bool isVarDelayed(const std::string&) const{ return (m_SG.getBackPropDelaySteps() != 0); }
+
+    VarAccessDim getVarDims(const Models::Base::Var &var) const{ return var.access.getDims<NeuronVarAccess>(); }
 
 private:
     //----------------------------------------------------------------------------

--- a/include/genn/genn/varAccess.h
+++ b/include/genn/genn/varAccess.h
@@ -45,8 +45,8 @@ enum class VarAccessDim : unsigned int
 enum class NeuronVarAccess : unsigned int
 {
     READ_WRITE              = static_cast<unsigned int>(VarAccessMode::READ_WRITE) | static_cast<unsigned int>(VarAccessDim::NEURON) | static_cast<unsigned int>(VarAccessDim::BATCH),
-    READ_ONLY               = static_cast<unsigned int>(VarAccessMode::READ_ONLY) | static_cast<unsigned int>(VarAccessDim::NEURON) | static_cast<unsigned int>(VarAccessDim::BATCH),
-    READ_ONLY_DUPLICATE     = static_cast<unsigned int>(VarAccessMode::READ_ONLY) | static_cast<unsigned int>(VarAccessDim::NEURON),
+    READ_ONLY               = static_cast<unsigned int>(VarAccessMode::READ_ONLY) | static_cast<unsigned int>(VarAccessDim::NEURON),
+    READ_ONLY_DUPLICATE     = static_cast<unsigned int>(VarAccessMode::READ_ONLY) | static_cast<unsigned int>(VarAccessDim::NEURON) | static_cast<unsigned int>(VarAccessDim::BATCH),
     READ_ONLY_SHARED_NEURON = static_cast<unsigned int>(VarAccessMode::READ_ONLY) | static_cast<unsigned int>(VarAccessDim::BATCH),
 };
 

--- a/include/genn/genn/varAccess.h
+++ b/include/genn/genn/varAccess.h
@@ -25,22 +25,13 @@ enum class VarAccessMode : unsigned int
     REDUCE_MAX  = static_cast<unsigned int>(VarAccessModeAttribute::REDUCE) | static_cast<unsigned int>(VarAccessModeAttribute::MAX),
 };
 
-//! Flags defining how variables should be duplicated across multiple batches
-enum class VarAccessDuplication : unsigned int
-{
-    DUPLICATE       = (1 << 5), //! This variable should be duplicated in each batch
-    SHARED          = (1 << 6), //! This variable should be shared between batches
-    SHARED_NEURON   = (1 << 7)  //! This variable should be shared between neurons
-};
-
 //! Flags defining dimensions this variables has
 enum class VarAccessDim : unsigned int
 {
     NEURON      = (1 << 5),
     PRE_NEURON  = (1 << 6),
     POST_NEURON = (1 << 7),
-    DELAY       = (1 << 8),
-    BATCH       = (1 << 9),
+    BATCH       = (1 << 8),
 };
 
 //! Supported combinations of access mode and dimension for neuron variables
@@ -53,7 +44,7 @@ enum class NeuronVarAccess : unsigned int
 };
 
 //! Supported combinations of access mode and dimension for synapse variables
-/*enum class SynapseVarAccess : unsigned int
+enum class SynapseVarAccess : unsigned int
 {
     // Synaptic variables
     READ_WRITE                  = static_cast<unsigned int>(VarAccessMode::READ_WRITE) | static_cast<unsigned int>(VarAccessDim::PRE_NEURON) | static_cast<unsigned int>(VarAccessDim::POST_NEURON) | static_cast<unsigned int>(VarAccessDim::BATCH),
@@ -61,17 +52,17 @@ enum class NeuronVarAccess : unsigned int
     READ_ONLY_DUPLICATE         = static_cast<unsigned int>(VarAccessMode::READ_ONLY) | static_cast<unsigned int>(VarAccessDim::PRE_NEURON) | static_cast<unsigned int>(VarAccessDim::POST_NEURON) | static_cast<unsigned int>(VarAccessDim::BATCH),
 
     // Presynaptic variables
-    READ_WRITE_PRE              = static_cast<unsigned int>(VarAccessMode::READ_WRITE) | static_cast<unsigned int>(VarAccessDim::PRE_NEURON) | static_cast<unsigned int>(VarAccessDim::BATCH),
-    READ_ONLY_PRE               = static_cast<unsigned int>(VarAccessMode::READ_ONLY) | static_cast<unsigned int>(VarAccessDim::PRE_NEURON),
-    READ_ONLY_PRE_DUPLICATE     = static_cast<unsigned int>(VarAccessMode::READ_ONLY) | static_cast<unsigned int>(VarAccessDim::PRE_NEURON) | static_cast<unsigned int>(VarAccessDim::BATCH),
+    //READ_WRITE_PRE              = static_cast<unsigned int>(VarAccessMode::READ_WRITE) | static_cast<unsigned int>(VarAccessDim::PRE_NEURON) | static_cast<unsigned int>(VarAccessDim::BATCH),
+    //READ_ONLY_PRE               = static_cast<unsigned int>(VarAccessMode::READ_ONLY) | static_cast<unsigned int>(VarAccessDim::PRE_NEURON),
+    //READ_ONLY_PRE_DUPLICATE     = static_cast<unsigned int>(VarAccessMode::READ_ONLY) | static_cast<unsigned int>(VarAccessDim::PRE_NEURON) | static_cast<unsigned int>(VarAccessDim::BATCH),
 
     // Postsynaptic variables
-    READ_WRITE_POST             = static_cast<unsigned int>(VarAccessMode::READ_WRITE) | static_cast<unsigned int>(VarAccessDim::POST_NEURON) | static_cast<unsigned int>(VarAccessDim::BATCH),
-    READ_ONLY_POST              = static_cast<unsigned int>(VarAccessMode::READ_ONLY) | static_cast<unsigned int>(VarAccessDim::POST_NEURON),
-    READ_ONLY_POST_DUPLICATE    = static_cast<unsigned int>(VarAccessMode::READ_ONLY) | static_cast<unsigned int>(VarAccessDim::POST_NEURON) | static_cast<unsigned int>(VarAccessDim::BATCH), 
+    //READ_WRITE_POST             = static_cast<unsigned int>(VarAccessMode::READ_WRITE) | static_cast<unsigned int>(VarAccessDim::POST_NEURON) | static_cast<unsigned int>(VarAccessDim::BATCH),
+    //READ_ONLY_POST              = static_cast<unsigned int>(VarAccessMode::READ_ONLY) | static_cast<unsigned int>(VarAccessDim::POST_NEURON),
+    //READ_ONLY_POST_DUPLICATE    = static_cast<unsigned int>(VarAccessMode::READ_ONLY) | static_cast<unsigned int>(VarAccessDim::POST_NEURON) | static_cast<unsigned int>(VarAccessDim::BATCH), 
 };
 
-enum class CustomUpdateVarAccess : unsigned int
+/*enum class CustomUpdateVarAccess : unsigned int
 {
     // Variables with matching shape
     READ_WRITE,
@@ -95,19 +86,6 @@ enum class CustomUpdateVarAccess : unsigned int
     REDUCE_POST_NEURON_MAX,       
 }*/
 
-//! Supported combinations of VarAccessMode and VarAccessDuplication
-enum class VarAccess : unsigned int
-{
-    READ_WRITE              = static_cast<unsigned int>(VarAccessMode::READ_WRITE) | static_cast<unsigned int>(VarAccessDuplication::DUPLICATE),
-    READ_ONLY               = static_cast<unsigned int>(VarAccessMode::READ_ONLY) | static_cast<unsigned int>(VarAccessDuplication::SHARED),
-    READ_ONLY_SHARED_NEURON = static_cast<unsigned int>(VarAccessMode::READ_ONLY) | static_cast<unsigned int>(VarAccessDuplication::SHARED_NEURON),
-    READ_ONLY_DUPLICATE     = static_cast<unsigned int>(VarAccessMode::READ_ONLY) | static_cast<unsigned int>(VarAccessDuplication::DUPLICATE),
-    REDUCE_BATCH_SUM        = static_cast<unsigned int>(VarAccessMode::REDUCE_SUM) | static_cast<unsigned int>(VarAccessDuplication::SHARED),
-    REDUCE_BATCH_MAX        = static_cast<unsigned int>(VarAccessMode::REDUCE_MAX) | static_cast<unsigned int>(VarAccessDuplication::SHARED),
-    REDUCE_NEURON_SUM       = static_cast<unsigned int>(VarAccessMode::REDUCE_SUM) | static_cast<unsigned int>(VarAccessDuplication::SHARED_NEURON),
-    REDUCE_NEURON_MAX       = static_cast<unsigned int>(VarAccessMode::REDUCE_MAX) | static_cast<unsigned int>(VarAccessDuplication::SHARED_NEURON),
-};
-
 //----------------------------------------------------------------------------
 // Operators
 //----------------------------------------------------------------------------
@@ -116,9 +94,9 @@ inline bool operator & (unsigned int type, VarAccessMode mode)
     return (type & static_cast<unsigned int>(mode)) != 0;
 }
 
-inline bool operator & (unsigned int type, VarAccessDuplication duplication)
+inline bool operator & (unsigned int type, VarAccessDim dim)
 {
-    return (type & static_cast<unsigned int>(duplication)) != 0;
+    return (type & static_cast<unsigned int>(dim)) != 0;
 }
 
 inline bool operator & (unsigned int type, VarAccessModeAttribute modeAttribute)
@@ -136,6 +114,11 @@ inline bool operator & (VarAccessMode a, VarAccessMode b)
     return (static_cast<unsigned int>(a) & static_cast<unsigned int>(b)) != 0;
 }
 
+inline unsigned int operator | (VarAccessDim a, VarAccessDim b)
+{
+    return (static_cast<unsigned int>(a) | static_cast<unsigned int>(b));
+}
+
 
 //----------------------------------------------------------------------------
 // Helpers
@@ -143,10 +126,5 @@ inline bool operator & (VarAccessMode a, VarAccessMode b)
 inline VarAccessMode getVarAccessMode(unsigned int type)
 {
     return static_cast<VarAccessMode>(type & 0x1F);
-}
-
-inline VarAccessDuplication getVarAccessDuplication(unsigned int type)
-{
-    return static_cast<VarAccessDuplication>(type & ~0x1F);
 }
 }   // namespace GeNN

--- a/include/genn/genn/varAccess.h
+++ b/include/genn/genn/varAccess.h
@@ -33,6 +33,68 @@ enum class VarAccessDuplication : unsigned int
     SHARED_NEURON   = (1 << 7)  //! This variable should be shared between neurons
 };
 
+//! Flags defining dimensions this variables has
+enum class VarAccessDim : unsigned int
+{
+    NEURON      = (1 << 5),
+    PRE_NEURON  = (1 << 6),
+    POST_NEURON = (1 << 7),
+    DELAY       = (1 << 8),
+    BATCH       = (1 << 9),
+};
+
+//! Supported combinations of access mode and dimension for neuron variables
+enum class NeuronVarAccess : unsigned int
+{
+    READ_WRITE              = static_cast<unsigned int>(VarAccessMode::READ_WRITE) | static_cast<unsigned int>(VarAccessDim::NEURON) | static_cast<unsigned int>(VarAccessDim::BATCH),
+    READ_ONLY               = static_cast<unsigned int>(VarAccessMode::READ_ONLY) | static_cast<unsigned int>(VarAccessDim::NEURON) | static_cast<unsigned int>(VarAccessDim::BATCH),
+    READ_ONLY_DUPLICATE     = static_cast<unsigned int>(VarAccessMode::READ_ONLY) | static_cast<unsigned int>(VarAccessDim::NEURON),
+    READ_ONLY_SHARED_NEURON = static_cast<unsigned int>(VarAccessMode::READ_ONLY) | static_cast<unsigned int>(VarAccessDim::BATCH),
+};
+
+//! Supported combinations of access mode and dimension for synapse variables
+/*enum class SynapseVarAccess : unsigned int
+{
+    // Synaptic variables
+    READ_WRITE                  = static_cast<unsigned int>(VarAccessMode::READ_WRITE) | static_cast<unsigned int>(VarAccessDim::PRE_NEURON) | static_cast<unsigned int>(VarAccessDim::POST_NEURON) | static_cast<unsigned int>(VarAccessDim::BATCH),
+    READ_ONLY                   = static_cast<unsigned int>(VarAccessMode::READ_ONLY) | static_cast<unsigned int>(VarAccessDim::PRE_NEURON) | static_cast<unsigned int>(VarAccessDim::POST_NEURON),
+    READ_ONLY_DUPLICATE         = static_cast<unsigned int>(VarAccessMode::READ_ONLY) | static_cast<unsigned int>(VarAccessDim::PRE_NEURON) | static_cast<unsigned int>(VarAccessDim::POST_NEURON) | static_cast<unsigned int>(VarAccessDim::BATCH),
+
+    // Presynaptic variables
+    READ_WRITE_PRE              = static_cast<unsigned int>(VarAccessMode::READ_WRITE) | static_cast<unsigned int>(VarAccessDim::PRE_NEURON) | static_cast<unsigned int>(VarAccessDim::BATCH),
+    READ_ONLY_PRE               = static_cast<unsigned int>(VarAccessMode::READ_ONLY) | static_cast<unsigned int>(VarAccessDim::PRE_NEURON),
+    READ_ONLY_PRE_DUPLICATE     = static_cast<unsigned int>(VarAccessMode::READ_ONLY) | static_cast<unsigned int>(VarAccessDim::PRE_NEURON) | static_cast<unsigned int>(VarAccessDim::BATCH),
+
+    // Postsynaptic variables
+    READ_WRITE_POST             = static_cast<unsigned int>(VarAccessMode::READ_WRITE) | static_cast<unsigned int>(VarAccessDim::POST_NEURON) | static_cast<unsigned int>(VarAccessDim::BATCH),
+    READ_ONLY_POST              = static_cast<unsigned int>(VarAccessMode::READ_ONLY) | static_cast<unsigned int>(VarAccessDim::POST_NEURON),
+    READ_ONLY_POST_DUPLICATE    = static_cast<unsigned int>(VarAccessMode::READ_ONLY) | static_cast<unsigned int>(VarAccessDim::POST_NEURON) | static_cast<unsigned int>(VarAccessDim::BATCH), 
+};
+
+enum class CustomUpdateVarAccess : unsigned int
+{
+    // Variables with matching shape
+    READ_WRITE,
+    READ_ONLY,
+
+    // Variables shared across batches
+    READ_WRITE_SHARED,
+    READ_ONLY_SHARED,
+
+
+    READ_WRITE_PRE,
+
+    // Reduction variables
+    REDUCE_BATCH_SUM,
+    REDUCE_BATCH_MAX,
+    REDUCE_NEURON_SUM,
+    REDUCE_NEURON_MAX,        
+    REDUCE_PRE_NEURON_SUM,
+    REDUCE_PRE_NEURON_MAX,       
+    REDUCE_POST_NEURON_SUM,       
+    REDUCE_POST_NEURON_MAX,       
+}*/
+
 //! Supported combinations of VarAccessMode and VarAccessDuplication
 enum class VarAccess : unsigned int
 {
@@ -49,19 +111,19 @@ enum class VarAccess : unsigned int
 //----------------------------------------------------------------------------
 // Operators
 //----------------------------------------------------------------------------
-inline bool operator & (VarAccess type, VarAccessMode mode)
+inline bool operator & (unsigned int type, VarAccessMode mode)
 {
-    return (static_cast<unsigned int>(type) & static_cast<unsigned int>(mode)) != 0;
+    return (type & static_cast<unsigned int>(mode)) != 0;
 }
 
-inline bool operator & (VarAccess type, VarAccessDuplication duplication)
+inline bool operator & (unsigned int type, VarAccessDuplication duplication)
 {
-    return (static_cast<unsigned int>(type) & static_cast<unsigned int>(duplication)) != 0;
+    return (type & static_cast<unsigned int>(duplication)) != 0;
 }
 
-inline bool operator & (VarAccess type, VarAccessModeAttribute modeAttribute)
+inline bool operator & (unsigned int type, VarAccessModeAttribute modeAttribute)
 {
-    return (static_cast<unsigned int>(type) & static_cast<unsigned int>(modeAttribute)) != 0;
+    return (type & static_cast<unsigned int>(modeAttribute)) != 0;
 }
 
 inline bool operator & (VarAccessMode mode, VarAccessModeAttribute modeAttribute)
@@ -78,13 +140,13 @@ inline bool operator & (VarAccessMode a, VarAccessMode b)
 //----------------------------------------------------------------------------
 // Helpers
 //----------------------------------------------------------------------------
-inline VarAccessMode getVarAccessMode(VarAccess type)
+inline VarAccessMode getVarAccessMode(unsigned int type)
 {
-    return static_cast<VarAccessMode>(static_cast<unsigned int>(type) & 0x1F);
+    return static_cast<VarAccessMode>(type & 0x1F);
 }
 
-inline VarAccessDuplication getVarAccessDuplication(VarAccess type)
+inline VarAccessDuplication getVarAccessDuplication(unsigned int type)
 {
-    return static_cast<VarAccessDuplication>(static_cast<unsigned int>(type) & ~0x1F);
+    return static_cast<VarAccessDuplication>(type & ~0x1F);
 }
 }   // namespace GeNN

--- a/include/genn/genn/varAccess.h
+++ b/include/genn/genn/varAccess.h
@@ -120,7 +120,7 @@ inline VarAccessDim clearDim(VarAccessDim a, VarAccessDim b)
 // VarAccess
 //----------------------------------------------------------------------------
 //! Wrapper class encapsulating 
-GENN_EXPORT class VarAccess
+class VarAccess
 {
 public:
     VarAccess()

--- a/include/genn/genn/weightUpdateModels.h
+++ b/include/genn/genn/weightUpdateModels.h
@@ -131,7 +131,7 @@ class StaticPulse : public Base
 public:
     DECLARE_SNIPPET(StaticPulse);
 
-    SET_VARS({{"g", "scalar", VarAccess::READ_ONLY}});
+    SET_VARS({{"g", "scalar", SynapseVarAccess::READ_ONLY}});
 
     SET_SIM_CODE("addToPost(g);\n");
 };
@@ -182,7 +182,7 @@ class StaticPulseDendriticDelay : public Base
 public:
     DECLARE_SNIPPET(StaticPulseDendriticDelay);
 
-    SET_VARS({{"g", "scalar", VarAccess::READ_ONLY}, {"d", "uint8_t", VarAccess::READ_ONLY}});
+    SET_VARS({{"g", "scalar", SynapseVarAccess::READ_ONLY}, {"d", "uint8_t", SynapseVarAccess::READ_ONLY}});
 
     SET_SIM_CODE("addToPostDelay(g, d);\n");
 };
@@ -219,7 +219,7 @@ public:
     DECLARE_SNIPPET(StaticGraded);
 
     SET_PARAM_NAMES({"Epre", "Vslope"});
-    SET_VARS({{"g", "scalar", VarAccess::READ_ONLY}});
+    SET_VARS({{"g", "scalar", SynapseVarAccess::READ_ONLY}});
 
     SET_EVENT_CODE("addToPost(fmax(0.0, g * tanh((V_pre - Epre) / Vslope) * DT));\n");
 

--- a/pygenn/__init__.py
+++ b/pygenn/__init__.py
@@ -4,8 +4,9 @@ import sys
 # pygenn interface
 from .genn import (create_var_ref, create_psm_var_ref, create_wu_pre_var_ref,
                    create_wu_post_var_ref, create_wu_var_ref, create_egp_ref,
-                   create_psm_egp_ref, create_wu_egp_ref, PlogSeverity,
-                   SpanType, SynapseMatrixType, VarAccess,
+                   create_psm_egp_ref, create_wu_egp_ref, 
+                   CustomUpdateVarAccess, NeuronVarAccess, PlogSeverity,
+                   SpanType, SynapseMatrixType, SynapseVarAccess,
                    VarAccessMode, VarLocation)
 from .genn_model import (GeNNModel, create_neuron_model,
                          create_postsynaptic_model,

--- a/pygenn/genn_groups.py
+++ b/pygenn/genn_groups.py
@@ -15,7 +15,7 @@ import numpy as np
 
 from . import neuron_models, types
 from .genn import (CustomUpdateWU, SynapseMatrixConnectivity,
-                   SynapseMatrixWeight, VarAccessDuplication, VarLocation)
+                   SynapseMatrixWeight, VarAccessDim, VarLocation)
 from .model_preprocessor import prepare_model, ExtraGlobalParameter, Variable
 
 

--- a/pygenn/genn_groups.py
+++ b/pygenn/genn_groups.py
@@ -789,10 +789,10 @@ class SynapseGroupMixin(GroupMixin):
             # **NOTE** we assume order is row-major
             if ((self.matrix_type & SynapseMatrixConnectivity.DENSE) or
                 (self.matrix_type & SynapseMatrixWeight.KERNEL)):
-                var_data._view[:] = var_data.values
+                var_data.view[:] = var_data.values
             elif (self.matrix_type & SynapseMatrixConnectivity.SPARSE):
                 # Sort variable to match GeNN order
-                if len(var_data.shape) == 1:
+                if len(var_data.view.shape) == 1:
                     sorted_var = var_data.values[self.synapse_order]
                 else:
                     sorted_var = var_data.values[:,self.synapse_order]
@@ -806,10 +806,10 @@ class SynapseGroupMixin(GroupMixin):
                 syn = 0
                 for i, r in zip(row_start_idx, self.row_lengths):
                     # Copy row from non-padded indices into correct location
-                    if len(var_data.shape) == 1:
-                        var_data._view[i:i + r] = sorted_var[syn:syn + r]
+                    if len(var_data.view.shape) == 1:
+                        var_data.view[i:i + r] = sorted_var[syn:syn + r]
                     else:
-                        var_data._view[:,i:i + r] = sorted_var[:,syn:syn + r]
+                        var_data.view[:,i:i + r] = sorted_var[:,syn:syn + r]
                     syn += r
             else:
                 raise Exception("Matrix format not supported")

--- a/pygenn/genn_groups.py
+++ b/pygenn/genn_groups.py
@@ -993,7 +993,7 @@ class CustomConnectivityUpdateMixin(GroupMixin):
                 # Determine shape of this variable
                 var_shape = _get_synapse_var_shape(
                     v.access.get_synapse_dims(), 
-                    self, 1)
+                    self.synapse_group, 1)
 
                 resolved_type = var_data.type.resolve(self._model.type_context)
                 var_data._view = self._assign_ext_ptr_array(

--- a/pygenn/src/genn.cc
+++ b/pygenn/src/genn.cc
@@ -705,7 +705,10 @@ PYBIND11_MODULE(genn, m)
         .def("get_synapse_dims", 
              [](const VarAccess &v) { return v.getDims<SynapseVarAccess>(); })
         .def("get_custom_update_dims", 
-             [](const VarAccess &v) { return v.getDims<CustomUpdateVarAccess>(); });
+             [](const VarAccess &v, VarAccessDim cuDims) 
+             { 
+                 return clearDim(cuDims, v.getDims<CustomUpdateVarAccess>()); 
+             });
 
     //------------------------------------------------------------------------
     // genn.Var

--- a/pygenn/src/genn.cc
+++ b/pygenn/src/genn.cc
@@ -696,10 +696,6 @@ PYBIND11_MODULE(genn, m)
     // genn.VarAccess
     //------------------------------------------------------------------------
     pybind11::class_<VarAccess>(m, "VarAccess")
-        .def(pybind11::init<NeuronVarAccess>())
-        .def(pybind11::init<SynapseVarAccess>())
-        .def(pybind11::init<CustomUpdateVarAccess>())
-        
         .def("get_neuron_dims", 
              [](const VarAccess &v) { return v.getDims<NeuronVarAccess>(); })
         .def("get_synapse_dims", 
@@ -714,9 +710,13 @@ PYBIND11_MODULE(genn, m)
     // genn.Var
     //------------------------------------------------------------------------
     pybind11::class_<Models::Base::Var>(m, "Var")
-        .def(pybind11::init<const std::string&, const std::string&, VarAccess>())
+        .def(pybind11::init<const std::string&, const std::string&, NeuronVarAccess>())
+        .def(pybind11::init<const std::string&, const std::string&, SynapseVarAccess>())
+        .def(pybind11::init<const std::string&, const std::string&, CustomUpdateVarAccess>())
         .def(pybind11::init<const std::string&, const std::string&>())
-        .def(pybind11::init<const std::string&, const Type::ResolvedType&, VarAccess>())
+        .def(pybind11::init<const std::string&, const Type::ResolvedType&, NeuronVarAccess>())
+        .def(pybind11::init<const std::string&, const Type::ResolvedType&, SynapseVarAccess>())
+        .def(pybind11::init<const std::string&, const Type::ResolvedType&, CustomUpdateVarAccess>())
         .def(pybind11::init<const std::string&, const Type::ResolvedType&>())
         .def_readonly("name", &Models::Base::Var::name)
         .def_readonly("type", &Models::Base::Var::type)

--- a/src/genn/backends/single_threaded_cpu/backend.cc
+++ b/src/genn/backends/single_threaded_cpu/backend.cc
@@ -2013,22 +2013,22 @@ void Backend::genEmitSpike(EnvironmentExternalBase &env, NeuronUpdateGroupMerged
 //--------------------------------------------------------------------------
 void Backend::genWriteBackReductions(EnvironmentExternalBase &env, CustomUpdateGroupMerged &cg, const std::string &idxName) const
 {
-    genWriteBackReductions(env, cg, idxName,
-                           [&cg](const Models::VarReference &varRef, const std::string &index)
-                           {
-                               return cg.getVarRefIndex(varRef.getDelayNeuronGroup() != nullptr,
-                                                        varRef.getVar().getAccess(NeuronVarAccess::READ_WRITE),
-                                                        index);
-                           });
+    genWriteBackReductions<NeuronVarAccess>(
+        env, cg, idxName,
+        [&cg](const Models::VarReference &varRef, const std::string &index)
+        {
+            return cg.getVarRefIndex(varRef.getDelayNeuronGroup() != nullptr,
+                                    varRef.getVar().access.getDims<NeuronVarAccess>(), index);
+        });
 }
 //--------------------------------------------------------------------------
 void Backend::genWriteBackReductions(EnvironmentExternalBase &env, CustomUpdateWUGroupMergedBase &cg, const std::string &idxName) const
 {
-    genWriteBackReductions(env, cg, idxName,
-                           [&cg](const Models::WUVarReference &varRef, const std::string &index)
-                           {
-                               return cg.getVarRefIndex(varRef.getVar().getAccess(SynapseVarAccess::READ_WRITE),
-                                                        index);
-                           });
+    genWriteBackReductions<SynapseVarAccess>(
+        env, cg, idxName,
+        [&cg](const Models::WUVarReference &varRef, const std::string &index)
+        {
+            return cg.getVarRefIndex(varRef.getVar().access.getDims<SynapseVarAccess>(), index);
+        });
 }
 }   // namespace GeNN::CodeGenerator::SingleThreadedCPU

--- a/src/genn/backends/single_threaded_cpu/backend.cc
+++ b/src/genn/backends/single_threaded_cpu/backend.cc
@@ -2013,7 +2013,7 @@ void Backend::genEmitSpike(EnvironmentExternalBase &env, NeuronUpdateGroupMerged
 //--------------------------------------------------------------------------
 void Backend::genWriteBackReductions(EnvironmentExternalBase &env, CustomUpdateGroupMerged &cg, const std::string &idxName) const
 {
-    genWriteBackReductions<NeuronVarAccess>(
+    genWriteBackReductions(
         env, cg, idxName,
         [&cg](const Models::VarReference &varRef, const std::string &index)
         {
@@ -2024,7 +2024,7 @@ void Backend::genWriteBackReductions(EnvironmentExternalBase &env, CustomUpdateG
 //--------------------------------------------------------------------------
 void Backend::genWriteBackReductions(EnvironmentExternalBase &env, CustomUpdateWUGroupMergedBase &cg, const std::string &idxName) const
 {
-    genWriteBackReductions<SynapseVarAccess>(
+    genWriteBackReductions(
         env, cg, idxName,
         [&cg](const Models::WUVarReference &varRef, const std::string &index)
         {

--- a/src/genn/backends/single_threaded_cpu/backend.cc
+++ b/src/genn/backends/single_threaded_cpu/backend.cc
@@ -2018,7 +2018,7 @@ void Backend::genWriteBackReductions(EnvironmentExternalBase &env, CustomUpdateG
         [&cg](const Models::VarReference &varRef, const std::string &index)
         {
             return cg.getVarRefIndex(varRef.getDelayNeuronGroup() != nullptr, 1,
-                                     varRef.getVar().access.getDims<NeuronVarAccess>(), index);
+                                     varRef.getDims(), index);
         });
 }
 //--------------------------------------------------------------------------
@@ -2028,7 +2028,7 @@ void Backend::genWriteBackReductions(EnvironmentExternalBase &env, CustomUpdateW
         env, cg, idxName,
         [&cg](const Models::WUVarReference &varRef, const std::string &index)
         {
-            return cg.getVarRefIndex(1, varRef.getVar().access.getDims<SynapseVarAccess>(), index);
+            return cg.getVarRefIndex(1, varRef.getDims(), index);
         });
 }
 }   // namespace GeNN::CodeGenerator::SingleThreadedCPU

--- a/src/genn/backends/single_threaded_cpu/backend.cc
+++ b/src/genn/backends/single_threaded_cpu/backend.cc
@@ -2016,9 +2016,8 @@ void Backend::genWriteBackReductions(EnvironmentExternalBase &env, CustomUpdateG
     genWriteBackReductions(env, cg, idxName,
                            [&cg](const Models::VarReference &varRef, const std::string &index)
                            {
-                               const unsigned int varAccess = varRef.getVar().access.value_or(static_cast<unsigned int>(VarAccess::READ_WRITE));
                                return cg.getVarRefIndex(varRef.getDelayNeuronGroup() != nullptr,
-                                                        getVarAccessDuplication(varAccess),
+                                                        getVarAccessDuplication(varRef.getVar().getAccess(VarAccess::READ_WRITE)),
                                                         index);
                            });
 }
@@ -2028,8 +2027,7 @@ void Backend::genWriteBackReductions(EnvironmentExternalBase &env, CustomUpdateW
     genWriteBackReductions(env, cg, idxName,
                            [&cg](const Models::WUVarReference &varRef, const std::string &index)
                            {
-                               const unsigned int varAccess = varRef.getVar().access.value_or(static_cast<unsigned int>(VarAccess::READ_WRITE));
-                               return cg.getVarRefIndex(getVarAccessDuplication(varAccess),
+                               return cg.getVarRefIndex(getVarAccessDuplication(varRef.getVar().getAccess(VarAccess::READ_WRITE)),
                                                         index);
                            });
 }

--- a/src/genn/backends/single_threaded_cpu/backend.cc
+++ b/src/genn/backends/single_threaded_cpu/backend.cc
@@ -2017,7 +2017,7 @@ void Backend::genWriteBackReductions(EnvironmentExternalBase &env, CustomUpdateG
                            [&cg](const Models::VarReference &varRef, const std::string &index)
                            {
                                return cg.getVarRefIndex(varRef.getDelayNeuronGroup() != nullptr,
-                                                        getVarAccessDuplication(varRef.getVar().getAccess(VarAccess::READ_WRITE)),
+                                                        varRef.getVar().getAccess(NeuronVarAccess::READ_WRITE),
                                                         index);
                            });
 }
@@ -2027,7 +2027,7 @@ void Backend::genWriteBackReductions(EnvironmentExternalBase &env, CustomUpdateW
     genWriteBackReductions(env, cg, idxName,
                            [&cg](const Models::WUVarReference &varRef, const std::string &index)
                            {
-                               return cg.getVarRefIndex(getVarAccessDuplication(varRef.getVar().getAccess(VarAccess::READ_WRITE)),
+                               return cg.getVarRefIndex(varRef.getVar().getAccess(SynapseVarAccess::READ_WRITE),
                                                         index);
                            });
 }

--- a/src/genn/backends/single_threaded_cpu/backend.cc
+++ b/src/genn/backends/single_threaded_cpu/backend.cc
@@ -2016,8 +2016,9 @@ void Backend::genWriteBackReductions(EnvironmentExternalBase &env, CustomUpdateG
     genWriteBackReductions(env, cg, idxName,
                            [&cg](const Models::VarReference &varRef, const std::string &index)
                            {
+                               const unsigned int varAccess = varRef.getVar().access.value_or(static_cast<unsigned int>(VarAccess::READ_WRITE));
                                return cg.getVarRefIndex(varRef.getDelayNeuronGroup() != nullptr,
-                                                        getVarAccessDuplication(varRef.getVar().access),
+                                                        getVarAccessDuplication(varAccess),
                                                         index);
                            });
 }
@@ -2027,7 +2028,8 @@ void Backend::genWriteBackReductions(EnvironmentExternalBase &env, CustomUpdateW
     genWriteBackReductions(env, cg, idxName,
                            [&cg](const Models::WUVarReference &varRef, const std::string &index)
                            {
-                               return cg.getVarRefIndex(getVarAccessDuplication(varRef.getVar().access),
+                               const unsigned int varAccess = varRef.getVar().access.value_or(static_cast<unsigned int>(VarAccess::READ_WRITE));
+                               return cg.getVarRefIndex(getVarAccessDuplication(varAccess),
                                                         index);
                            });
 }

--- a/src/genn/genn/code_generator/backendBase.cc
+++ b/src/genn/genn/code_generator/backendBase.cc
@@ -411,7 +411,7 @@ void buildStandardCustomUpdateEnvironment(const BackendBase &backend, Environmen
 }
 //--------------------------------------------------------------------------
 template<typename G>
-void buildStandardCustomUpdateWUEnvironment(const BackendBase &backend, EnvironmentGroupMergedField<G> &env, unsigned int batchSize)
+void buildStandardCustomUpdateWUEnvironment(EnvironmentGroupMergedField<G> &env, unsigned int batchSize)
 {
     // Add batch offset if group is batched
     if((env.getGroup().getArchetype().getDims() & VarAccessDim::BATCH) && (batchSize > 1)) {
@@ -579,12 +579,12 @@ void BackendBase::buildStandardEnvironment(EnvironmentGroupMergedField<CustomUpd
 //-----------------------------------------------------------------------
 void BackendBase::buildStandardEnvironment(EnvironmentGroupMergedField<CustomUpdateWUGroupMerged> &env, unsigned int batchSize) const
 {
-    buildStandardCustomUpdateWUEnvironment(*this, env, batchSize);
+    buildStandardCustomUpdateWUEnvironment(env, batchSize);
 }
 //-----------------------------------------------------------------------
 void BackendBase::buildStandardEnvironment(EnvironmentGroupMergedField<CustomUpdateTransposeWUGroupMerged> &env, unsigned int batchSize) const
 {
-    buildStandardCustomUpdateWUEnvironment(*this, env, batchSize);
+    buildStandardCustomUpdateWUEnvironment(env, batchSize);
 }
 //-----------------------------------------------------------------------
 void BackendBase::buildStandardEnvironment(EnvironmentGroupMergedField<CustomConnectivityUpdateGroupMerged> &env) const
@@ -611,13 +611,13 @@ void BackendBase::buildStandardEnvironment(EnvironmentGroupMergedField<CustomUpd
 void BackendBase::buildStandardEnvironment(EnvironmentGroupMergedField<CustomWUUpdateInitGroupMerged> &env, unsigned int batchSize) const
 {
     buildCustomUpdateWUSizeEnvironment(*this, env);
-    buildStandardCustomUpdateWUEnvironment(*this, env, batchSize);
+    buildStandardCustomUpdateWUEnvironment(env, batchSize);
 }
 //-----------------------------------------------------------------------
 void BackendBase::buildStandardEnvironment(EnvironmentGroupMergedField<CustomWUUpdateSparseInitGroupMerged> &env, unsigned int batchSize) const
 {
     buildCustomUpdateWUSizeEnvironment(*this, env);
-    buildStandardCustomUpdateWUEnvironment(*this, env, batchSize);
+    buildStandardCustomUpdateWUEnvironment(env, batchSize);
 }
 //-----------------------------------------------------------------------
 void BackendBase::buildStandardEnvironment(EnvironmentGroupMergedField<CustomConnectivityUpdatePreInitGroupMerged> &env) const

--- a/src/genn/genn/code_generator/backendBase.cc
+++ b/src/genn/genn/code_generator/backendBase.cc
@@ -706,18 +706,18 @@ std::vector<BackendBase::ReductionTarget> BackendBase::genInitReductionTargets(C
         [batchSize, &cg](const Models::VarReference &varRef, const std::string &index)
         {
             return cg.getVarRefIndex(varRef.getDelayNeuronGroup() != nullptr, batchSize,
-                                     varRef.getVar().access.getDims<NeuronVarAccess>(), index);
+                                     varRef.getDims(), index);
         });
 }
 //-----------------------------------------------------------------------
 std::vector<BackendBase::ReductionTarget> BackendBase::genInitReductionTargets(CodeStream &os, const CustomUpdateWUGroupMerged &cg, 
                                                                                unsigned int batchSize, const std::string &idx) const
 {
-    return genInitReductionTargets<NeuronVarAccess>(
+    return genInitReductionTargets<SynapseVarAccess>(
         os, cg, batchSize, idx,
         [batchSize, &cg](const Models::WUVarReference &varRef, const std::string &index)
         {
-            return cg.getVarRefIndex(batchSize, varRef.getVar().access.getDims<SynapseVarAccess>(), index);
+            return cg.getVarRefIndex(batchSize, varRef.getDims(), index);
         });
 }
 }   // namespace GeNN::CodeGenerator

--- a/src/genn/genn/code_generator/backendBase.cc
+++ b/src/genn/genn/code_generator/backendBase.cc
@@ -702,9 +702,8 @@ std::vector<BackendBase::ReductionTarget> BackendBase::genInitReductionTargets(C
     return genInitReductionTargets(os, cg, idx,
                                    [&cg](const Models::VarReference &varRef, const std::string &index)
                                    {
-                                       const unsigned int varAccess = varRef.getVar().access.value_or(static_cast<unsigned int>(VarAccess::READ_WRITE)); 
                                        return cg.getVarRefIndex(varRef.getDelayNeuronGroup() != nullptr,
-                                                                getVarAccessDuplication(varAccess),
+                                                                getVarAccessDuplication(varRef.getVar().getAccess(VarAccess::READ_WRITE)),
                                                                 index);
                                    });
 }
@@ -714,8 +713,7 @@ std::vector<BackendBase::ReductionTarget> BackendBase::genInitReductionTargets(C
     return genInitReductionTargets(os, cg, idx,
                                    [&cg](const Models::WUVarReference &varRef, const std::string &index)
                                    {
-                                       const unsigned int varAccess = varRef.getVar().access.value_or(static_cast<unsigned int>(VarAccess::READ_WRITE)); 
-                                       return cg.getVarRefIndex(getVarAccessDuplication(varAccess),
+                                       return cg.getVarRefIndex(getVarAccessDuplication(varRef.getVar().getAccess(VarAccess::READ_WRITE)),
                                                                 index);
                                    });
 }

--- a/src/genn/genn/code_generator/backendBase.cc
+++ b/src/genn/genn/code_generator/backendBase.cc
@@ -703,7 +703,7 @@ std::vector<BackendBase::ReductionTarget> BackendBase::genInitReductionTargets(C
                                    [&cg](const Models::VarReference &varRef, const std::string &index)
                                    {
                                        return cg.getVarRefIndex(varRef.getDelayNeuronGroup() != nullptr,
-                                                                getVarAccessDuplication(varRef.getVar().getAccess(VarAccess::READ_WRITE)),
+                                                                varRef.getVar().getAccess(NeuronVarAccess::READ_WRITE),
                                                                 index);
                                    });
 }
@@ -713,7 +713,7 @@ std::vector<BackendBase::ReductionTarget> BackendBase::genInitReductionTargets(C
     return genInitReductionTargets(os, cg, idx,
                                    [&cg](const Models::WUVarReference &varRef, const std::string &index)
                                    {
-                                       return cg.getVarRefIndex(getVarAccessDuplication(varRef.getVar().getAccess(VarAccess::READ_WRITE)),
+                                       return cg.getVarRefIndex(varRef.getVar().getAccess(SynapseVarAccess::READ_WRITE),
                                                                 index);
                                    });
 }

--- a/src/genn/genn/code_generator/backendBase.cc
+++ b/src/genn/genn/code_generator/backendBase.cc
@@ -699,22 +699,22 @@ std::string BackendBase::getReductionOperation(const std::string &reduction, con
 //-----------------------------------------------------------------------
 std::vector<BackendBase::ReductionTarget> BackendBase::genInitReductionTargets(CodeStream &os, const CustomUpdateGroupMerged &cg, const std::string &idx) const
 {
-    return genInitReductionTargets(os, cg, idx,
-                                   [&cg](const Models::VarReference &varRef, const std::string &index)
-                                   {
-                                       return cg.getVarRefIndex(varRef.getDelayNeuronGroup() != nullptr,
-                                                                varRef.getVar().getAccess(NeuronVarAccess::READ_WRITE),
-                                                                index);
-                                   });
+    return genInitReductionTargets<NeuronVarAccess>(
+        os, cg, idx,
+        [&cg](const Models::VarReference &varRef, const std::string &index)
+        {
+            return cg.getVarRefIndex(varRef.getDelayNeuronGroup() != nullptr,
+                                        varRef.getVar().access.getDims<NeuronVarAccess>(), index);
+        });
 }
 //-----------------------------------------------------------------------
 std::vector<BackendBase::ReductionTarget> BackendBase::genInitReductionTargets(CodeStream &os, const CustomUpdateWUGroupMerged &cg, const std::string &idx) const
 {
-    return genInitReductionTargets(os, cg, idx,
-                                   [&cg](const Models::WUVarReference &varRef, const std::string &index)
-                                   {
-                                       return cg.getVarRefIndex(varRef.getVar().getAccess(SynapseVarAccess::READ_WRITE),
-                                                                index);
-                                   });
+    return genInitReductionTargets<NeuronVarAccess>(
+        os, cg, idx,
+        [&cg](const Models::WUVarReference &varRef, const std::string &index)
+        {
+            return cg.getVarRefIndex(varRef.getVar().access.getDims<SynapseVarAccess>(), index);
+        });
 }
 }   // namespace GeNN::CodeGenerator

--- a/src/genn/genn/code_generator/backendBase.cc
+++ b/src/genn/genn/code_generator/backendBase.cc
@@ -702,8 +702,9 @@ std::vector<BackendBase::ReductionTarget> BackendBase::genInitReductionTargets(C
     return genInitReductionTargets(os, cg, idx,
                                    [&cg](const Models::VarReference &varRef, const std::string &index)
                                    {
+                                       const unsigned int varAccess = varRef.getVar().access.value_or(static_cast<unsigned int>(VarAccess::READ_WRITE)); 
                                        return cg.getVarRefIndex(varRef.getDelayNeuronGroup() != nullptr,
-                                                                getVarAccessDuplication(varRef.getVar().access),
+                                                                getVarAccessDuplication(varAccess),
                                                                 index);
                                    });
 }
@@ -713,7 +714,8 @@ std::vector<BackendBase::ReductionTarget> BackendBase::genInitReductionTargets(C
     return genInitReductionTargets(os, cg, idx,
                                    [&cg](const Models::WUVarReference &varRef, const std::string &index)
                                    {
-                                       return cg.getVarRefIndex(getVarAccessDuplication(varRef.getVar().access),
+                                       const unsigned int varAccess = varRef.getVar().access.value_or(static_cast<unsigned int>(VarAccess::READ_WRITE)); 
+                                       return cg.getVarRefIndex(getVarAccessDuplication(varAccess),
                                                                 index);
                                    });
 }

--- a/src/genn/genn/code_generator/backendSIMT.cc
+++ b/src/genn/genn/code_generator/backendSIMT.cc
@@ -587,7 +587,8 @@ void BackendSIMT::genNeuronUpdateKernel(EnvironmentExternalBase &env, ModelSpecM
             }
 
             // Copy spikes into block of $(_spk)
-            const std::string queueOffset = ng.getWriteVarIndex(ng.getArchetype().isDelayRequired(), batchSize, VarAccessDim::BATCH | VarAccessDim::NEURON, "");
+            const std::string queueOffset = ng.getWriteVarIndex(ng.getArchetype().isDelayRequired(), batchSize, 
+                                                                VarAccessDim::BATCH | VarAccessDim::NEURON, "");
             if(!Utils::areTokensEmpty(ng.getArchetype().getThresholdConditionCodeTokens())) {
                 const std::string queueOffsetTrueSpk = ng.getWriteVarIndex(ng.getArchetype().isTrueSpikeRequired() && ng.getArchetype().isDelayRequired(), 
                                                                            batchSize, VarAccessDim::BATCH | VarAccessDim::NEURON, "");
@@ -805,7 +806,7 @@ void BackendSIMT::genPostsynapticUpdateKernel(EnvironmentExternalBase &env, Mode
                 {
                     CodeStream::Scope b(groupEnv.getStream());
                     const std::string index = "(r * " + std::to_string(getKernelBlockSize(KernelPostsynapticUpdate)) + ") + " + getThreadID();
-                    groupEnv.printLine("const unsigned int spk = $(_trg_spk)[" + sg.getPostVarIndex(batchSize, VarAccessDim::BATCH | VarAccessDim::POST_NEURON, index) + "];");
+                    groupEnv.printLine("const unsigned int spk = $(_trg_spk)[" + sg.getPostVarIndex(batchSize, VarAccessDim::BATCH | VarAccessDim::NEURON, index) + "];");
                     groupEnv.getStream() << "shSpk[" << getThreadID() << "] = spk;" << std::endl;
 
                     if(sg.getArchetype().getMatrixType() & SynapseMatrixConnectivity::SPARSE) {

--- a/src/genn/genn/code_generator/backendSIMT.cc
+++ b/src/genn/genn/code_generator/backendSIMT.cc
@@ -514,7 +514,7 @@ void BackendSIMT::genNeuronUpdateKernel(EnvironmentExternalBase &env, ModelSpecM
                 // Add population RNG field
                 groupEnv.addField(getPopulationRNGType().createPointer(), "_rng", "rng",
                                   [this](const auto &g, size_t) { return getDeviceVarPrefix() + "rng" + g.getName(); },
-                                  ng.getVarIndex(batchSize, VarAccessDuplication::DUPLICATE, "$(id)"));
+                                  ng.getVarIndex(batchSize, VarAccessDim::BATCH | VarAccessDim::NEURON, "$(id)"));
                 // **TODO** for OCL do genPopulationRNGPreamble(os, popSubs, "group->rng[" + ng.getVarIndex(batchSize, VarAccessDuplication::DUPLICATE, "$(id)") + "]") in initialiser
 
                 ng.generateNeuronUpdate(*this, groupEnv, batchSize,
@@ -587,10 +587,10 @@ void BackendSIMT::genNeuronUpdateKernel(EnvironmentExternalBase &env, ModelSpecM
             }
 
             // Copy spikes into block of $(_spk)
-            const std::string queueOffset = ng.getWriteVarIndex(ng.getArchetype().isDelayRequired(), batchSize, VarAccessDuplication::DUPLICATE, "");
+            const std::string queueOffset = ng.getWriteVarIndex(ng.getArchetype().isDelayRequired(), batchSize, VarAccessDim::BATCH | VarAccessDim::NEURON, "");
             if(!Utils::areTokensEmpty(ng.getArchetype().getThresholdConditionCodeTokens())) {
                 const std::string queueOffsetTrueSpk = ng.getWriteVarIndex(ng.getArchetype().isTrueSpikeRequired() && ng.getArchetype().isDelayRequired(), 
-                                                                           batchSize, VarAccessDuplication::DUPLICATE, "");
+                                                                           batchSize, VarAccessDim::BATCH | VarAccessDim::NEURON, "");
                 groupEnv.print("if(" + getThreadID() + " < $(_sh_spk_count))");
                 {
                     CodeStream::Scope b(groupEnv.getStream());
@@ -805,7 +805,7 @@ void BackendSIMT::genPostsynapticUpdateKernel(EnvironmentExternalBase &env, Mode
                 {
                     CodeStream::Scope b(groupEnv.getStream());
                     const std::string index = "(r * " + std::to_string(getKernelBlockSize(KernelPostsynapticUpdate)) + ") + " + getThreadID();
-                    groupEnv.printLine("const unsigned int spk = $(_trg_spk)[" + sg.getPostVarIndex(batchSize, VarAccessDuplication::DUPLICATE, index) + "];");
+                    groupEnv.printLine("const unsigned int spk = $(_trg_spk)[" + sg.getPostVarIndex(batchSize, VarAccessDim::BATCH | VarAccessDim::POST_NEURON, index) + "];");
                     groupEnv.getStream() << "shSpk[" << getThreadID() << "] = spk;" << std::endl;
 
                     if(sg.getArchetype().getMatrixType() & SynapseMatrixConnectivity::SPARSE) {

--- a/src/genn/genn/code_generator/backendSIMT.cc
+++ b/src/genn/genn/code_generator/backendSIMT.cc
@@ -205,12 +205,12 @@ size_t BackendSIMT::getNumInitialisationRNGStreams(const ModelSpecMerged &modelM
 //--------------------------------------------------------------------------
 size_t BackendSIMT::getPaddedNumCustomUpdateThreads(const CustomUpdateInternal &cg, unsigned int batchSize) const
 {
-    const size_t numCopies = (cg.isBatched() && !cg.isBatchReduction()) ? batchSize : 1;
+    const size_t numCopies = ((cg.getDims() & VarAccessDim::BATCH) && !cg.isBatchReduction()) ? batchSize : 1;
 
     if (cg.isNeuronReduction()) {
         return padKernelSize(32 * numCopies, KernelCustomUpdate);
     }
-    else if (cg.isPerNeuron()) {
+    else if (!(cg.getDims() & VarAccessDim::NEURON)) {
         return numCopies * padKernelSize(cg.getSize(), KernelCustomUpdate);
     }
     else {
@@ -221,7 +221,7 @@ size_t BackendSIMT::getPaddedNumCustomUpdateThreads(const CustomUpdateInternal &
 size_t BackendSIMT::getPaddedNumCustomUpdateWUThreads(const CustomUpdateWUInternal &cg, unsigned int batchSize) const
 {
     const SynapseGroupInternal *sgInternal = static_cast<const SynapseGroupInternal*>(cg.getSynapseGroup());
-    const size_t numCopies = (cg.isBatched() && !cg.isBatchReduction()) ? batchSize : 1;
+    const size_t numCopies = ((cg.getDims() & VarAccessDim::BATCH) && !cg.isBatchReduction()) ? batchSize : 1;
 
     if(sgInternal->getMatrixType() & SynapseMatrixWeight::KERNEL) {
         return numCopies * padKernelSize(sgInternal->getKernelSizeFlattened(), KernelCustomUpdate);
@@ -239,7 +239,7 @@ size_t BackendSIMT::getPaddedNumCustomUpdateTransposeWUThreads(const CustomUpdat
     
     const size_t paddedNumPre = padKernelSize(cg.getSynapseGroup()->getSrcNeuronGroup()->getNumNeurons(), KernelCustomTransposeUpdate);
     const size_t paddedNumPost = padKernelSize(cg.getSynapseGroup()->getTrgNeuronGroup()->getNumNeurons(), KernelCustomTransposeUpdate);
-    const size_t numCopies = cg.isBatched() ? batchSize : 1;
+    const size_t numCopies = (cg.getDims() & VarAccessDim::BATCH) ? batchSize : 1;
     return numCopies * paddedNumPre * paddedNumPost / getKernelBlockSize(KernelCustomTransposeUpdate);
 }
 //--------------------------------------------------------------------------
@@ -950,7 +950,8 @@ void BackendSIMT::genCustomUpdateKernel(EnvironmentExternal &env, ModelSpecMerge
                     CodeStream::Scope b(groupEnv.getStream());
                     
                     // Initialise reduction targets
-                    const auto reductionTargets = genInitReductionTargets(groupEnv.getStream(), cg, groupEnv["id"]);
+                    const auto reductionTargets = genInitReductionTargets(groupEnv.getStream(), cg, 
+                                                                          batchSize, groupEnv["id"]);
 
                     // Loop through batches
                     // **TODO** this naive approach is good for reduction when there are lots of neurons/synapses but,
@@ -960,11 +961,11 @@ void BackendSIMT::genCustomUpdateKernel(EnvironmentExternal &env, ModelSpecMerge
                         CodeStream::Scope b(groupEnv.getStream());
                         EnvironmentGroupMergedField<CustomUpdateGroupMerged> batchEnv(groupEnv, cg);
                         batchEnv.add(Type::Uint32.addConst(), "batch", "batch");
-                        buildStandardEnvironment(batchEnv);
+                        buildStandardEnvironment(batchEnv, batchSize);
 
                         // **THINK** it would be great to 'lift' reads of SHARED variables out of this loop
                         cg.generateCustomUpdate(
-                            *this, batchEnv,
+                            *this, batchEnv, batchSize,
                             [&reductionTargets, this](auto &env, const auto&)
                             {
                                 // Loop through reduction targets and generate reduction
@@ -995,10 +996,10 @@ void BackendSIMT::genCustomUpdateKernel(EnvironmentExternal &env, ModelSpecMerge
                                  {groupEnv.addInitialiser("const unsigned int batch = $(id) / 32;")});
 
                     EnvironmentGroupMergedField<CustomUpdateGroupMerged> batchEnv(groupEnv, cg);
-                    buildStandardEnvironment(batchEnv);
+                    buildStandardEnvironment(batchEnv, batchSize);
 
                     // Initialise reduction targets
-                    const auto reductionTargets = genInitReductionTargets(batchEnv.getStream(), cg);
+                    const auto reductionTargets = genInitReductionTargets(batchEnv.getStream(), cg, batchSize);
 
                     // Loop through warps of data
                     // **TODO** this approach is good for reductions where there are small numbers of neurons but large batches sizes but,
@@ -1012,7 +1013,7 @@ void BackendSIMT::genCustomUpdateKernel(EnvironmentExternal &env, ModelSpecMerge
 
                         // **THINK** it would be great to 'lift' reads of NEURON_SHARED variables out of this loop
                         cg.generateCustomUpdate(
-                            *this, batchEnv,
+                            *this, batchEnv, batchSize,
                             [&reductionTargets, this](auto &env, const auto&)
                             {
                                 // Loop through reduction targets and generate reduction
@@ -1042,24 +1043,25 @@ void BackendSIMT::genCustomUpdateKernel(EnvironmentExternal &env, ModelSpecMerge
                 }
             }
             // Otherwise, if this update isn't per-neuron
-            else if (!cg.getArchetype().isPerNeuron()) {
+            else if (cg.getArchetype().getDims() & VarAccessDim::NEURON) {
                 // Use local ID for batch and always use zero for ID
                 groupEnv.add(Type::Uint32.addConst(), "batch", "$(_id)");
                 groupEnv.add(Type::Uint32.addConst(), "id", "0");
 
                 groupEnv.getStream() << "// only do this for existing neurons" << std::endl;
-                groupEnv.getStream() << "if(" << groupEnv["batch"] << " < " << (cg.getArchetype().isBatched() ? batchSize : 1) << ")";
+                groupEnv.getStream() << "if(" << groupEnv["batch"] << " < " << ((cg.getArchetype().getDims() & VarAccessDim::BATCH) ? batchSize : 1) << ")";
                 {
                     CodeStream::Scope b(groupEnv.getStream());
                     EnvironmentGroupMergedField<CustomUpdateGroupMerged> batchEnv(groupEnv, cg);
-                    buildStandardEnvironment(batchEnv);
+                    buildStandardEnvironment(batchEnv, batchSize);
 
-                    cg.generateCustomUpdate(*this, batchEnv, [](auto&, auto&){});
+                    cg.generateCustomUpdate(*this, batchEnv, batchSize,
+                                            [](auto&, auto&){});
                 }
             }
             // Otherwise
             else {
-                if(cg.getArchetype().isBatched()) {
+                if((cg.getArchetype().getDims() & VarAccessDim::BATCH) && (batchSize > 1)) {
                     // Split ID into intra-batch ID and batch
                     // **TODO** fast-divide style optimisations here
                     const std::string blockSizeStr = std::to_string(blockSize);
@@ -1077,13 +1079,14 @@ void BackendSIMT::genCustomUpdateKernel(EnvironmentExternal &env, ModelSpecMerge
                 }
 
                 EnvironmentGroupMergedField<CustomUpdateGroupMerged> batchEnv(groupEnv, cg);
-                buildStandardEnvironment(batchEnv);
+                buildStandardEnvironment(batchEnv, batchSize);
                 
                 batchEnv.getStream() << "// only do this for existing neurons" << std::endl;
                 batchEnv.print("if($(id) < $(size))");
                 {
                     CodeStream::Scope b(batchEnv.getStream());
-                    cg.generateCustomUpdate(*this, batchEnv, [](auto&, auto&){});
+                    cg.generateCustomUpdate(*this, batchEnv, batchSize,
+                                            [](auto&, auto&){});
                 }
             }
         });
@@ -1112,7 +1115,7 @@ void BackendSIMT::genCustomUpdateWUKernel(EnvironmentExternal &env, ModelSpecMer
             // If update isn't a batch reduction
             if(!cg.getArchetype().isBatchReduction()) {
                 // If it's batched
-                if(cg.getArchetype().isBatched()) {
+                if((cg.getArchetype().getDims() & VarAccessDim::BATCH) && (batchSize > 1)) {
                     // Split ID into intra-batch ID and batch
                     // **TODO** fast-divide style optimisations here
                     const std::string blockSizeStr = std::to_string(blockSize);
@@ -1163,7 +1166,8 @@ void BackendSIMT::genCustomUpdateWUKernel(EnvironmentExternal &env, ModelSpecMer
                 synEnv.add(Type::Uint32.addConst(), "id_syn", "$(id)");
 
                 // Initialise reduction targets
-                const auto reductionTargets = genInitReductionTargets(synEnv.getStream(), cg, synEnv["id_syn"]);
+                const auto reductionTargets = genInitReductionTargets(synEnv.getStream(), cg, 
+                                                                      batchSize, synEnv["id_syn"]);
 
                 // If this is a reduction
                 if(cg.getArchetype().isBatchReduction()) {
@@ -1178,10 +1182,10 @@ void BackendSIMT::genCustomUpdateWUKernel(EnvironmentExternal &env, ModelSpecMer
                 // **NOTE** use scope to force batchEnv to generate all code within loop
                 {
                     EnvironmentGroupMergedField<CustomUpdateWUGroupMerged> batchEnv(synEnv, cg);
-                    buildStandardEnvironment(batchEnv);
+                    buildStandardEnvironment(batchEnv, batchSize);
 
                     cg.generateCustomUpdate(
-                        *this, batchEnv,
+                        *this, batchEnv, batchSize,
                         [&reductionTargets, this](auto &env, auto &cg)
                         {
                                 // If this is a reduction
@@ -1216,12 +1220,13 @@ void BackendSIMT::genCustomTransposeUpdateWUKernel(EnvironmentExternal &env, Mod
                                                    BackendBase::MemorySpaces &memorySpaces, const std::string &updateGroup, size_t &idStart) const
 {
     // Generate 2D array
+    const unsigned int batchSize = modelMerged.getModel().getBatchSize();
     const size_t blockSize = getKernelBlockSize(KernelCustomTransposeUpdate);
     env.getStream() << getSharedPrefix() << " float shTile[" << blockSize << "][" << (blockSize + 1) << "];" << std::endl;
     genParallelGroup<CustomUpdateTransposeWUGroupMerged>(
         env, modelMerged, memorySpaces, updateGroup, idStart, &ModelSpecMerged::genMergedCustomUpdateTransposeWUGroups,
-        [&modelMerged, this](const CustomUpdateWUInternal &cu) { return getPaddedNumCustomUpdateTransposeWUThreads(cu, modelMerged.getModel().getBatchSize()); },
-        [blockSize, this](EnvironmentExternalBase &env, CustomUpdateTransposeWUGroupMerged &cg)
+        [batchSize, &modelMerged, this](const CustomUpdateWUInternal &cu) { return getPaddedNumCustomUpdateTransposeWUThreads(cu, batchSize); },
+        [batchSize, blockSize, this](EnvironmentExternalBase &env, CustomUpdateTransposeWUGroupMerged &cg)
         {
             EnvironmentGroupMergedField<CustomUpdateTransposeWUGroupMerged> groupEnv(env, cg);
             buildSizeEnvironment(groupEnv);
@@ -1232,7 +1237,7 @@ void BackendSIMT::genCustomTransposeUpdateWUKernel(EnvironmentExternal &env, Mod
             // Calculate what block this kernel starts at (because of kernel merging, it may not start at block 0)
             groupEnv.getStream() << "const unsigned int blockStart = " << groupEnv["_group_start_id"] << " / " << blockSize << ";" << std::endl;
 
-            if(cg.getArchetype().isBatched()) {
+            if((cg.getArchetype().getDims() & VarAccessDim::BATCH) && (batchSize > 1)) {
                 // If there's multiple batches we also need to know how many Y blocks and hence total blocks there are
                 groupEnv.getStream() << "const unsigned int numYBlocks = (" << groupEnv["num_pre"] << " + " << (blockSize - 1) << ") / " << blockSize << ";" << std::endl;
                 groupEnv.getStream() << "const unsigned int numBlocks = numXBlocks * numYBlocks;" << std::endl;
@@ -1252,7 +1257,7 @@ void BackendSIMT::genCustomTransposeUpdateWUKernel(EnvironmentExternal &env, Mod
             }
 
             EnvironmentGroupMergedField<CustomUpdateTransposeWUGroupMerged> batchEnv(groupEnv, cg);
-            buildStandardEnvironment(batchEnv);
+            buildStandardEnvironment(batchEnv, batchSize);
 
             // Add field for transpose field and get its name
             const std::string transposeVarName = cg.addTransposeField(*this, batchEnv);
@@ -1287,7 +1292,7 @@ void BackendSIMT::genCustomTransposeUpdateWUKernel(EnvironmentExternal &env, Mod
                             synEnv.add(Type::Uint32.addConst(), "id_syn", "idx",
                                        {synEnv.addInitialiser("const unsigned int idx = ((y + j) * $(num_post)) + x;")});
                             cg.generateCustomUpdate(
-                                *this, synEnv,
+                                *this, synEnv, batchSize,
                                 [&transposeVarName, this](auto &env, const auto&)
                                 {        
                                     // Write forward weight to shared memory
@@ -1317,7 +1322,7 @@ void BackendSIMT::genCustomTransposeUpdateWUKernel(EnvironmentExternal &env, Mod
                         {
                             CodeStream::Scope b(batchEnv.getStream());
                             batchEnv.print("$(" + transposeVarName + "_transpose)[");
-                            if(cg.getArchetype().isBatched()) {
+                            if((cg.getArchetype().getDims() & VarAccessDim::BATCH) && (batchSize > 1)) {
                                 batchEnv.print("$(_batch_offset) + ");
                             }
                             batchEnv.printLine("((y + j) * $(num_pre)) + x] = shTile[" + getThreadID(0) + "][" + getThreadID(1) + " + j];");
@@ -1444,7 +1449,7 @@ void BackendSIMT::genInitializeKernel(EnvironmentExternalBase &env, ModelSpecMer
         [batchSize, this](EnvironmentExternalBase &env, CustomUpdateInitGroupMerged &cg)
         {
             EnvironmentGroupMergedField<CustomUpdateInitGroupMerged> groupEnv(env, cg);
-            buildStandardEnvironment(groupEnv);
+            buildStandardEnvironment(groupEnv, batchSize);
 
             groupEnv.getStream() << "// only do this for existing variables" << std::endl;
             groupEnv.print("if($(id) < $(size))");
@@ -1471,7 +1476,7 @@ void BackendSIMT::genInitializeKernel(EnvironmentExternalBase &env, ModelSpecMer
         [batchSize, this](EnvironmentExternalBase &env, CustomWUUpdateInitGroupMerged &cg)
         {
             EnvironmentGroupMergedField<CustomWUUpdateInitGroupMerged> groupEnv(env, cg);
-            buildStandardEnvironment(groupEnv);
+            buildStandardEnvironment(groupEnv, batchSize);
             const SynapseGroup *sg = cg.getArchetype().getSynapseGroup();
             genSynapseVarInit(groupEnv, batchSize, cg, cg.getArchetype().isInitRNGRequired(), 
                               (sg->getMatrixType() & SynapseMatrixWeight::KERNEL), sg->getKernelSize().size());
@@ -1749,7 +1754,7 @@ void BackendSIMT::genInitializeSparseKernel(EnvironmentExternalBase &env, ModelS
         [batchSize, numInitializeThreads, this](EnvironmentExternalBase &env, CustomWUUpdateSparseInitGroupMerged &cg)
         {
             EnvironmentGroupMergedField<CustomWUUpdateSparseInitGroupMerged> groupEnv(env, cg);
-            buildStandardEnvironment(groupEnv);
+            buildStandardEnvironment(groupEnv, batchSize);
 
             // If this custom update requires an RNG for initialisation,
             // make copy of global phillox RNG and skip ahead by thread id

--- a/src/genn/genn/code_generator/customConnectivityUpdateGroupMerged.cc
+++ b/src/genn/genn/code_generator/customConnectivityUpdateGroupMerged.cc
@@ -37,11 +37,11 @@ CustomConnectivityUpdateGroupMerged::CustomConnectivityUpdateGroupMerged(size_t 
                                {  
                                    boost::uuids::detail::sha1 hashA;  
                                    Type::updateHash(a.getVar().type, hashA);
-                                   Utils::updateHash(a.getVar().access.template getDims<SynapseVarAccess>(), hashA);
+                                   Utils::updateHash(a.getDims(), hashA);
 
                                    boost::uuids::detail::sha1 hashB;
                                    Type::updateHash(b.getVar().type, hashB);
-                                   Utils::updateHash(b.getVar().access.template getDims<SynapseVarAccess>(), hashB);
+                                   Utils::updateHash(b.getDims(), hashB);
 
                                    return (hashA.get_digest() < hashB.get_digest());
                                 });
@@ -56,61 +56,6 @@ CustomConnectivityUpdateGroupMerged::CustomConnectivityUpdateGroupMerged(size_t 
                        {
                            return (vars.size() == m_SortedDependentVars.front().size());
                        }));
-    
-    
-    /*addField(Uint32, "rowStride",
-            [&backend](const auto &cg, size_t) 
-            { 
-                const SynapseGroupInternal *sgInternal = static_cast<const SynapseGroupInternal*>(cg.getSynapseGroup());
-                return std::to_string(backend.getSynapticMatrixRowStride(*sgInternal)); 
-            });
-    
-    
-    assert(getArchetype().getSynapseGroup()->getMatrixType() & SynapseMatrixConnectivity::SPARSE);
-    addField(getArchetype().getSynapseGroup()->getSparseIndType().createPointer(), "ind", 
-             [&backend](const auto &cg, size_t) 
-             { 
-                 return backend.getDeviceVarPrefix() + "ind" + cg.getSynapseGroup()->getName(); 
-             });
-
-    addField(Uint32.createPointer(), "rowLength",
-             [&backend](const auto &cg, size_t) 
-             { 
-                 return backend.getDeviceVarPrefix() + "rowLength" + cg.getSynapseGroup()->getName(); 
-             });
-
-    // If some presynaptic variables are delayed, add delay pointer
-    if (getArchetype().getPreDelayNeuronGroup() != nullptr) {
-        addField(Uint32.createPointer(), "preSpkQuePtr", 
-                 [&backend](const auto &cg, size_t) 
-                 { 
-                     return backend.getScalarAddressPrefix() + "spkQuePtr" + cg.getPreDelayNeuronGroup()->getName(); 
-                 });
-    }
-
-    // If some postsynaptic variables are delayed, add delay pointer
-    if (getArchetype().getPostDelayNeuronGroup() != nullptr) {
-        addField(Uint32.createPointer(), "postSpkQuePtr", 
-                 [&backend](const auto &cg, size_t) 
-                 { 
-                     return backend.getScalarAddressPrefix() + "spkQuePtr" + cg.getPostDelayNeuronGroup()->getName(); 
-                 });
-    }
-    
-
-    // Add variables to struct
-
-    
-    // Loop through sorted dependent variables
-    for(size_t i = 0; i < getSortedArchetypeDependentVars().size(); i++) {
-        auto resolvedType = getSortedArchetypeDependentVars().at(i).getVar().type.resolve(getTypeContext());
-        addField(resolvedType.createPointer(), "_dependentVar" + std::to_string(i), 
-                 [i, &backend, this](const auto&, size_t g) 
-                 { 
-                     const auto &varRef = m_SortedDependentVars[g][i];
-                     return backend.getDeviceVarPrefix() + varRef.getVar().name + varRef.getTargetName(); 
-                 });
-    }*/
 }
 //----------------------------------------------------------------------------
 boost::uuids::detail::sha1::digest_type CustomConnectivityUpdateGroupMerged::getHashDigest() const

--- a/src/genn/genn/code_generator/customConnectivityUpdateGroupMerged.cc
+++ b/src/genn/genn/code_generator/customConnectivityUpdateGroupMerged.cc
@@ -37,11 +37,11 @@ CustomConnectivityUpdateGroupMerged::CustomConnectivityUpdateGroupMerged(size_t 
                                {  
                                    boost::uuids::detail::sha1 hashA;  
                                    Type::updateHash(a.getVar().type, hashA);
-                                   Utils::updateHash(getVarAccessDuplication(a.getVar().getAccess(VarAccess::READ_WRITE)), hashA);
+                                   Utils::updateHash(a.getVar().getAccess(VarAccess::READ_WRITE), hashA);
 
                                    boost::uuids::detail::sha1 hashB;
                                    Type::updateHash(b.getVar().type, hashB);
-                                   Utils::updateHash(getVarAccessDuplication(b.getVar().getAccess(VarAccess::READ_WRITE)), hashB);
+                                   Utils::updateHash(b.getVar().getAccess(VarAccess::READ_WRITE), hashB);
 
                                    return (hashA.get_digest() < hashB.get_digest());
                                 });

--- a/src/genn/genn/code_generator/customConnectivityUpdateGroupMerged.cc
+++ b/src/genn/genn/code_generator/customConnectivityUpdateGroupMerged.cc
@@ -37,11 +37,11 @@ CustomConnectivityUpdateGroupMerged::CustomConnectivityUpdateGroupMerged(size_t 
                                {  
                                    boost::uuids::detail::sha1 hashA;  
                                    Type::updateHash(a.getVar().type, hashA);
-                                   Utils::updateHash(a.getVar().getAccess(VarAccess::READ_WRITE), hashA);
+                                   Utils::updateHash(a.getVar().access.getDims<SynapseVarAccess>(), hashA);
 
                                    boost::uuids::detail::sha1 hashB;
                                    Type::updateHash(b.getVar().type, hashB);
-                                   Utils::updateHash(b.getVar().getAccess(VarAccess::READ_WRITE), hashB);
+                                   Utils::updateHash(b.getVar().access.getDims<SynapseVarAccess>(), hashB);
 
                                    return (hashA.get_digest() < hashB.get_digest());
                                 });

--- a/src/genn/genn/code_generator/customConnectivityUpdateGroupMerged.cc
+++ b/src/genn/genn/code_generator/customConnectivityUpdateGroupMerged.cc
@@ -37,11 +37,11 @@ CustomConnectivityUpdateGroupMerged::CustomConnectivityUpdateGroupMerged(size_t 
                                {  
                                    boost::uuids::detail::sha1 hashA;  
                                    Type::updateHash(a.getVar().type, hashA);
-                                   Utils::updateHash(getVarAccessDuplication(a.getVar().access), hashA);
+                                   Utils::updateHash(getVarAccessDuplication(a.getVar().getAccess(VarAccess::READ_WRITE)), hashA);
 
                                    boost::uuids::detail::sha1 hashB;
                                    Type::updateHash(b.getVar().type, hashB);
-                                   Utils::updateHash(getVarAccessDuplication(b.getVar().access), hashB);
+                                   Utils::updateHash(getVarAccessDuplication(b.getVar().getAccess(VarAccess::READ_WRITE)), hashB);
 
                                    return (hashA.get_digest() < hashB.get_digest());
                                 });

--- a/src/genn/genn/code_generator/customConnectivityUpdateGroupMerged.cc
+++ b/src/genn/genn/code_generator/customConnectivityUpdateGroupMerged.cc
@@ -37,11 +37,11 @@ CustomConnectivityUpdateGroupMerged::CustomConnectivityUpdateGroupMerged(size_t 
                                {  
                                    boost::uuids::detail::sha1 hashA;  
                                    Type::updateHash(a.getVar().type, hashA);
-                                   Utils::updateHash(a.getVar().access.getDims<SynapseVarAccess>(), hashA);
+                                   Utils::updateHash(a.getVar().access.template getDims<SynapseVarAccess>(), hashA);
 
                                    boost::uuids::detail::sha1 hashB;
                                    Type::updateHash(b.getVar().type, hashB);
-                                   Utils::updateHash(b.getVar().access.getDims<SynapseVarAccess>(), hashB);
+                                   Utils::updateHash(b.getVar().access.template getDims<SynapseVarAccess>(), hashB);
 
                                    return (hashA.get_digest() < hashB.get_digest());
                                 });

--- a/src/genn/genn/code_generator/customUpdateGroupMerged.cc
+++ b/src/genn/genn/code_generator/customUpdateGroupMerged.cc
@@ -71,7 +71,7 @@ void CustomUpdateGroupMerged::generateCustomUpdate(const BackendBase &backend, E
         [this, &varEnv](const std::string&, const Models::VarReference &v)
         { 
             return getVarRefIndex(v.getDelayNeuronGroup() != nullptr, 
-                                  getVarAccessDuplication(v.getVar().access), 
+                                  getVarAccessDuplication(v.getVar().getAccess(VarAccess::READ_WRITE)), 
                                   "$(id)");
         });
 
@@ -195,8 +195,8 @@ void CustomUpdateWUGroupMergedBase::generateCustomUpdate(const BackendBase &back
         *this, *this, getTypeContext(), varEnv, backend.getDeviceVarPrefix(), "", "l",
         [this, &varEnv](const std::string&, const Models::WUVarReference &v)
         { 
-            return getVarRefIndex(getVarAccessDuplication(v.getVar().access), 
-                                  varEnv["id_syn"]);
+            return getVarRefIndex(getVarAccessDuplication(v.getVar().getAccess(VarAccess::READ_WRITE)), 
+                                  "$(id_syn)");
         });
 
     Transpiler::ErrorHandler errorHandler("Custom update '" + getArchetype().getName() + "' update code");

--- a/src/genn/genn/code_generator/customUpdateGroupMerged.cc
+++ b/src/genn/genn/code_generator/customUpdateGroupMerged.cc
@@ -71,7 +71,7 @@ void CustomUpdateGroupMerged::generateCustomUpdate(const BackendBase &backend, E
         [this, batchSize, &varEnv](const std::string&, const Models::VarReference &v)
         { 
             return getVarRefIndex(v.getDelayNeuronGroup() != nullptr, batchSize,
-                                  v.getVar().access.getDims<NeuronVarAccess>(), "$(id)");
+                                  v.getDims(), "$(id)");
         });
 
     Transpiler::ErrorHandler errorHandler("Custom update '" + getArchetype().getName() + "' update code");

--- a/src/genn/genn/code_generator/customUpdateGroupMerged.cc
+++ b/src/genn/genn/code_generator/customUpdateGroupMerged.cc
@@ -62,7 +62,7 @@ void CustomUpdateGroupMerged::generateCustomUpdate(const BackendBase &backend, E
         *this, *this, getTypeContext(), cuEnv, backend.getDeviceVarPrefix(), "", "l",
         [this, batchSize, &cuEnv](const std::string&, VarAccess d)
         {
-            return getVarIndex(batchSize, clearDim(getArchetype().getDims(), d.getDims<NeuronVarAccess>()), "$(id)");
+            return getVarIndex(batchSize, clearDim(getArchetype().getDims(), d.getDims<CustomUpdateVarAccess>()), "$(id)");
         });
     
     // Create an environment which caches variable references in local variables if they are accessed
@@ -189,7 +189,7 @@ void CustomUpdateWUGroupMergedBase::generateCustomUpdate(const BackendBase &back
         *this, *this, getTypeContext(), cuEnv, backend.getDeviceVarPrefix(), "", "l",
         [this, batchSize, &cuEnv](const std::string&, VarAccess d)
         {
-            return getVarIndex(batchSize, clearDim(getArchetype().getDims(), d.getDims<SynapseVarAccess>()), "$(id_syn)");
+            return getVarIndex(batchSize, clearDim(getArchetype().getDims(), d.getDims<CustomUpdateVarAccess>()), "$(id_syn)");
         });
     
     // Create an environment which caches variable references in local variables if they are accessed
@@ -197,7 +197,7 @@ void CustomUpdateWUGroupMergedBase::generateCustomUpdate(const BackendBase &back
         *this, *this, getTypeContext(), varEnv, backend.getDeviceVarPrefix(), "", "l",
         [this, batchSize, &varEnv](const std::string&, const Models::WUVarReference &v)
         { 
-            return getVarRefIndex(batchSize, v.getVar().access.getDims<SynapseVarAccess>(), "$(id_syn)");
+            return getVarRefIndex(batchSize, v.getDims(), "$(id_syn)");
         });
 
     Transpiler::ErrorHandler errorHandler("Custom update '" + getArchetype().getName() + "' update code");

--- a/src/genn/genn/code_generator/generateRunner.cc
+++ b/src/genn/genn/code_generator/generateRunner.cc
@@ -29,12 +29,12 @@ namespace
 {
 unsigned int getNumVarCopies(unsigned int varAccess, unsigned int batchSize, bool batched = true)
 {
-    return ((varAccess & VarAccessDuplication::SHARED) || !batched) ? 1 : batchSize;
+    return ((varAccess & VarAccessDim::BATCH) && batched) ? batchSize : 1;
 }
 //--------------------------------------------------------------------------
 unsigned int getNumVarElements(unsigned int varAccess, unsigned int numNeurons)
 {
-    return (varAccess & VarAccessDuplication::SHARED_NEURON) ? 1 : numNeurons;
+    return (varAccess & VarAccessDim::NEURON) ? numNeurons : 1;
 }
 //--------------------------------------------------------------------------
 unsigned int getVarSize(unsigned int varAccess, unsigned int numElements, unsigned int batchSize, 

--- a/src/genn/genn/code_generator/generateRunner.cc
+++ b/src/genn/genn/code_generator/generateRunner.cc
@@ -27,17 +27,17 @@ using namespace GeNN::CodeGenerator;
 //--------------------------------------------------------------------------
 namespace
 {
-unsigned int getNumVarCopies(VarAccess varAccess, unsigned int batchSize, bool batched = true)
+unsigned int getNumVarCopies(unsigned int varAccess, unsigned int batchSize, bool batched = true)
 {
     return ((varAccess & VarAccessDuplication::SHARED) || !batched) ? 1 : batchSize;
 }
 //--------------------------------------------------------------------------
-unsigned int getNumVarElements(VarAccess varAccess, unsigned int numNeurons)
+unsigned int getNumVarElements(unsigned int varAccess, unsigned int numNeurons)
 {
     return (varAccess & VarAccessDuplication::SHARED_NEURON) ? 1 : numNeurons;
 }
 //--------------------------------------------------------------------------
-unsigned int getVarSize(VarAccess varAccess, unsigned int numElements, unsigned int batchSize, 
+unsigned int getVarSize(unsigned int varAccess, unsigned int numElements, unsigned int batchSize, 
                         unsigned int delaySlots = 1, bool batched = true)
 {
     return getNumVarCopies(varAccess, batchSize, batched) * getNumVarElements(varAccess, numElements) * delaySlots;

--- a/src/genn/genn/code_generator/generateRunner.cc
+++ b/src/genn/genn/code_generator/generateRunner.cc
@@ -1177,7 +1177,7 @@ MemAlloc GeNN::CodeGenerator::generateRunner(const filesystem::path &outputPath,
         [batchSize](const CustomUpdateInternal &c, const Models::Base::Var &var)
         { 
             return getVarSize(var.access.getDims<NeuronVarAccess>(), 
-                              c.getSize(), batchSize, 1, c.isBatched());
+                              c.getSize(), batchSize, 1, c.getDims() & VarAccessDim::BATCH);
         });
 
     genCustomUpdate<CustomUpdateVarAdapter, CustomUpdateEGPAdapter>(
@@ -1192,7 +1192,7 @@ MemAlloc GeNN::CodeGenerator::generateRunner(const filesystem::path &outputPath,
                                   ? sg->getKernelSizeFlattened() 
                                   : sg->getSrcNeuronGroup()->getNumNeurons() * backend.getSynapticMatrixRowStride(*sg));
             return getVarSize(var.access.getDims<SynapseVarAccess>(), count, 
-                              batchSize, 1, c.isBatched());
+                              batchSize, 1, c.getDims() & VarAccessDim::BATCH);
         });
     allVarStreams << std::endl;
 

--- a/src/genn/genn/code_generator/initGroupMerged.cc
+++ b/src/genn/genn/code_generator/initGroupMerged.cc
@@ -997,7 +997,7 @@ boost::uuids::detail::sha1::digest_type CustomConnectivityUpdatePreInitGroupMerg
     return hash.get_digest();
 }
 //----------------------------------------------------------------------------
-void CustomConnectivityUpdatePreInitGroupMerged::generateInit(const BackendBase &backend, EnvironmentExternalBase &env, unsigned int batchSize)
+void CustomConnectivityUpdatePreInitGroupMerged::generateInit(const BackendBase &backend, EnvironmentExternalBase &env, unsigned int)
 {
     genInitNeuronVarCode<CustomConnectivityUpdatePreVarAdapter>(backend, env, *this, "", "size", 0, 1);
 }
@@ -1026,7 +1026,7 @@ boost::uuids::detail::sha1::digest_type CustomConnectivityUpdatePostInitGroupMer
     return hash.get_digest();
 }
 //----------------------------------------------------------------------------
-void CustomConnectivityUpdatePostInitGroupMerged::generateInit(const BackendBase &backend, EnvironmentExternalBase &env, unsigned int batchSize)
+void CustomConnectivityUpdatePostInitGroupMerged::generateInit(const BackendBase &backend, EnvironmentExternalBase &env, unsigned int)
 {
     // Initialise presynaptic custom connectivity update variables
     genInitNeuronVarCode<CustomConnectivityUpdatePostVarAdapter>(backend, env, *this, "", "size", 0, 1);

--- a/src/genn/genn/code_generator/initGroupMerged.cc
+++ b/src/genn/genn/code_generator/initGroupMerged.cc
@@ -87,7 +87,7 @@ void genInitNeuronVarCode(const BackendBase &backend, EnvironmentExternalBase &e
                             });
 
             // If variable is shared between neurons
-            if (getVarAccessDuplication(var.access) == VarAccessDuplication::SHARED_NEURON) {
+            if (getVarAccessDuplication(var.getAccess(VarAccess::READ_WRITE)) == VarAccessDuplication::SHARED_NEURON) {
                 backend.genPopVariableInit(
                     varEnv,
                     [&adaptor, &fieldGroup, &fieldSuffix, &group, &resolvedType, &var, &varInit, batchSize, numDelaySlots]
@@ -103,7 +103,7 @@ void genInitNeuronVarCode(const BackendBase &backend, EnvironmentExternalBase &e
                         prettyPrintStatements(varInit.getCodeTokens(), group.getTypeContext(), varInitEnv, errorHandler);
                         
                         // Fill value across all delay slots and batches
-                        genScalarFill(varInitEnv, "_value", "$(value)", getVarAccessDuplication(var.access),
+                        genScalarFill(varInitEnv, "_value", "$(value)", getVarAccessDuplication(var.getAccess(VarAccess::READ_WRITE)),
                                       batchSize, adaptor.isVarDelayed(var.name), numDelaySlots);
                     });
             }
@@ -125,7 +125,8 @@ void genInitNeuronVarCode(const BackendBase &backend, EnvironmentExternalBase &e
 
                         // Fill value across all delay slots and batches
                         genVariableFill(varInitEnv, "_value", "$(value)", "id", "$(" + count + ")",
-                                        getVarAccessDuplication(var.access), batchSize, adaptor.isVarDelayed(var.name), numDelaySlots);
+                                        getVarAccessDuplication(var.getAccess(VarAccess::READ_WRITE)), 
+                                        batchSize, adaptor.isVarDelayed(var.name), numDelaySlots);
                     });
             }
         }
@@ -184,7 +185,7 @@ void genInitWUVarCode(const BackendBase &backend, EnvironmentExternalBase &env, 
 
                     // Fill value across all batches
                     genVariableFill(varInitEnv, "_value", "$(value)", "id_syn", stride,
-                                    getVarAccessDuplication(var.access), batchSize);
+                                    getVarAccessDuplication(var.getAccess(VarAccess::READ_WRITE)), batchSize);
                 });
         }
     }

--- a/src/genn/genn/code_generator/initGroupMerged.cc
+++ b/src/genn/genn/code_generator/initGroupMerged.cc
@@ -853,7 +853,7 @@ void CustomUpdateInitGroupMerged::generateInit(const BackendBase &backend, Envir
 {
     // Initialise custom update variables
     genInitNeuronVarCode<CustomUpdateVarAdapter>(backend, env, *this, "", "size", 1, 
-                                                 getArchetype().isBatched() ? batchSize : 1);        
+                                                 (getArchetype().getDims() & VarAccessDim::BATCH) ? batchSize : 1);        
 }
 
 // ----------------------------------------------------------------------------
@@ -911,7 +911,7 @@ void CustomWUUpdateInitGroupMerged::generateInit(const BackendBase &backend, Env
     // Loop through rows
     const std::string stride = kernel ? "$(_kernel_size)" : "$(num_pre) * $(_row_stride)";
     genInitWUVarCode<CustomUpdateVarAdapter>(
-        backend, groupEnv, *this, stride, getArchetype().isBatched() ? batchSize : 1, false,
+        backend, groupEnv, *this, stride, (getArchetype().getDims() & VarAccessDim::BATCH) ? batchSize : 1, false,
         [&backend, kernel, this](EnvironmentExternalBase &varInitEnv, BackendBase::HandlerEnv handler)
         {
             if (kernel) {
@@ -966,7 +966,7 @@ void CustomWUUpdateSparseInitGroupMerged::generateInit(const BackendBase &backen
 {
     genInitWUVarCode<CustomUpdateVarAdapter>(
         backend, env, *this, "$(num_pre) * $(_row_stride)",
-        getArchetype().isBatched() ? batchSize : 1, false,
+        (getArchetype().getDims() & VarAccessDim::BATCH) ? batchSize : 1, false,
         [&backend](EnvironmentExternalBase &varInitEnv, BackendBase::HandlerEnv handler)
         {
             return backend.genSparseSynapseVariableRowInit(varInitEnv, handler); 

--- a/src/genn/genn/code_generator/initGroupMerged.cc
+++ b/src/genn/genn/code_generator/initGroupMerged.cc
@@ -21,10 +21,10 @@ using namespace GeNN::Transpiler;
 namespace
 {
 void genVariableFill(EnvironmentExternalBase &env, const std::string &target, const std::string &value, const std::string &idx, const std::string &stride,
-                     VarAccessDuplication varDuplication, unsigned int batchSize, bool delay = false, unsigned int numDelaySlots = 1)
+                     unsigned int varAccess, unsigned int batchSize, bool delay = false, unsigned int numDelaySlots = 1)
 {
     // Determine number of values to fill in each thread
-    const unsigned int numValues = ((varDuplication == VarAccessDuplication::SHARED) ? 1 : batchSize) * ((delay ? numDelaySlots : 1));
+    const unsigned int numValues = ((varAccess & VarAccessDim::BATCH) ? batchSize : 1) * ((delay ? numDelaySlots : 1));
 
     // If there's only one, don't generate a loop
     if(numValues == 1) {
@@ -41,10 +41,10 @@ void genVariableFill(EnvironmentExternalBase &env, const std::string &target, co
 }
 //--------------------------------------------------------------------------
 void genScalarFill(EnvironmentExternalBase &env, const std::string &target, const std::string &value,
-                   VarAccessDuplication varDuplication, unsigned int batchSize, bool delay = false, unsigned int numDelaySlots = 1)
+                   unsigned int varAccess, unsigned int batchSize, bool delay = false, unsigned int numDelaySlots = 1)
 {
     // Determine number of values to fill in each thread
-    const unsigned int numValues = ((varDuplication == VarAccessDuplication::SHARED) ? 1 : batchSize) * ((delay ? numDelaySlots : 1));
+    const unsigned int numValues = ((varAccess & VarAccessDim::BATCH) ? batchSize : 1) * ((delay ? numDelaySlots : 1));
 
     // If there's only one, don't generate a loop
     if(numValues == 1) {
@@ -86,29 +86,9 @@ void genInitNeuronVarCode(const BackendBase &backend, EnvironmentExternalBase &e
                                 return backend.getDeviceVarPrefix() + var.name + A(g).getNameSuffix(); 
                             });
 
-            // If variable is shared between neurons
-            if (getVarAccessDuplication(var.getAccess(VarAccess::READ_WRITE)) == VarAccessDuplication::SHARED_NEURON) {
-                backend.genPopVariableInit(
-                    varEnv,
-                    [&adaptor, &fieldGroup, &fieldSuffix, &group, &resolvedType, &var, &varInit, batchSize, numDelaySlots]
-                    (EnvironmentExternalBase &env)
-                    {
-                        // Generate initial value into temporary variable
-                        EnvironmentGroupMergedField<G, F> varInitEnv(env, group, fieldGroup);
-                        varInitEnv.getStream() << resolvedType.getName() << " initVal;" << std::endl;
-                        varInitEnv.add(resolvedType, "value", "initVal");
-                        
-                        // Pretty print variable initialisation code
-                        Transpiler::ErrorHandler errorHandler("Group '" + group.getArchetype().getName() + "' variable '" + var.name + "' init code");
-                        prettyPrintStatements(varInit.getCodeTokens(), group.getTypeContext(), varInitEnv, errorHandler);
-                        
-                        // Fill value across all delay slots and batches
-                        genScalarFill(varInitEnv, "_value", "$(value)", getVarAccessDuplication(var.getAccess(VarAccess::READ_WRITE)),
-                                      batchSize, adaptor.isVarDelayed(var.name), numDelaySlots);
-                    });
-            }
-            // Otherwise
-            else {
+            // If variable has NEURON axis
+            const unsigned int varAccess = var.getAccess(NeuronVarAccess::READ_WRITE);
+            if (varAccess & VarAccessDim::NEURON) {
                 backend.genVariableInit(
                     varEnv, count, "id",
                     [&adaptor, &fieldGroup, &fieldSuffix, &group, &var, &resolvedType, &varInit, batchSize, count, numDelaySlots]
@@ -125,8 +105,28 @@ void genInitNeuronVarCode(const BackendBase &backend, EnvironmentExternalBase &e
 
                         // Fill value across all delay slots and batches
                         genVariableFill(varInitEnv, "_value", "$(value)", "id", "$(" + count + ")",
-                                        getVarAccessDuplication(var.getAccess(VarAccess::READ_WRITE)), 
-                                        batchSize, adaptor.isVarDelayed(var.name), numDelaySlots);
+                                        varAccess, batchSize, adaptor.isVarDelayed(var.name), numDelaySlots);
+                    });
+            }
+            // Otherwise
+            else {
+                backend.genPopVariableInit(
+                    varEnv,
+                    [&adaptor, &fieldGroup, &fieldSuffix, &group, &resolvedType, &var, &varInit, batchSize, numDelaySlots]
+                    (EnvironmentExternalBase &env)
+                    {
+                        // Generate initial value into temporary variable
+                        EnvironmentGroupMergedField<G, F> varInitEnv(env, group, fieldGroup);
+                        varInitEnv.getStream() << resolvedType.getName() << " initVal;" << std::endl;
+                        varInitEnv.add(resolvedType, "value", "initVal");
+                        
+                        // Pretty print variable initialisation code
+                        Transpiler::ErrorHandler errorHandler("Group '" + group.getArchetype().getName() + "' variable '" + var.name + "' init code");
+                        prettyPrintStatements(varInit.getCodeTokens(), group.getTypeContext(), varInitEnv, errorHandler);
+                        
+                        // Fill value across all delay slots and batches
+                        genScalarFill(varInitEnv, "_value", "$(value)", varAccess,
+                                      batchSize, adaptor.isVarDelayed(var.name), numDelaySlots);
                     });
             }
         }
@@ -185,7 +185,7 @@ void genInitWUVarCode(const BackendBase &backend, EnvironmentExternalBase &env, 
 
                     // Fill value across all batches
                     genVariableFill(varInitEnv, "_value", "$(value)", "id_syn", stride,
-                                    getVarAccessDuplication(var.getAccess(VarAccess::READ_WRITE)), batchSize);
+                                    var.getAccess(SynapseVarAccess::READ_WRITE), batchSize);
                 });
         }
     }
@@ -222,7 +222,7 @@ void NeuronInitGroupMerged::InSynPSM::generate(const BackendBase &backend, Envir
         [batchSize, this] (EnvironmentExternalBase &varEnv)
         {
             genVariableFill(varEnv, "_out_post", Type::writeNumeric(0.0, getScalarType()), 
-                            "id", "$(num_neurons)", VarAccessDuplication::DUPLICATE, batchSize);
+                            "id", "$(num_neurons)", VarAccessDim::BATCH | VarAccessDim::NEURON, batchSize);
 
         });
 
@@ -235,7 +235,7 @@ void NeuronInitGroupMerged::InSynPSM::generate(const BackendBase &backend, Envir
             [batchSize, this](EnvironmentExternalBase &varEnv)
             {
                 genVariableFill(varEnv, "_den_delay", Type::writeNumeric(0.0, getScalarType()),
-                                "id", "$(num_neurons)", VarAccessDuplication::DUPLICATE, 
+                                "id", "$(num_neurons)", VarAccessDim::BATCH | VarAccessDim::NEURON, 
                                 batchSize, true, getArchetype().getMaxDendriticDelayTimesteps());
             });
 
@@ -269,7 +269,7 @@ void NeuronInitGroupMerged::OutSynPreOutput::generate(const BackendBase &backend
                             [batchSize, this] (EnvironmentExternalBase &varEnv)
                             {
                                 genVariableFill(varEnv, "_out_pre", Type::writeNumeric(0.0, getScalarType()),
-                                                "id", "$(num_neurons)", VarAccessDuplication::DUPLICATE, batchSize);
+                                                "id", "$(num_neurons)", VarAccessDim::BATCH | VarAccessDim::NEURON, batchSize);
                             });
 }
 
@@ -450,7 +450,8 @@ void NeuronInitGroupMerged::genInitSpikeCount(const BackendBase &backend, Enviro
                     (getArchetype().isTrueSpikeRequired() && getArchetype().isDelayRequired());
 
                 // Zero across all delay slots and batches
-                genScalarFill(spikeCountEnv, "_spk_cnt", "0", VarAccessDuplication::DUPLICATE, batchSize, delayRequired, getArchetype().getNumDelaySlots());
+                genScalarFill(spikeCountEnv, "_spk_cnt", "0", VarAccessDim::BATCH | VarAccessDim::NEURON, 
+                              batchSize, delayRequired, getArchetype().getNumDelaySlots());
             });
     }
 
@@ -480,8 +481,8 @@ void NeuronInitGroupMerged::genInitSpikes(const BackendBase &backend, Environmen
                     (getArchetype().isTrueSpikeRequired() && getArchetype().isDelayRequired());
 
                 // Zero across all delay slots and batches
-                genVariableFill(varEnv, "_spk", "0", "id", "$(num_neurons)", 
-                                VarAccessDuplication::DUPLICATE, batchSize, delayRequired, getArchetype().getNumDelaySlots());
+                genVariableFill(varEnv, "_spk", "0", "id", "$(num_neurons)", VarAccessDim::BATCH | VarAccessDim::NEURON,
+                                batchSize, delayRequired, getArchetype().getNumDelaySlots());
             });
     }
 }
@@ -499,7 +500,7 @@ void NeuronInitGroupMerged::genInitSpikeTime(const BackendBase &backend, Environ
     backend.genVariableInit(env, "num_neurons", "id",
         [batchSize, varName, this] (EnvironmentExternalBase &varEnv)
         {
-            genVariableFill(varEnv, varName, "-TIME_MAX", "id", "$(num_neurons)", VarAccessDuplication::DUPLICATE, 
+            genVariableFill(varEnv, varName, "-TIME_MAX", "id", "$(num_neurons)", VarAccessDim::BATCH | VarAccessDim::NEURON, 
                             batchSize, getArchetype().isDelayRequired(), getArchetype().getNumDelaySlots());
         });
 }

--- a/src/genn/genn/code_generator/initGroupMerged.cc
+++ b/src/genn/genn/code_generator/initGroupMerged.cc
@@ -87,7 +87,7 @@ void genInitNeuronVarCode(const BackendBase &backend, EnvironmentExternalBase &e
                             });
 
             // If variable has NEURON axis
-            const VarAccessDim varDims = var.access.template getDims<NeuronVarAccess>();
+            const VarAccessDim varDims = adaptor.getVarDims(var);
             if (varDims & VarAccessDim::NEURON) {
                 backend.genVariableInit(
                     varEnv, count, "id",
@@ -171,7 +171,7 @@ void genInitWUVarCode(const BackendBase &backend, EnvironmentExternalBase &env, 
 
             // Generate target-specific code to initialise variable
             genSynapseVariableRowInitFn(varEnv,
-                [&group, &resolvedType, &stride, &var, &varInit, batchSize]
+                [&adaptor, &group, &resolvedType, &stride, &var, &varInit, batchSize]
                 (EnvironmentExternalBase &env)
                 {
                     // Generate initial value into temporary variable
@@ -185,7 +185,7 @@ void genInitWUVarCode(const BackendBase &backend, EnvironmentExternalBase &env, 
 
                     // Fill value across all batches
                     genVariableFill(varInitEnv, "_value", "$(value)", "id_syn", stride,
-                                    var.access.template getDims<SynapseVarAccess>(), batchSize);
+                                    adaptor.getVarDims(var), batchSize);
                 });
         }
     }

--- a/src/genn/genn/code_generator/initGroupMerged.cc
+++ b/src/genn/genn/code_generator/initGroupMerged.cc
@@ -87,7 +87,7 @@ void genInitNeuronVarCode(const BackendBase &backend, EnvironmentExternalBase &e
                             });
 
             // If variable has NEURON axis
-            const VarAccessDim varDims = var.access.getDims<NeuronVarAccess>();
+            const VarAccessDim varDims = var.access.template getDims<NeuronVarAccess>();
             if (varDims & VarAccessDim::NEURON) {
                 backend.genVariableInit(
                     varEnv, count, "id",
@@ -173,19 +173,19 @@ void genInitWUVarCode(const BackendBase &backend, EnvironmentExternalBase &env, 
             genSynapseVariableRowInitFn(varEnv,
                 [&group, &resolvedType, &stride, &var, &varInit, batchSize]
                 (EnvironmentExternalBase &env)
-                { 
+                {
                     // Generate initial value into temporary variable
                     EnvironmentGroupMergedField<G> varInitEnv(env, group);
                     varInitEnv.getStream() << resolvedType.getName() << " initVal;" << std::endl;
                     varInitEnv.add(resolvedType, "value", "initVal");
-                        
+
                     // Pretty print variable initialisation code
                     Transpiler::ErrorHandler errorHandler("Variable '" + var.name + "' init code" + std::to_string(group.getIndex()));
                     prettyPrintStatements(varInit.getCodeTokens(), group.getTypeContext(), varInitEnv, errorHandler);
 
                     // Fill value across all batches
                     genVariableFill(varInitEnv, "_value", "$(value)", "id_syn", stride,
-                                    var.access.getDims<SynapseVarAccess>(), batchSize);
+                                    var.access.template getDims<SynapseVarAccess>(), batchSize);
                 });
         }
     }

--- a/src/genn/genn/code_generator/modelSpecMerged.cc
+++ b/src/genn/genn/code_generator/modelSpecMerged.cc
@@ -34,11 +34,11 @@ using namespace GeNN::CodeGenerator;
                        &SynapseGroupInternal::getWUHashDigest);
 
     createMergedGroups(getModel().getCustomUpdates(), m_MergedCustomUpdateGroups,
-                       [](const CustomUpdateInternal&) { return true; },
+                       [](const CustomUpdateInternal &cg) { return !Utils::areTokensEmpty(cg.getUpdateCodeTokens()); },
                        &CustomUpdateInternal::getHashDigest);
 
     createMergedGroups(getModel().getCustomWUUpdates(), m_MergedCustomUpdateWUGroups,
-                       [](const CustomUpdateWUInternal &cg) { return !cg.isTransposeOperation(); },
+                       [](const CustomUpdateWUInternal &cg) { return !Utils::areTokensEmpty(cg.getUpdateCodeTokens()) && !cg.isTransposeOperation(); },
                        &CustomUpdateWUInternal::getHashDigest);
 
     createMergedGroups(getModel().getCustomWUUpdates(), m_MergedCustomUpdateTransposeWUGroups,

--- a/src/genn/genn/code_generator/neuronUpdateGroupMerged.cc
+++ b/src/genn/genn/code_generator/neuronUpdateGroupMerged.cc
@@ -242,9 +242,10 @@ void NeuronUpdateGroupMerged::InSynWUMPostCode::genCopyDelayedVars(EnvironmentEx
         // Loop through variables and copy between read and write delay slots
         // **YUCK** this a bit sketchy as fields may not have been added - could add fields here but need to guarantee uniqueness
         for(const auto &v : getArchetype().getWUModel()->getPostVars()) {
-            if(v.access & VarAccessMode::READ_WRITE) {
-                env.print("group->" + v.name + suffix + "[" + ng.getWriteVarIndex(true, batchSize, getVarAccessDuplication(v.access), "$(id)") + "] = ");
-                env.printLine("group->" + v.name + suffix + "[" + ng.getReadVarIndex(true, batchSize, getVarAccessDuplication(v.access), "$(id)") + "];");
+            const unsigned int varAccess = v.getAccess(VarAccess::READ_WRITE);
+            if(varAccess & VarAccessMode::READ_WRITE) {
+                env.print("group->" + v.name + suffix + "[" + ng.getWriteVarIndex(true, batchSize, getVarAccessDuplication(varAccess), "$(id)") + "] = ");
+                env.printLine("group->" + v.name + suffix + "[" + ng.getReadVarIndex(true, batchSize, getVarAccessDuplication(varAccess), "$(id)") + "];");
             }
         }
     }
@@ -333,9 +334,10 @@ void NeuronUpdateGroupMerged::OutSynWUMPreCode::genCopyDelayedVars(EnvironmentEx
         // Loop through variables and copy between read and write delay slots
         // **YUCK** this a bit sketchy as fields may not have been added - could add fields here but need to guarantee uniqueness
         for(const auto &v : getArchetype().getWUModel()->getPreVars()) {
-            if(v.access & VarAccessMode::READ_WRITE) {
-                env.print("group->" + v.name + suffix + "[" + ng.getWriteVarIndex(true, batchSize, getVarAccessDuplication(v.access), "$(id)") + "] = ");
-                env.printLine("group->" + v.name + suffix + "[" + ng.getReadVarIndex(true, batchSize, getVarAccessDuplication(v.access), "$(id)") + "];");
+            const unsigned int varAccess = v.getAccess(VarAccess::READ_WRITE);
+            if(varAccess & VarAccessMode::READ_WRITE) {
+                env.print("group->" + v.name + suffix + "[" + ng.getWriteVarIndex(true, batchSize, getVarAccessDuplication(varAccess), "$(id)") + "] = ");
+                env.printLine("group->" + v.name + suffix + "[" + ng.getReadVarIndex(true, batchSize, getVarAccessDuplication(varAccess), "$(id)") + "];");
             }
         }
     }

--- a/src/genn/genn/code_generator/presynapticUpdateStrategySIMT.cc
+++ b/src/genn/genn/code_generator/presynapticUpdateStrategySIMT.cc
@@ -96,7 +96,7 @@ void PreSpan::genUpdate(EnvironmentExternalBase &env, PresynapticUpdateGroupMerg
     {
         CodeStream::Scope b(env.getStream());
 
-        env.printLine("const unsigned int preInd = $(_src_spk" + eventSuffix + ")[" + sg.getPreVarIndex(batchSize, VarAccessDuplication::DUPLICATE, "spike") + "];");
+        env.printLine("const unsigned int preInd = $(_src_spk" + eventSuffix + ")[" + sg.getPreVarIndex(batchSize, VarAccessDim::BATCH | VarAccessDim::PRE_NEURON, "spike") + "];");
 
         const auto indexType = backend.getSynapseIndexType(sg);
         const auto indexTypeName = indexType.getName();
@@ -247,7 +247,7 @@ void PostSpan::genUpdate(EnvironmentExternalBase &env, PresynapticUpdateGroupMer
         {
             CodeStream::Scope b(env.getStream());
             const std::string index = "(r * " + std::to_string(backend.getKernelBlockSize(KernelPresynapticUpdate)) + ") + " + backend.getThreadID();
-            env.printLine("const unsigned int spk = $(_src_spk" + eventSuffix + ")[" + sg.getPreVarIndex(batchSize, VarAccessDuplication::DUPLICATE, index) + "];");
+            env.printLine("const unsigned int spk = $(_src_spk" + eventSuffix + ")[" + sg.getPreVarIndex(batchSize, VarAccessDim::BATCH | VarAccessDim::PRE_NEURON, index) + "];");
             env.printLine("$(_sh_spk" +  eventSuffix + ")[" + backend.getThreadID() + "] = spk;");
             if(sg.getArchetype().getMatrixType() & SynapseMatrixConnectivity::SPARSE) {
                 env.printLine("$(_sh_row_length)[" + backend.getThreadID() + "] = $(_row_length)[spk];");
@@ -459,7 +459,7 @@ void PreSpanProcedural::genUpdate(EnvironmentExternalBase &env, PresynapticUpdat
         // Create environment and add presynaptic index
         EnvironmentGroupMergedField<PresynapticUpdateGroupMerged> synEnv(groupEnv, sg);
         synEnv.add(Type::Uint32.addConst(), "id_pre", "preInd",
-                   {synEnv.addInitialiser("const unsigned int preInd = $(_src_spk" + eventSuffix + ")[" + sg.getPreVarIndex(batchSize, VarAccessDuplication::DUPLICATE, "$(_spike)") + "];")});
+                   {synEnv.addInitialiser("const unsigned int preInd = $(_src_spk" + eventSuffix + ")[" + sg.getPreVarIndex(batchSize, VarAccessDim::BATCH | VarAccessDim::PRE_NEURON, "$(_spike)") + "];")});
 
         // **YUCK** add a hidden copy of num_post so we can overwrite deeper in here without losing access to original
         synEnv.add(Type::Uint32.addConst(), "_num_post", "$(num_post)");
@@ -639,7 +639,7 @@ void PostSpanBitmask::genUpdate(EnvironmentExternalBase &env, PresynapticUpdateG
         {
             CodeStream::Scope b(env.getStream());
             const std::string index = "(r * " + std::to_string(backend.getKernelBlockSize(KernelPresynapticUpdate)) + ") + " + backend.getThreadID();
-            env.printLine("const unsigned int spk = $(_src_spk" + eventSuffix + ")[" + sg.getPreVarIndex(batchSize, VarAccessDuplication::DUPLICATE, index) + "];");
+            env.printLine("const unsigned int spk = $(_src_spk" + eventSuffix + ")[" + sg.getPreVarIndex(batchSize, VarAccessDim::BATCH | VarAccessDim::PRE_NEURON, index) + "];");
             env.printLine("$(_sh_spk" + eventSuffix + ")[" + backend.getThreadID() + "] = spk;");
         }
         backend.genSharedMemBarrier(env.getStream());
@@ -873,7 +873,7 @@ void PostSpanToeplitz::genUpdate(EnvironmentExternalBase &env, PresynapticUpdate
                 {
                     CodeStream::Scope b(env.getStream());
                     const std::string index = "(r * " + std::to_string(backend.getKernelBlockSize(KernelPresynapticUpdate)) + ") + " + backend.getThreadID();
-                    env.printLine("const unsigned int spk = $(_src_spk" + eventSuffix + ")[" + sg.getPreVarIndex(batchSize, VarAccessDuplication::DUPLICATE, index) + "];");
+                    env.printLine("const unsigned int spk = $(_src_spk" + eventSuffix + ")[" + sg.getPreVarIndex(batchSize, VarAccessDim::BATCH | VarAccessDim::PRE_NEURON, index) + "];");
                     env.printLine("$(_sh_spk" +  eventSuffix + ")[" + backend.getThreadID() + "] = spk;");
                 }
                 backend.genSharedMemBarrier(env.getStream());

--- a/src/genn/genn/code_generator/presynapticUpdateStrategySIMT.cc
+++ b/src/genn/genn/code_generator/presynapticUpdateStrategySIMT.cc
@@ -96,7 +96,7 @@ void PreSpan::genUpdate(EnvironmentExternalBase &env, PresynapticUpdateGroupMerg
     {
         CodeStream::Scope b(env.getStream());
 
-        env.printLine("const unsigned int preInd = $(_src_spk" + eventSuffix + ")[" + sg.getPreVarIndex(batchSize, VarAccessDim::BATCH | VarAccessDim::PRE_NEURON, "spike") + "];");
+        env.printLine("const unsigned int preInd = $(_src_spk" + eventSuffix + ")[" + sg.getPreVarIndex(batchSize, VarAccessDim::BATCH | VarAccessDim::NEURON, "spike") + "];");
 
         const auto indexType = backend.getSynapseIndexType(sg);
         const auto indexTypeName = indexType.getName();
@@ -247,7 +247,7 @@ void PostSpan::genUpdate(EnvironmentExternalBase &env, PresynapticUpdateGroupMer
         {
             CodeStream::Scope b(env.getStream());
             const std::string index = "(r * " + std::to_string(backend.getKernelBlockSize(KernelPresynapticUpdate)) + ") + " + backend.getThreadID();
-            env.printLine("const unsigned int spk = $(_src_spk" + eventSuffix + ")[" + sg.getPreVarIndex(batchSize, VarAccessDim::BATCH | VarAccessDim::PRE_NEURON, index) + "];");
+            env.printLine("const unsigned int spk = $(_src_spk" + eventSuffix + ")[" + sg.getPreVarIndex(batchSize, VarAccessDim::BATCH | VarAccessDim::NEURON, index) + "];");
             env.printLine("$(_sh_spk" +  eventSuffix + ")[" + backend.getThreadID() + "] = spk;");
             if(sg.getArchetype().getMatrixType() & SynapseMatrixConnectivity::SPARSE) {
                 env.printLine("$(_sh_row_length)[" + backend.getThreadID() + "] = $(_row_length)[spk];");
@@ -459,7 +459,7 @@ void PreSpanProcedural::genUpdate(EnvironmentExternalBase &env, PresynapticUpdat
         // Create environment and add presynaptic index
         EnvironmentGroupMergedField<PresynapticUpdateGroupMerged> synEnv(groupEnv, sg);
         synEnv.add(Type::Uint32.addConst(), "id_pre", "preInd",
-                   {synEnv.addInitialiser("const unsigned int preInd = $(_src_spk" + eventSuffix + ")[" + sg.getPreVarIndex(batchSize, VarAccessDim::BATCH | VarAccessDim::PRE_NEURON, "$(_spike)") + "];")});
+                   {synEnv.addInitialiser("const unsigned int preInd = $(_src_spk" + eventSuffix + ")[" + sg.getPreVarIndex(batchSize, VarAccessDim::BATCH | VarAccessDim::NEURON, "$(_spike)") + "];")});
 
         // **YUCK** add a hidden copy of num_post so we can overwrite deeper in here without losing access to original
         synEnv.add(Type::Uint32.addConst(), "_num_post", "$(num_post)");
@@ -639,7 +639,7 @@ void PostSpanBitmask::genUpdate(EnvironmentExternalBase &env, PresynapticUpdateG
         {
             CodeStream::Scope b(env.getStream());
             const std::string index = "(r * " + std::to_string(backend.getKernelBlockSize(KernelPresynapticUpdate)) + ") + " + backend.getThreadID();
-            env.printLine("const unsigned int spk = $(_src_spk" + eventSuffix + ")[" + sg.getPreVarIndex(batchSize, VarAccessDim::BATCH | VarAccessDim::PRE_NEURON, index) + "];");
+            env.printLine("const unsigned int spk = $(_src_spk" + eventSuffix + ")[" + sg.getPreVarIndex(batchSize, VarAccessDim::BATCH | VarAccessDim::NEURON, index) + "];");
             env.printLine("$(_sh_spk" + eventSuffix + ")[" + backend.getThreadID() + "] = spk;");
         }
         backend.genSharedMemBarrier(env.getStream());
@@ -873,7 +873,7 @@ void PostSpanToeplitz::genUpdate(EnvironmentExternalBase &env, PresynapticUpdate
                 {
                     CodeStream::Scope b(env.getStream());
                     const std::string index = "(r * " + std::to_string(backend.getKernelBlockSize(KernelPresynapticUpdate)) + ") + " + backend.getThreadID();
-                    env.printLine("const unsigned int spk = $(_src_spk" + eventSuffix + ")[" + sg.getPreVarIndex(batchSize, VarAccessDim::BATCH | VarAccessDim::PRE_NEURON, index) + "];");
+                    env.printLine("const unsigned int spk = $(_src_spk" + eventSuffix + ")[" + sg.getPreVarIndex(batchSize, VarAccessDim::BATCH | VarAccessDim::NEURON, index) + "];");
                     env.printLine("$(_sh_spk" +  eventSuffix + ")[" + backend.getThreadID() + "] = spk;");
                 }
                 backend.genSharedMemBarrier(env.getStream());

--- a/src/genn/genn/code_generator/synapseUpdateGroupMerged.cc
+++ b/src/genn/genn/code_generator/synapseUpdateGroupMerged.cc
@@ -30,13 +30,13 @@ void applySynapseSubstitutions(const BackendBase &backend, EnvironmentExternalBa
     // Substitute names of pre and postsynaptic weight update variable
     synEnv.template addVars<SynapseWUPreVarAdapter>(
         backend.getDeviceVarPrefix(),
-        [&sg, batchSize](VarAccess a, const std::string&) 
+        [&sg, batchSize](unsigned int a, const std::string&) 
         { 
             return sg.getPreWUVarIndex(batchSize, getVarAccessDuplication(a), "$(id_pre)");
         }, "", true);
     synEnv.template addVars<SynapseWUPostVarAdapter>(
         backend.getDeviceVarPrefix(),
-        [&sg, batchSize](VarAccess a, const std::string&) 
+        [&sg, batchSize](unsigned int a, const std::string&) 
         { 
             return sg.getPostWUVarIndex(batchSize, getVarAccessDuplication(a), "$(id_post)");
         }, "", true);
@@ -78,7 +78,7 @@ void applySynapseSubstitutions(const BackendBase &backend, EnvironmentExternalBa
     if (sg.getArchetype().getMatrixType() & SynapseMatrixWeight::INDIVIDUAL) {
         synEnv.template addVars<SynapseWUVarAdapter>(
             backend.getDeviceVarPrefix(),
-            [&sg, batchSize](VarAccess a, const std::string&) 
+            [&sg, batchSize](unsigned int a, const std::string&) 
             { 
                 return sg.getSynVarIndex(batchSize, getVarAccessDuplication(a), "$(id_syn)");
             });
@@ -121,7 +121,7 @@ void applySynapseSubstitutions(const BackendBase &backend, EnvironmentExternalBa
 
         synEnv.template addVars<SynapseWUVarAdapter>(
             backend.getDeviceVarPrefix(),
-            [&sg, batchSize](VarAccess a, const std::string&) 
+            [&sg, batchSize](unsigned int a, const std::string&) 
             { 
                 return sg.getKernelVarIndex(batchSize, getVarAccessDuplication(a), "$(id_kernel)");
             });

--- a/src/genn/genn/code_generator/synapseUpdateGroupMerged.cc
+++ b/src/genn/genn/code_generator/synapseUpdateGroupMerged.cc
@@ -53,8 +53,8 @@ void applySynapseSubstitutions(const BackendBase &backend, EnvironmentExternalBa
     const std::string timeStr = sg.getTimeType().getName();
     const std::string axonalDelayMs = Type::writeNumeric(dt * (double)(sg.getArchetype().getDelaySteps() + 1u), sg.getTimeType());
     const bool preDelay = sg.getArchetype().getSrcNeuronGroup()->isDelayRequired();
-    const std::string preSTIndex = sg.getPreVarIndex(preDelay, batchSize, VarAccessDim::BATCH | VarAccessDim::PRE_NEURON, "$(id_pre)");
-    const std::string prevPreSTIndex = sg.getPrePrevSpikeTimeIndex(preDelay, batchSize, VarAccessDim::BATCH | VarAccessDim::PRE_NEURON, "$(id_pre)");
+    const std::string preSTIndex = sg.getPreVarIndex(preDelay, batchSize, VarAccessDim::BATCH | VarAccessDim::NEURON, "$(id_pre)");
+    const std::string prevPreSTIndex = sg.getPrePrevSpikeTimeIndex(preDelay, batchSize, VarAccessDim::BATCH | VarAccessDim::NEURON, "$(id_pre)");
     synEnv.add(sg.getTimeType().addConst(), "st_pre", "stPre",
                {synEnv.addInitialiser("const " + timeStr + " stPre = " + axonalDelayMs + " + $(_src_st)[" + preSTIndex + "];")});
     synEnv.add(sg.getTimeType().addConst(), "prev_st_pre", "prevSTPre",
@@ -67,8 +67,8 @@ void applySynapseSubstitutions(const BackendBase &backend, EnvironmentExternalBa
     // Calculate backprop delay to add to (somatic) spike times and substitute in postsynaptic spike times
     const std::string backPropDelayMs = Type::writeNumeric(dt * (double)(sg.getArchetype().getBackPropDelaySteps() + 1u), sg.getTimeType());
     const bool postDelay = sg.getArchetype().getTrgNeuronGroup()->isDelayRequired();
-    const std::string postSTIndex = sg.getPostVarIndex(postDelay, batchSize, VarAccessDim::BATCH | VarAccessDim::POST_NEURON, "$(id_post)");
-    const std::string prevPostSTIndex = sg.getPostPrevSpikeTimeIndex(postDelay, batchSize, VarAccessDim::BATCH | VarAccessDim::POST_NEURON, "$(id_post)");
+    const std::string postSTIndex = sg.getPostVarIndex(postDelay, batchSize, VarAccessDim::BATCH | VarAccessDim::NEURON, "$(id_post)");
+    const std::string prevPostSTIndex = sg.getPostPrevSpikeTimeIndex(postDelay, batchSize, VarAccessDim::BATCH | VarAccessDim::NEURON, "$(id_post)");
     synEnv.add(sg.getTimeType().addConst(), "st_post", "stPost",
                {synEnv.addInitialiser("const " + timeStr + " stPost = " + backPropDelayMs + " + $(_trg_st)[" + postSTIndex + "];")});
     synEnv.add(sg.getTimeType().addConst(), "prev_st_post", "prevSTPost",

--- a/src/genn/genn/currentSourceModels.cc
+++ b/src/genn/genn/currentSourceModels.cc
@@ -35,7 +35,7 @@ void Base::validate(const std::unordered_map<std::string, double> &paramValues,
     // If any variables have a reduction access mode, give an error
     const auto vars = getVars();
     if(std::any_of(vars.cbegin(), vars.cend(),
-                   [](const Models::Base::Var &v){ return !v.access.isValidNeuron(); }))
+                   [](const Models::Base::Var &v){ return !v.access.template isValid<NeuronVarAccess>(); }))
     {
         throw std::runtime_error("Current source model variables much have NeuronVarAccess access type");
     }

--- a/src/genn/genn/currentSourceModels.cc
+++ b/src/genn/genn/currentSourceModels.cc
@@ -37,7 +37,7 @@ void Base::validate(const std::unordered_map<std::string, double> &paramValues,
     if(std::any_of(vars.cbegin(), vars.cend(),
                    [](const Models::Base::Var &v){ return !v.access.template isValid<NeuronVarAccess>(); }))
     {
-        throw std::runtime_error("Current source model variables much have NeuronVarAccess access type");
+        throw std::runtime_error("Current source model variables must have NeuronVarAccess access type");
     }
 }
 }   // namespace GeNN::CurrentSourceModels

--- a/src/genn/genn/currentSourceModels.cc
+++ b/src/genn/genn/currentSourceModels.cc
@@ -35,7 +35,11 @@ void Base::validate(const std::unordered_map<std::string, double> &paramValues,
     // If any variables have a reduction access mode, give an error
     const auto vars = getVars();
     if(std::any_of(vars.cbegin(), vars.cend(),
-                   [](const Models::Base::Var &v){ return (v.access & VarAccessModeAttribute::REDUCE); }))
+                   [](const Models::Base::Var &v)
+                   { 
+                       const unsigned int varAccess = v.access.value_or(static_cast<unsigned int>(VarAccess::READ_WRITE));
+                       return (varAccess & VarAccessModeAttribute::REDUCE); 
+                   }))
     {
         throw std::runtime_error("Current source models cannot include variables with REDUCE access modes - they are only supported by custom update models");
     }

--- a/src/genn/genn/currentSourceModels.cc
+++ b/src/genn/genn/currentSourceModels.cc
@@ -37,8 +37,7 @@ void Base::validate(const std::unordered_map<std::string, double> &paramValues,
     if(std::any_of(vars.cbegin(), vars.cend(),
                    [](const Models::Base::Var &v)
                    { 
-                       const unsigned int varAccess = v.access.value_or(static_cast<unsigned int>(VarAccess::READ_WRITE));
-                       return (varAccess & VarAccessModeAttribute::REDUCE); 
+                       return (v.getAccessMode() & VarAccessModeAttribute::REDUCE); 
                    }))
     {
         throw std::runtime_error("Current source models cannot include variables with REDUCE access modes - they are only supported by custom update models");

--- a/src/genn/genn/currentSourceModels.cc
+++ b/src/genn/genn/currentSourceModels.cc
@@ -35,12 +35,9 @@ void Base::validate(const std::unordered_map<std::string, double> &paramValues,
     // If any variables have a reduction access mode, give an error
     const auto vars = getVars();
     if(std::any_of(vars.cbegin(), vars.cend(),
-                   [](const Models::Base::Var &v)
-                   { 
-                       return (v.getAccessMode() & VarAccessModeAttribute::REDUCE); 
-                   }))
+                   [](const Models::Base::Var &v){ return !v.access.isValidNeuron(); }))
     {
-        throw std::runtime_error("Current source models cannot include variables with REDUCE access modes - they are only supported by custom update models");
+        throw std::runtime_error("Current source model variables much have NeuronVarAccess access type");
     }
 }
 }   // namespace GeNN::CurrentSourceModels

--- a/src/genn/genn/customConnectivityUpdate.cc
+++ b/src/genn/genn/customConnectivityUpdate.cc
@@ -180,8 +180,7 @@ void CustomConnectivityUpdate::finalise(double dt, unsigned int batchSize)
         if (std::any_of(getPreVarReferences().cbegin(), getPreVarReferences().cend(),
                         [](const auto &v) 
                         { 
-                            const unsigned int varAccess = v.second.getVar().access.value_or(static_cast<unsigned int>(VarAccess::READ_WRITE)); 
-                            return (getVarAccessDuplication(varAccess) != VarAccessDuplication::SHARED); 
+                            return (getVarAccessDuplication(v.second.getVar().getAccess(VarAccess::READ_WRITE)) != VarAccessDuplication::SHARED); 
                         }))
         {
             throw std::runtime_error("Presynaptic variables referenced by CustomConnectivityUpdate must be SHARED across batches");
@@ -191,8 +190,7 @@ void CustomConnectivityUpdate::finalise(double dt, unsigned int batchSize)
         if (std::any_of(getPostVarReferences().cbegin(), getPostVarReferences().cend(),
                         [](const auto &v) 
                         { 
-                            const unsigned int varAccess = v.second.getVar().access.value_or(static_cast<unsigned int>(VarAccess::READ_WRITE)); 
-                            return (getVarAccessDuplication(varAccess) != VarAccessDuplication::SHARED); 
+                            return (getVarAccessDuplication(v.second.getVar().getAccess(VarAccess::READ_WRITE)) != VarAccessDuplication::SHARED); 
                         }))
         {
             throw std::runtime_error("Postsynaptic variables referenced by CustomConnectivityUpdate must be SHARED across batches");

--- a/src/genn/genn/customConnectivityUpdate.cc
+++ b/src/genn/genn/customConnectivityUpdate.cc
@@ -176,11 +176,11 @@ void CustomConnectivityUpdate::finalise(double dt, unsigned int batchSize)
     // If model is batched we need to check all variable references 
     // are SHARED as, connectivity itself is always SHARED
     if (batchSize > 1) {
-        // If any referenced presynaptic variables aren't shared, give error
+        // If any referenced presynaptic variables are batched, give error
         if (std::any_of(getPreVarReferences().cbegin(), getPreVarReferences().cend(),
                         [](const auto &v) 
                         { 
-                            return (getVarAccessDuplication(v.second.getVar().getAccess(VarAccess::READ_WRITE)) != VarAccessDuplication::SHARED); 
+                            return (v.second.getVar().getAccess(NeuronVarAccess::READ_WRITE) & VarAccessDim::BATCH); 
                         }))
         {
             throw std::runtime_error("Presynaptic variables referenced by CustomConnectivityUpdate must be SHARED across batches");
@@ -190,7 +190,7 @@ void CustomConnectivityUpdate::finalise(double dt, unsigned int batchSize)
         if (std::any_of(getPostVarReferences().cbegin(), getPostVarReferences().cend(),
                         [](const auto &v) 
                         { 
-                            return (getVarAccessDuplication(v.second.getVar().getAccess(VarAccess::READ_WRITE)) != VarAccessDuplication::SHARED); 
+                            return (v.second.getVar().getAccess(NeuronVarAccess::READ_WRITE)& VarAccessDim::BATCH); 
                         }))
         {
             throw std::runtime_error("Postsynaptic variables referenced by CustomConnectivityUpdate must be SHARED across batches");

--- a/src/genn/genn/customConnectivityUpdate.cc
+++ b/src/genn/genn/customConnectivityUpdate.cc
@@ -180,7 +180,7 @@ void CustomConnectivityUpdate::finalise(double dt, unsigned int batchSize)
         if (std::any_of(getPreVarReferences().cbegin(), getPreVarReferences().cend(),
                         [](const auto &v) 
                         { 
-                            return (v.second.getVar().access.getDims<NeuronVarAccess>() & VarAccessDim::BATCH); 
+                            return (v.second.getVar().access.template getDims<NeuronVarAccess>() & VarAccessDim::BATCH); 
                         }))
         {
             throw std::runtime_error("Presynaptic variables referenced by CustomConnectivityUpdate must be SHARED across batches");
@@ -190,7 +190,7 @@ void CustomConnectivityUpdate::finalise(double dt, unsigned int batchSize)
         if (std::any_of(getPostVarReferences().cbegin(), getPostVarReferences().cend(),
                         [](const auto &v) 
                         { 
-                            return (v.second.getVar().access.getDims<NeuronVarAccess>() & VarAccessDim::BATCH); 
+                            return (v.second.getVar().access.template getDims<NeuronVarAccess>() & VarAccessDim::BATCH); 
                         }))
         {
             throw std::runtime_error("Postsynaptic variables referenced by CustomConnectivityUpdate must be SHARED across batches");

--- a/src/genn/genn/customConnectivityUpdate.cc
+++ b/src/genn/genn/customConnectivityUpdate.cc
@@ -178,14 +178,22 @@ void CustomConnectivityUpdate::finalise(double dt, unsigned int batchSize)
     if (batchSize > 1) {
         // If any referenced presynaptic variables aren't shared, give error
         if (std::any_of(getPreVarReferences().cbegin(), getPreVarReferences().cend(),
-                        [](const auto &v) { return (getVarAccessDuplication(v.second.getVar().access) != VarAccessDuplication::SHARED); }))
+                        [](const auto &v) 
+                        { 
+                            const unsigned int varAccess = v.second.getVar().access.value_or(static_cast<unsigned int>(VarAccess::READ_WRITE)); 
+                            return (getVarAccessDuplication(varAccess) != VarAccessDuplication::SHARED); 
+                        }))
         {
             throw std::runtime_error("Presynaptic variables referenced by CustomConnectivityUpdate must be SHARED across batches");
         }
 
         // If any referenced presynaptic variables aren't shared, give error
         if (std::any_of(getPostVarReferences().cbegin(), getPostVarReferences().cend(),
-                        [](const auto &v) { return (getVarAccessDuplication(v.second.getVar().access) != VarAccessDuplication::SHARED); }))
+                        [](const auto &v) 
+                        { 
+                            const unsigned int varAccess = v.second.getVar().access.value_or(static_cast<unsigned int>(VarAccess::READ_WRITE)); 
+                            return (getVarAccessDuplication(varAccess) != VarAccessDuplication::SHARED); 
+                        }))
         {
             throw std::runtime_error("Postsynaptic variables referenced by CustomConnectivityUpdate must be SHARED across batches");
         }

--- a/src/genn/genn/customConnectivityUpdate.cc
+++ b/src/genn/genn/customConnectivityUpdate.cc
@@ -313,7 +313,7 @@ boost::uuids::detail::sha1::digest_type CustomConnectivityUpdate::getHashDigest(
                    {
                        boost::uuids::detail::sha1 hash;  
                        Type::updateHash(v.getVar().type, hash);
-                       Utils::updateHash(v.isDuplicated(), hash);
+                       Utils::updateHash(v.getDims(), hash);
                        return hash.get_digest();
                    });
     
@@ -329,7 +329,7 @@ boost::uuids::detail::sha1::digest_type CustomConnectivityUpdate::getHashDigest(
 
     // Update hash with duplication mode of synaptic variable references
     for(const auto &v : getVarReferences()) {
-        Utils::updateHash(v.second.isDuplicated(), hash);
+        Utils::updateHash(v.second.getDims(), hash);
     }
 
     return hash.get_digest();

--- a/src/genn/genn/customConnectivityUpdate.cc
+++ b/src/genn/genn/customConnectivityUpdate.cc
@@ -180,7 +180,7 @@ void CustomConnectivityUpdate::finalise(double dt, unsigned int batchSize)
         if (std::any_of(getPreVarReferences().cbegin(), getPreVarReferences().cend(),
                         [](const auto &v) 
                         { 
-                            return (v.second.getVar().getAccess(NeuronVarAccess::READ_WRITE) & VarAccessDim::BATCH); 
+                            return (v.second.getVar().access.getDims<NeuronVarAccess>() & VarAccessDim::BATCH); 
                         }))
         {
             throw std::runtime_error("Presynaptic variables referenced by CustomConnectivityUpdate must be SHARED across batches");
@@ -190,7 +190,7 @@ void CustomConnectivityUpdate::finalise(double dt, unsigned int batchSize)
         if (std::any_of(getPostVarReferences().cbegin(), getPostVarReferences().cend(),
                         [](const auto &v) 
                         { 
-                            return (v.second.getVar().getAccess(NeuronVarAccess::READ_WRITE)& VarAccessDim::BATCH); 
+                            return (v.second.getVar().access.getDims<NeuronVarAccess>() & VarAccessDim::BATCH); 
                         }))
         {
             throw std::runtime_error("Postsynaptic variables referenced by CustomConnectivityUpdate must be SHARED across batches");

--- a/src/genn/genn/customConnectivityUpdate.cc
+++ b/src/genn/genn/customConnectivityUpdate.cc
@@ -180,7 +180,7 @@ void CustomConnectivityUpdate::finalise(double dt, unsigned int batchSize)
         if (std::any_of(getPreVarReferences().cbegin(), getPreVarReferences().cend(),
                         [](const auto &v) 
                         { 
-                            return (v.second.getVar().access.template getDims<NeuronVarAccess>() & VarAccessDim::BATCH); 
+                            return (v.second.getDims() & VarAccessDim::BATCH); 
                         }))
         {
             throw std::runtime_error("Presynaptic variables referenced by CustomConnectivityUpdate must be SHARED across batches");
@@ -190,7 +190,7 @@ void CustomConnectivityUpdate::finalise(double dt, unsigned int batchSize)
         if (std::any_of(getPostVarReferences().cbegin(), getPostVarReferences().cend(),
                         [](const auto &v) 
                         { 
-                            return (v.second.getVar().access.template getDims<NeuronVarAccess>() & VarAccessDim::BATCH); 
+                            return (v.second.getDims() & VarAccessDim::BATCH); 
                         }))
         {
             throw std::runtime_error("Postsynaptic variables referenced by CustomConnectivityUpdate must be SHARED across batches");

--- a/src/genn/genn/customConnectivityUpdate.cc
+++ b/src/genn/genn/customConnectivityUpdate.cc
@@ -124,9 +124,9 @@ CustomConnectivityUpdate::CustomConnectivityUpdate(const std::string &name, cons
     }
 
     // Check variable reference types
-    Models::checkVarReferences(m_VarReferences, getCustomConnectivityUpdateModel()->getVarRefs());
-    Models::checkVarReferences(m_PreVarReferences, getCustomConnectivityUpdateModel()->getPreVarRefs());
-    Models::checkVarReferences(m_PostVarReferences, getCustomConnectivityUpdateModel()->getPostVarRefs());
+    Models::checkVarReferenceTypes(m_VarReferences, getCustomConnectivityUpdateModel()->getVarRefs());
+    Models::checkVarReferenceTypes(m_PreVarReferences, getCustomConnectivityUpdateModel()->getPreVarRefs());
+    Models::checkVarReferenceTypes(m_PostVarReferences, getCustomConnectivityUpdateModel()->getPostVarRefs());
 
     // Give error if any WU var references aren't pointing to synapse group
     if (std::any_of(m_VarReferences.cbegin(), m_VarReferences.cend(),

--- a/src/genn/genn/customConnectivityUpdateModels.cc
+++ b/src/genn/genn/customConnectivityUpdateModels.cc
@@ -61,17 +61,17 @@ void Base::validate(const std::unordered_map<std::string, double> &paramValues,
     if(std::any_of(vars.cbegin(), vars.cend(),
                    [](const Models::Base::Var &v){ return !v.access.template isValid<SynapseVarAccess>(); }))
     {
-        throw std::runtime_error("Custom connectivity update models variables much have SynapseVarAccess access type");
+        throw std::runtime_error("Custom connectivity update models variables must have SynapseVarAccess access type");
     }
     if(std::any_of(preVars.cbegin(), preVars.cend(),
                    [](const Models::Base::Var &v){ return !v.access.template isValid<NeuronVarAccess>(); }))
     {
-        throw std::runtime_error("Custom connectivity update models presynaptic variables much have NeuronVarAccess access type");
+        throw std::runtime_error("Custom connectivity update models presynaptic variables must have NeuronVarAccess access type");
     }
     if(std::any_of(postVars.cbegin(), postVars.cend(),
                    [](const Models::Base::Var &v){ return !v.access.template isValid<NeuronVarAccess>(); }))
     {
-        throw std::runtime_error("Custom connectivity update models postsynaptic variables much have NeuronVarAccess access type");
+        throw std::runtime_error("Custom connectivity update models postsynaptic variables must have NeuronVarAccess access type");
     }
 }
 }   // namespace GeNN::CustomConnectivityUpdateModels

--- a/src/genn/genn/customConnectivityUpdateModels.cc
+++ b/src/genn/genn/customConnectivityUpdateModels.cc
@@ -75,7 +75,7 @@ void Base::validate(const std::unordered_map<std::string, double> &paramValues,
     if (std::any_of(vars.cbegin(), vars.cend(),
                     [](const Models::Base::Var &v) 
                     { 
-                        return (v.getAccess(VarAccess::READ_WRITE) & VarAccessDuplication::SHARED_NEURON); 
+                        return (v.getAccess(SynapseVarAccess::READ_WRITE) & VarAccessDim::SHARED_NEURON); 
                     }))
     {
         throw std::runtime_error("Custom connectivity update models cannot include variables with SHARED_NEURON access modes - they are only supported on pre, postsynaptic or neuron variables");

--- a/src/genn/genn/customConnectivityUpdateModels.cc
+++ b/src/genn/genn/customConnectivityUpdateModels.cc
@@ -61,23 +61,11 @@ void Base::validate(const std::unordered_map<std::string, double> &paramValues,
     // If any variables have a reduction access mode, give an error
     // **YUCK** copy-paste from WUM - could go in helper/Models::Base
     if(std::any_of(vars.cbegin(), vars.cend(),
-                   [](const Models::Base::Var &v)
-                   {
-                       const unsigned int varAccess = v.access.value_or(static_cast<unsigned int>(VarAccess::READ_WRITE)); 
-                       return (varAccess & VarAccessModeAttribute::REDUCE); 
-                   })
+                   [](const Models::Base::Var &v){ return (v.getAccessMode() & VarAccessModeAttribute::REDUCE); })
        || std::any_of(preVars.cbegin(), preVars.cend(),
-                      [](const Models::Base::Var &v)
-                      {
-                          const unsigned int varAccess = v.access.value_or(static_cast<unsigned int>(VarAccess::READ_WRITE)); 
-                          return (varAccess & VarAccessModeAttribute::REDUCE); 
-                      })
+                      [](const Models::Base::Var &v){ return (v.getAccessMode() & VarAccessModeAttribute::REDUCE); })
        || std::any_of(postVars.cbegin(), postVars.cend(),
-                      [](const Models::Base::Var &v)
-                      {
-                          const unsigned int varAccess = v.access.value_or(static_cast<unsigned int>(VarAccess::READ_WRITE)); 
-                          return (varAccess & VarAccessModeAttribute::REDUCE); 
-                      }))
+                      [](const Models::Base::Var &v){ return (v.getAccessMode() & VarAccessModeAttribute::REDUCE); }))
     {
         throw std::runtime_error("Custom connectivity update models cannot include variables with REDUCE access modes - they are only supported by custom update models");
     }
@@ -87,8 +75,7 @@ void Base::validate(const std::unordered_map<std::string, double> &paramValues,
     if (std::any_of(vars.cbegin(), vars.cend(),
                     [](const Models::Base::Var &v) 
                     { 
-                        const unsigned int varAccess = v.access.value_or(static_cast<unsigned int>(VarAccess::READ_WRITE)); 
-                        return (varAccess & VarAccessDuplication::SHARED_NEURON); 
+                        return (v.getAccess(VarAccess::READ_WRITE) & VarAccessDuplication::SHARED_NEURON); 
                     }))
     {
         throw std::runtime_error("Custom connectivity update models cannot include variables with SHARED_NEURON access modes - they are only supported on pre, postsynaptic or neuron variables");

--- a/src/genn/genn/customConnectivityUpdateModels.cc
+++ b/src/genn/genn/customConnectivityUpdateModels.cc
@@ -60,12 +60,24 @@ void Base::validate(const std::unordered_map<std::string, double> &paramValues,
     
     // If any variables have a reduction access mode, give an error
     // **YUCK** copy-paste from WUM - could go in helper/Models::Base
-    if (std::any_of(vars.cbegin(), vars.cend(),
-                    [](const Models::Base::Var &v) { return (v.access & VarAccessModeAttribute::REDUCE); })
-        || std::any_of(preVars.cbegin(), preVars.cend(),
-                       [](const Models::Base::Var &v) { return (v.access & VarAccessModeAttribute::REDUCE); })
-        || std::any_of(postVars.cbegin(), postVars.cend(),
-                       [](const Models::Base::Var &v) { return (v.access & VarAccessModeAttribute::REDUCE); }))
+    if(std::any_of(vars.cbegin(), vars.cend(),
+                   [](const Models::Base::Var &v)
+                   {
+                       const unsigned int varAccess = v.access.value_or(static_cast<unsigned int>(VarAccess::READ_WRITE)); 
+                       return (varAccess & VarAccessModeAttribute::REDUCE); 
+                   })
+       || std::any_of(preVars.cbegin(), preVars.cend(),
+                      [](const Models::Base::Var &v)
+                      {
+                          const unsigned int varAccess = v.access.value_or(static_cast<unsigned int>(VarAccess::READ_WRITE)); 
+                          return (varAccess & VarAccessModeAttribute::REDUCE); 
+                      })
+       || std::any_of(postVars.cbegin(), postVars.cend(),
+                      [](const Models::Base::Var &v)
+                      {
+                          const unsigned int varAccess = v.access.value_or(static_cast<unsigned int>(VarAccess::READ_WRITE)); 
+                          return (varAccess & VarAccessModeAttribute::REDUCE); 
+                      }))
     {
         throw std::runtime_error("Custom connectivity update models cannot include variables with REDUCE access modes - they are only supported by custom update models");
     }
@@ -73,7 +85,11 @@ void Base::validate(const std::unordered_map<std::string, double> &paramValues,
     // If any variables have shared neuron duplication mode, give an error
     // **YUCK** copy-paste from WUM - could go in helper/Models::Base
     if (std::any_of(vars.cbegin(), vars.cend(),
-                    [](const Models::Base::Var &v) { return (v.access & VarAccessDuplication::SHARED_NEURON); }))
+                    [](const Models::Base::Var &v) 
+                    { 
+                        const unsigned int varAccess = v.access.value_or(static_cast<unsigned int>(VarAccess::READ_WRITE)); 
+                        return (varAccess & VarAccessDuplication::SHARED_NEURON); 
+                    }))
     {
         throw std::runtime_error("Custom connectivity update models cannot include variables with SHARED_NEURON access modes - they are only supported on pre, postsynaptic or neuron variables");
     }

--- a/src/genn/genn/customConnectivityUpdateModels.cc
+++ b/src/genn/genn/customConnectivityUpdateModels.cc
@@ -59,17 +59,17 @@ void Base::validate(const std::unordered_map<std::string, double> &paramValues,
     
     // Check variables have suitable access types
     if(std::any_of(vars.cbegin(), vars.cend(),
-                   [](const Models::Base::Var &v){ return !v.access.isValidSynapse(); }))
+                   [](const Models::Base::Var &v){ return !v.access.template isValid<SynapseVarAccess>(); }))
     {
         throw std::runtime_error("Custom connectivity update models variables much have SynapseVarAccess access type");
     }
     if(std::any_of(preVars.cbegin(), preVars.cend(),
-                   [](const Models::Base::Var &v){ return !v.access.isValidNeuron(); }))
+                   [](const Models::Base::Var &v){ return !v.access.template isValid<NeuronVarAccess>(); }))
     {
         throw std::runtime_error("Custom connectivity update models presynaptic variables much have NeuronVarAccess access type");
     }
     if(std::any_of(postVars.cbegin(), postVars.cend(),
-                   [](const Models::Base::Var &v){ return !v.access.isValidNeuron(); }))
+                   [](const Models::Base::Var &v){ return !v.access.template isValid<NeuronVarAccess>(); }))
     {
         throw std::runtime_error("Custom connectivity update models postsynaptic variables much have NeuronVarAccess access type");
     }

--- a/src/genn/genn/customUpdate.cc
+++ b/src/genn/genn/customUpdate.cc
@@ -298,8 +298,8 @@ boost::uuids::detail::sha1::digest_type CustomUpdateWU::getHashDigest() const
         // Update hash with whether variable references require transpose
         Utils::updateHash((v.second.getTransposeSynapseGroup() == nullptr), hash);
 
-        // Update hash with access mode of target variable dimensions as this effects indexing code
-        Utils::updateHash(v.second.getVar().access.getDims<SynapseVarAccess>(), hash);
+        // Update hash with dimensionality of target variable dimensions as this effects indexing code
+        Utils::updateHash(v.second.getDims(), hash);
     }
 
     return hash.get_digest();

--- a/src/genn/genn/customUpdate.cc
+++ b/src/genn/genn/customUpdate.cc
@@ -139,12 +139,12 @@ CustomUpdate::CustomUpdate(const std::string &name, const std::string &updateGro
     m_PerNeuron = std::any_of(m_VarReferences.cbegin(), m_VarReferences.cend(),
                               [](const auto& v) 
                               {
-                                  return (v.second.getVar().access.getDims<NeuronVarAccess>() & VarAccessDim::NEURON); 
+                                  return (v.second.getVar().access.template getDims<NeuronVarAccess>() & VarAccessDim::NEURON); 
                               });
     m_PerNeuron |= std::any_of(modelVars.cbegin(), modelVars.cend(),
                                [](const Models::Base::Var& v) 
                                {
-                                   return (v.access.getDims<NeuronVarAccess>() & VarAccessDim::NEURON); 
+                                   return (v.access.template getDims<NeuronVarAccess>() & VarAccessDim::NEURON); 
                                });
 
     // Loop through all variable references

--- a/src/genn/genn/customUpdate.cc
+++ b/src/genn/genn/customUpdate.cc
@@ -132,7 +132,7 @@ CustomUpdate::CustomUpdate(const std::string &name, const std::string &updateGro
     }
 
     // Check variable reference types
-    Models::checkVarReferences(m_VarReferences, getCustomUpdateModel()->getVarRefs());
+    Models::checkVarReferenceTypes(m_VarReferences, getCustomUpdateModel()->getVarRefs());
 
     // Update is per-neuron if any variables or variable reference targets have neuron dimension
     const auto modelVars = getCustomUpdateModel()->getVars();
@@ -251,7 +251,7 @@ CustomUpdateWU::CustomUpdateWU(const std::string &name, const std::string &updat
     }
 
     // Check variable reference types
-    Models::checkVarReferences(m_VarReferences, getCustomUpdateModel()->getVarRefs());
+    Models::checkVarReferenceTypes(m_VarReferences, getCustomUpdateModel()->getVarRefs());
 
     // Give error if references point to different synapse groups
     // **NOTE** this could be relaxed for dense

--- a/src/genn/genn/customUpdateModels.cc
+++ b/src/genn/genn/customUpdateModels.cc
@@ -55,5 +55,13 @@ void Base::validate(const std::unordered_map<std::string, double> &paramValues,
     // Validate variable reference initialisers
     Utils::validateInitialisers(varRefs, varRefTargets, "Variable reference", description);
     Utils::validateVecNames(getExtraGlobalParamRefs(), "Extra global parameter reference");
+
+    // If any variables have an invalid access mode, give an error
+    const auto vars = getVars();
+    if(std::any_of(vars.cbegin(), vars.cend(),
+                   [](const Models::Base::Var &v){ return !v.access.template isValid<CustomUpdateVarAccess>(); }))
+    {
+        throw std::runtime_error("Custom update model variables must have CustomUpdateVarAccess access type");
+    }
 }
 }   // namespace GeNN::CustomUpdateModels

--- a/src/genn/genn/models.cc
+++ b/src/genn/genn/models.cc
@@ -75,8 +75,7 @@ std::string VarReference::getTargetName() const
 //----------------------------------------------------------------------------
 bool VarReference::isDuplicated() const
 {
-    const unsigned int varAccess = getVar().access.value_or(static_cast<unsigned int>(VarAccess::READ_WRITE)); 
-    if(varAccess & VarAccessDuplication::SHARED) {
+    if(getVar().getAccess(VarAccess::READ_WRITE) & VarAccessDuplication::SHARED) {
         return false;
     }
     else {
@@ -176,8 +175,7 @@ std::string WUVarReference::getTargetName() const
 //----------------------------------------------------------------------------
 bool WUVarReference::isDuplicated() const
 {
-    const unsigned int varAccess = getVar().access.value_or(static_cast<unsigned int>(VarAccess::READ_WRITE)); 
-    if(varAccess & VarAccessDuplication::SHARED) {
+    if(getVar().getAccess(VarAccess::READ_WRITE) & VarAccessDuplication::SHARED) {
         return false;
     }
     else {
@@ -332,9 +330,9 @@ WUVarReference::WUVarReference(size_t varIndex, const Models::Base::VarVec &varV
     }
 
     // Check duplicatedness of variables
-    const unsigned int varAccess = getVar().access.value_or(static_cast<unsigned int>(VarAccess::READ_WRITE)); 
-    const unsigned int transposeVarAccess = getTransposeVar().access.value_or(static_cast<unsigned int>(VarAccess::READ_WRITE)); 
-    if((varAccess & VarAccessDuplication::DUPLICATE) != (transposeVarAccess & VarAccessDuplication::DUPLICATE)) {
+    if((getVar().getAccess(VarAccess::READ_WRITE) & VarAccessDuplication::DUPLICATE) 
+       != (getTransposeVar().getAccess(VarAccess::READ_WRITE) & VarAccessDuplication::DUPLICATE)) 
+    {
         throw std::runtime_error("Transpose updates can only be performed on similarly batched variables");
     }
 }

--- a/src/genn/genn/models.cc
+++ b/src/genn/genn/models.cc
@@ -76,7 +76,7 @@ std::string VarReference::getTargetName() const
 bool VarReference::isDuplicated() const
 {
     // If target variable has BATCH dimension
-    if(getVar().getAccess(NeuronVarAccess::READ_WRITE) & VarAccessDim::BATCH) {
+    if(getVar().access.getDims<NeuronVarAccess>() & VarAccessDim::BATCH) {
         return std::visit(
             Utils::Overload{
                 [](const CURef &ref) { return ref.group->isBatched(); },
@@ -177,7 +177,7 @@ std::string WUVarReference::getTargetName() const
 bool WUVarReference::isDuplicated() const
 {
     // If target variable has BATCH dimension
-    if(getVar().getAccess(SynapseVarAccess::READ_WRITE) & VarAccessDim::BATCH) {
+    if(getVar().access.getDims<SynapseVarAccess>() & VarAccessDim::BATCH) {
         return std::visit(
             Utils::Overload{
                 [](const CURef &ref) { return ref.group->isBatched(); },
@@ -332,8 +332,8 @@ WUVarReference::WUVarReference(size_t varIndex, const Models::Base::VarVec &varV
     }
 
     // Check duplicatedness of variables
-    if((getVar().getAccess(SynapseVarAccess::READ_WRITE) & VarAccessDim::BATCH) 
-       != (getTransposeVar().getAccess(SynapseVarAccess::READ_WRITE) & VarAccessDim::BATCH)) 
+    if((getVar().access.getDims<SynapseVarAccess>() & VarAccessDim::BATCH) 
+       != (getTransposeVar().access.getDims<SynapseVarAccess>() & VarAccessDim::BATCH)) 
     {
         throw std::runtime_error("Transpose updates can only be performed on similarly batched variables");
     }
@@ -385,7 +385,7 @@ void updateHash(const Base::Var &v, boost::uuids::detail::sha1 &hash)
 {
     Utils::updateHash(v.name, hash);
     Type::updateHash(v.type, hash);
-    Utils::updateHash(v.access, hash);
+    v.access.updateHash(hash);
 }
 //----------------------------------------------------------------------------
 void updateHash(const Base::VarRef &v, boost::uuids::detail::sha1 &hash)

--- a/src/genn/genn/models.cc
+++ b/src/genn/genn/models.cc
@@ -75,7 +75,8 @@ std::string VarReference::getTargetName() const
 //----------------------------------------------------------------------------
 bool VarReference::isDuplicated() const
 {
-    if(getVar().access & VarAccessDuplication::SHARED) {
+    const unsigned int varAccess = getVar().access.value_or(static_cast<unsigned int>(VarAccess::READ_WRITE)); 
+    if(varAccess & VarAccessDuplication::SHARED) {
         return false;
     }
     else {
@@ -175,7 +176,8 @@ std::string WUVarReference::getTargetName() const
 //----------------------------------------------------------------------------
 bool WUVarReference::isDuplicated() const
 {
-    if(getVar().access & VarAccessDuplication::SHARED) {
+    const unsigned int varAccess = getVar().access.value_or(static_cast<unsigned int>(VarAccess::READ_WRITE)); 
+    if(varAccess & VarAccessDuplication::SHARED) {
         return false;
     }
     else {
@@ -330,7 +332,9 @@ WUVarReference::WUVarReference(size_t varIndex, const Models::Base::VarVec &varV
     }
 
     // Check duplicatedness of variables
-    if((getVar().access & VarAccessDuplication::DUPLICATE) != (getTransposeVar().access & VarAccessDuplication::DUPLICATE)) {
+    const unsigned int varAccess = getVar().access.value_or(static_cast<unsigned int>(VarAccess::READ_WRITE)); 
+    const unsigned int transposeVarAccess = getTransposeVar().access.value_or(static_cast<unsigned int>(VarAccess::READ_WRITE)); 
+    if((varAccess & VarAccessDuplication::DUPLICATE) != (transposeVarAccess & VarAccessDuplication::DUPLICATE)) {
         throw std::runtime_error("Transpose updates can only be performed on similarly batched variables");
     }
 }

--- a/src/genn/genn/neuronModels.cc
+++ b/src/genn/genn/neuronModels.cc
@@ -52,7 +52,7 @@ void Base::validate(const std::unordered_map<std::string, double> &paramValues,
     if(std::any_of(vars.cbegin(), vars.cend(),
                    [](const Models::Base::Var &v){ return !v.access.template isValid<NeuronVarAccess>(); }))
     {
-        throw std::runtime_error("Neuron model variables much have NeuronVarAccess access type");
+        throw std::runtime_error("Neuron model variables must have NeuronVarAccess access type");
     }
 }
 }   // namespace GeNN::NeuronModels

--- a/src/genn/genn/neuronModels.cc
+++ b/src/genn/genn/neuronModels.cc
@@ -50,7 +50,11 @@ void Base::validate(const std::unordered_map<std::string, double> &paramValues,
     // If any variables have a reduction access mode, give an error
     const auto vars = getVars();
     if(std::any_of(vars.cbegin(), vars.cend(),
-                   [](const Models::Base::Var &v){ return (v.access & VarAccessModeAttribute::REDUCE); }))
+                   [](const Models::Base::Var &v)
+                   { 
+                       const unsigned int varAccess = v.access.value_or(static_cast<unsigned int>(VarAccess::READ_WRITE));
+                       return (varAccess & VarAccessModeAttribute::REDUCE); 
+                   }))
     {
         throw std::runtime_error("Neuron models cannot include variables with REDUCE access modes - they are only supported by custom update models");
     }

--- a/src/genn/genn/neuronModels.cc
+++ b/src/genn/genn/neuronModels.cc
@@ -50,9 +50,9 @@ void Base::validate(const std::unordered_map<std::string, double> &paramValues,
     // If any variables have a reduction access mode, give an error
     const auto vars = getVars();
     if(std::any_of(vars.cbegin(), vars.cend(),
-                   [](const Models::Base::Var &v){ return (v.getAccessMode() & VarAccessModeAttribute::REDUCE); }))
+                   [](const Models::Base::Var &v){ return !v.access.isValidNeuron(); }))
     {
-        throw std::runtime_error("Neuron models cannot include variables with REDUCE access modes - they are only supported by custom update models");
+        throw std::runtime_error("Neuron model variables much have NeuronVarAccess access type");
     }
 }
 }   // namespace GeNN::NeuronModels

--- a/src/genn/genn/neuronModels.cc
+++ b/src/genn/genn/neuronModels.cc
@@ -50,11 +50,7 @@ void Base::validate(const std::unordered_map<std::string, double> &paramValues,
     // If any variables have a reduction access mode, give an error
     const auto vars = getVars();
     if(std::any_of(vars.cbegin(), vars.cend(),
-                   [](const Models::Base::Var &v)
-                   { 
-                       const unsigned int varAccess = v.access.value_or(static_cast<unsigned int>(VarAccess::READ_WRITE));
-                       return (varAccess & VarAccessModeAttribute::REDUCE); 
-                   }))
+                   [](const Models::Base::Var &v){ return (v.getAccessMode() & VarAccessModeAttribute::REDUCE); }))
     {
         throw std::runtime_error("Neuron models cannot include variables with REDUCE access modes - they are only supported by custom update models");
     }

--- a/src/genn/genn/neuronModels.cc
+++ b/src/genn/genn/neuronModels.cc
@@ -50,7 +50,7 @@ void Base::validate(const std::unordered_map<std::string, double> &paramValues,
     // If any variables have a reduction access mode, give an error
     const auto vars = getVars();
     if(std::any_of(vars.cbegin(), vars.cend(),
-                   [](const Models::Base::Var &v){ return !v.access.isValidNeuron(); }))
+                   [](const Models::Base::Var &v){ return !v.access.template isValid<NeuronVarAccess>(); }))
     {
         throw std::runtime_error("Neuron model variables much have NeuronVarAccess access type");
     }

--- a/src/genn/genn/neuronModels.cc
+++ b/src/genn/genn/neuronModels.cc
@@ -47,7 +47,7 @@ void Base::validate(const std::unordered_map<std::string, double> &paramValues,
 
     Utils::validateVecNames(getAdditionalInputVars(), "Additional input variable");
 
-    // If any variables have a reduction access mode, give an error
+    // If any variables have an invalid access mode, give an error
     const auto vars = getVars();
     if(std::any_of(vars.cbegin(), vars.cend(),
                    [](const Models::Base::Var &v){ return !v.access.template isValid<NeuronVarAccess>(); }))

--- a/src/genn/genn/postsynapticModels.cc
+++ b/src/genn/genn/postsynapticModels.cc
@@ -33,11 +33,12 @@ void Base::validate(const std::unordered_map<std::string, double> &paramValues,
     // Superclass
     Models::Base::validate(paramValues, varValues, description);
 
+    // If any variables have a reduction access mode, give an error
     const auto vars = getVars();
     if(std::any_of(vars.cbegin(), vars.cend(),
-                   [](const Models::Base::Var &v){ return (v.getAccessMode() & VarAccessModeAttribute::REDUCE); }))
+                   [](const Models::Base::Var &v){ return !v.access.isValidNeuron(); }))
     {
-        throw std::runtime_error("Postsynaptic models cannot include variables with REDUCE access modes - they are only supported by custom update models");
+        throw std::runtime_error("Postsynaptic model variables much have NeuronVarAccess access type");
     }
 }
 }   // namespace GeNN::PostsynapticModels

--- a/src/genn/genn/postsynapticModels.cc
+++ b/src/genn/genn/postsynapticModels.cc
@@ -38,7 +38,7 @@ void Base::validate(const std::unordered_map<std::string, double> &paramValues,
     if(std::any_of(vars.cbegin(), vars.cend(),
                    [](const Models::Base::Var &v){ return !v.access.template isValid<NeuronVarAccess>(); }))
     {
-        throw std::runtime_error("Postsynaptic model variables much have NeuronVarAccess access type");
+        throw std::runtime_error("Postsynaptic model variables must have NeuronVarAccess access type");
     }
 }
 }   // namespace GeNN::PostsynapticModels

--- a/src/genn/genn/postsynapticModels.cc
+++ b/src/genn/genn/postsynapticModels.cc
@@ -36,7 +36,7 @@ void Base::validate(const std::unordered_map<std::string, double> &paramValues,
     // If any variables have a reduction access mode, give an error
     const auto vars = getVars();
     if(std::any_of(vars.cbegin(), vars.cend(),
-                   [](const Models::Base::Var &v){ return !v.access.isValidNeuron(); }))
+                   [](const Models::Base::Var &v){ return !v.access.template isValid<NeuronVarAccess>(); }))
     {
         throw std::runtime_error("Postsynaptic model variables much have NeuronVarAccess access type");
     }

--- a/src/genn/genn/postsynapticModels.cc
+++ b/src/genn/genn/postsynapticModels.cc
@@ -35,7 +35,11 @@ void Base::validate(const std::unordered_map<std::string, double> &paramValues,
 
     const auto vars = getVars();
     if(std::any_of(vars.cbegin(), vars.cend(),
-                   [](const Models::Base::Var &v){ return (v.access & VarAccessModeAttribute::REDUCE); }))
+                   [](const Models::Base::Var &v)
+                   { 
+                       const unsigned int varAccess = v.access.value_or(static_cast<unsigned int>(VarAccess::READ_WRITE));
+                       return (varAccess & VarAccessModeAttribute::REDUCE);
+                   }))
     {
         throw std::runtime_error("Postsynaptic models cannot include variables with REDUCE access modes - they are only supported by custom update models");
     }

--- a/src/genn/genn/postsynapticModels.cc
+++ b/src/genn/genn/postsynapticModels.cc
@@ -35,11 +35,7 @@ void Base::validate(const std::unordered_map<std::string, double> &paramValues,
 
     const auto vars = getVars();
     if(std::any_of(vars.cbegin(), vars.cend(),
-                   [](const Models::Base::Var &v)
-                   { 
-                       const unsigned int varAccess = v.access.value_or(static_cast<unsigned int>(VarAccess::READ_WRITE));
-                       return (varAccess & VarAccessModeAttribute::REDUCE);
-                   }))
+                   [](const Models::Base::Var &v){ return (v.getAccessMode() & VarAccessModeAttribute::REDUCE); }))
     {
         throw std::runtime_error("Postsynaptic models cannot include variables with REDUCE access modes - they are only supported by custom update models");
     }

--- a/src/genn/genn/weightUpdateModels.cc
+++ b/src/genn/genn/weightUpdateModels.cc
@@ -85,11 +85,23 @@ void Base::validate(const std::unordered_map<std::string, double> &paramValues,
     const auto preVars = getPreVars();
     const auto postVars = getPostVars();
     if(std::any_of(vars.cbegin(), vars.cend(),
-                   [](const Models::Base::Var &v){ return (v.access & VarAccessModeAttribute::REDUCE); })
+                   [](const Models::Base::Var &v)
+                   {
+                       const unsigned int varAccess = v.access.value_or(static_cast<unsigned int>(VarAccess::READ_WRITE)); 
+                       return (varAccess & VarAccessModeAttribute::REDUCE); 
+                   })
        || std::any_of(preVars.cbegin(), preVars.cend(),
-                      [](const Models::Base::Var &v){ return (v.access & VarAccessModeAttribute::REDUCE); })
+                      [](const Models::Base::Var &v)
+                      {
+                          const unsigned int varAccess = v.access.value_or(static_cast<unsigned int>(VarAccess::READ_WRITE)); 
+                          return (varAccess & VarAccessModeAttribute::REDUCE); 
+                      })
        || std::any_of(postVars.cbegin(), postVars.cend(),
-                      [](const Models::Base::Var &v){ return (v.access & VarAccessModeAttribute::REDUCE); }))
+                      [](const Models::Base::Var &v)
+                      {
+                          const unsigned int varAccess = v.access.value_or(static_cast<unsigned int>(VarAccess::READ_WRITE)); 
+                          return (varAccess & VarAccessModeAttribute::REDUCE); 
+                      }))
     {
         throw std::runtime_error("Weight update models cannot include variables with REDUCE access modes - they are only supported by custom update models");
     }
@@ -102,7 +114,11 @@ void Base::validate(const std::unordered_map<std::string, double> &paramValues,
 
     // If any variables have shared neuron duplication mode, give an error
     if (std::any_of(vars.cbegin(), vars.cend(),
-                    [](const Models::Base::Var &v) { return (v.access & VarAccessDuplication::SHARED_NEURON); }))
+                    [](const Models::Base::Var &v) 
+                    { 
+                        const unsigned int varAccess = v.access.value_or(static_cast<unsigned int>(VarAccess::READ_WRITE)); 
+                        return (varAccess & VarAccessDuplication::SHARED_NEURON); 
+                    }))
     {
         throw std::runtime_error("Weight update models cannot include variables with SHARED_NEURON access modes - they are only supported on pre, postsynaptic or neuron variables");
     }

--- a/src/genn/genn/weightUpdateModels.cc
+++ b/src/genn/genn/weightUpdateModels.cc
@@ -90,17 +90,17 @@ void Base::validate(const std::unordered_map<std::string, double> &paramValues,
     // Check variables have suitable access types
     const auto vars = getVars();
     if(std::any_of(vars.cbegin(), vars.cend(),
-                   [](const Models::Base::Var &v){ return !v.access.isValidSynapse(); }))
+                   [](const Models::Base::Var &v){ return !v.access.template isValid<SynapseVarAccess>(); }))
     {
         throw std::runtime_error("Weight update models variables much have SynapseVarAccess access type");
     }
     if(std::any_of(preVars.cbegin(), preVars.cend(),
-                   [](const Models::Base::Var &v){ return !v.access.isValidNeuron(); }))
+                   [](const Models::Base::Var &v){ return !v.access.template isValid<NeuronVarAccess>(); }))
     {
         throw std::runtime_error("Weight update models presynaptic variables much have NeuronVarAccess access type");
     }
     if(std::any_of(postVars.cbegin(), postVars.cend(),
-                   [](const Models::Base::Var &v){ return !v.access.isValidNeuron(); }))
+                   [](const Models::Base::Var &v){ return !v.access.template isValid<NeuronVarAccess>(); }))
     {
         throw std::runtime_error("Weight update models postsynaptic variables much have NeuronVarAccess access type");
     }

--- a/src/genn/genn/weightUpdateModels.cc
+++ b/src/genn/genn/weightUpdateModels.cc
@@ -92,17 +92,17 @@ void Base::validate(const std::unordered_map<std::string, double> &paramValues,
     if(std::any_of(vars.cbegin(), vars.cend(),
                    [](const Models::Base::Var &v){ return !v.access.template isValid<SynapseVarAccess>(); }))
     {
-        throw std::runtime_error("Weight update models variables much have SynapseVarAccess access type");
+        throw std::runtime_error("Weight update models variables must have SynapseVarAccess access type");
     }
     if(std::any_of(preVars.cbegin(), preVars.cend(),
                    [](const Models::Base::Var &v){ return !v.access.template isValid<NeuronVarAccess>(); }))
     {
-        throw std::runtime_error("Weight update models presynaptic variables much have NeuronVarAccess access type");
+        throw std::runtime_error("Weight update models presynaptic variables must have NeuronVarAccess access type");
     }
     if(std::any_of(postVars.cbegin(), postVars.cend(),
                    [](const Models::Base::Var &v){ return !v.access.template isValid<NeuronVarAccess>(); }))
     {
-        throw std::runtime_error("Weight update models postsynaptic variables much have NeuronVarAccess access type");
+        throw std::runtime_error("Weight update models postsynaptic variables must have NeuronVarAccess access type");
     }
 }
 }   // namespace WeightUpdateModels

--- a/src/genn/genn/weightUpdateModels.cc
+++ b/src/genn/genn/weightUpdateModels.cc
@@ -85,23 +85,11 @@ void Base::validate(const std::unordered_map<std::string, double> &paramValues,
     const auto preVars = getPreVars();
     const auto postVars = getPostVars();
     if(std::any_of(vars.cbegin(), vars.cend(),
-                   [](const Models::Base::Var &v)
-                   {
-                       const unsigned int varAccess = v.access.value_or(static_cast<unsigned int>(VarAccess::READ_WRITE)); 
-                       return (varAccess & VarAccessModeAttribute::REDUCE); 
-                   })
+                   [](const Models::Base::Var &v){ return (v.getAccessMode() & VarAccessModeAttribute::REDUCE); })
        || std::any_of(preVars.cbegin(), preVars.cend(),
-                      [](const Models::Base::Var &v)
-                      {
-                          const unsigned int varAccess = v.access.value_or(static_cast<unsigned int>(VarAccess::READ_WRITE)); 
-                          return (varAccess & VarAccessModeAttribute::REDUCE); 
-                      })
+                      [](const Models::Base::Var &v){ return (v.getAccessMode() & VarAccessModeAttribute::REDUCE); })
        || std::any_of(postVars.cbegin(), postVars.cend(),
-                      [](const Models::Base::Var &v)
-                      {
-                          const unsigned int varAccess = v.access.value_or(static_cast<unsigned int>(VarAccess::READ_WRITE)); 
-                          return (varAccess & VarAccessModeAttribute::REDUCE); 
-                      }))
+                      [](const Models::Base::Var &v){ return (v.getAccessMode() & VarAccessModeAttribute::REDUCE); }))
     {
         throw std::runtime_error("Weight update models cannot include variables with REDUCE access modes - they are only supported by custom update models");
     }
@@ -116,8 +104,7 @@ void Base::validate(const std::unordered_map<std::string, double> &paramValues,
     if (std::any_of(vars.cbegin(), vars.cend(),
                     [](const Models::Base::Var &v) 
                     { 
-                        const unsigned int varAccess = v.access.value_or(static_cast<unsigned int>(VarAccess::READ_WRITE)); 
-                        return (varAccess & VarAccessDuplication::SHARED_NEURON); 
+                        return (v.getAccess(VarAccess::READ_WRITE) & VarAccessDuplication::SHARED_NEURON); 
                     }))
     {
         throw std::runtime_error("Weight update models cannot include variables with SHARED_NEURON access modes - they are only supported on pre, postsynaptic or neuron variables");

--- a/tests/features/test_custom_connectivity_update.py
+++ b/tests/features/test_custom_connectivity_update.py
@@ -3,7 +3,7 @@ import pytest
 from pygenn import types
 
 from pygenn import GeNNModel
-from pygenn.genn import VarAccess, VarAccessMode
+from pygenn.genn import SynapseVarAccess, VarAccessMode
 
 from bitarray import bitarray
 from bitarray.util import hex2ba
@@ -26,8 +26,8 @@ neuron_model = create_neuron_model(
 
 weight_update_model = create_weight_update_model(
     "weight_update",
-    var_name_types=[("g", "scalar", VarAccess.READ_ONLY_DUPLICATE),
-                    ("d", "unsigned int", VarAccess.READ_ONLY)])
+    var_name_types=[("g", "scalar", SynapseVarAccess.READ_ONLY_DUPLICATE),
+                    ("d", "unsigned int", SynapseVarAccess.READ_ONLY)])
 
 
 # Snippet to initialise variable to hold its column-major index

--- a/tests/features/test_custom_update.py
+++ b/tests/features/test_custom_update.py
@@ -3,7 +3,8 @@ import pytest
 from pygenn import types
 
 from pygenn import GeNNModel
-from pygenn.genn import VarAccess, VarAccessMode
+from pygenn.genn import (CustomUpdateVarAccess, NeuronVarAccess,
+                         SynapseVarAccess, VarAccessMode)
 
 from scipy.special import softmax
 from pygenn import (create_current_source_model, 
@@ -27,25 +28,30 @@ from pygenn import (create_current_source_model,
 def test_custom_update(backend, precision, batch_size):
     neuron_model = create_neuron_model(
         "neuron",
-        var_name_types=[("X", "scalar", VarAccess.READ_ONLY_DUPLICATE), ("XShared", "scalar", VarAccess.READ_ONLY_SHARED_NEURON)])
+        var_name_types=[("X", "scalar", NeuronVarAccess.READ_ONLY_DUPLICATE), 
+                        ("XShared", "scalar", NeuronVarAccess.READ_ONLY_SHARED_NEURON)])
 
     current_source_model = create_current_source_model(
         "current_source",
-        var_name_types=[("X", "scalar", VarAccess.READ_ONLY_DUPLICATE), ("XShared", "scalar", VarAccess.READ_ONLY_SHARED_NEURON)])
+        var_name_types=[("X", "scalar", NeuronVarAccess.READ_ONLY_DUPLICATE), 
+                        ("XShared", "scalar", NeuronVarAccess.READ_ONLY_SHARED_NEURON)])
 
     weight_update_model = create_weight_update_model(
         "weight_update",
-        var_name_types=[("X", "scalar", VarAccess.READ_ONLY_DUPLICATE)],
-        pre_var_name_types=[("preX", "scalar", VarAccess.READ_ONLY_DUPLICATE), ("preXShared", "scalar", VarAccess.READ_ONLY_SHARED_NEURON)],
-        post_var_name_types=[("postX", "scalar", VarAccess.READ_ONLY_DUPLICATE), ("postXShared", "scalar", VarAccess.READ_ONLY_SHARED_NEURON)])
+        var_name_types=[("X", "scalar", SynapseVarAccess.READ_ONLY_DUPLICATE)],
+        pre_var_name_types=[("preX", "scalar", NeuronVarAccess.READ_ONLY_DUPLICATE), 
+                            ("preXShared", "scalar", NeuronVarAccess.READ_ONLY_SHARED_NEURON)],
+        post_var_name_types=[("postX", "scalar", NeuronVarAccess.READ_ONLY_DUPLICATE), 
+                             ("postXShared", "scalar", NeuronVarAccess.READ_ONLY_SHARED_NEURON)])
 
     postsynaptic_update_model = create_postsynaptic_model(
         "postsynaptic_update",
-        var_name_types=[("psmX", "scalar", VarAccess.READ_ONLY_DUPLICATE), ("psmXShared", "scalar", VarAccess.READ_ONLY_SHARED_NEURON)])
+        var_name_types=[("psmX", "scalar", NeuronVarAccess.READ_ONLY_DUPLICATE), 
+                        ("psmXShared", "scalar", NeuronVarAccess.READ_ONLY_SHARED_NEURON)])
 
     custom_update_model = create_custom_update_model(
         "custom_update",
-        var_name_types=[("X", "scalar", VarAccess.READ_ONLY_DUPLICATE)],
+        var_name_types=[("X", "scalar", CustomUpdateVarAccess.READ_ONLY_DUPLICATE)],
         var_refs=[("R", "scalar")])
 
     set_time_custom_update_model = create_custom_update_model(
@@ -210,7 +216,7 @@ def test_custom_update(backend, precision, batch_size):
 def test_custom_update_transpose(backend, precision, batch_size):
     static_pulse_duplicate_model = create_weight_update_model(
         "static_pulse_duplicate",
-        var_name_types=[("g", "scalar", VarAccess.READ_ONLY_DUPLICATE)],
+        var_name_types=[("g", "scalar", SynapseVarAccess.READ_ONLY_DUPLICATE)],
         sim_code=
         """
         addToPost(g);
@@ -266,7 +272,8 @@ def test_custom_update_transpose(backend, precision, batch_size):
 def test_custom_update_neuron_reduce(backend, precision, batch_size):
     reduction_neuron_model = create_neuron_model(
         "reduction_neuron",
-        var_name_types=[("X", "scalar", VarAccess.READ_ONLY_DUPLICATE), ("Y", "scalar", VarAccess.READ_ONLY_DUPLICATE)])
+        var_name_types=[("X", "scalar", CustomUpdateVarAccess.READ_ONLY_DUPLICATE), 
+                        ("Y", "scalar", CustomUpdateVarAccess.READ_ONLY_DUPLICATE)])
 
     softmax_1_custom_update_model = create_custom_update_model(
         "softmax_1",
@@ -274,7 +281,7 @@ def test_custom_update_neuron_reduce(backend, precision, batch_size):
         """
         MaxX = X;
         """,
-        var_name_types=[("MaxX", "scalar", VarAccess.REDUCE_NEURON_MAX)],
+        var_name_types=[("MaxX", "scalar", CustomUpdateVarAccess.REDUCE_NEURON_MAX)],
         var_refs=[("X", "scalar", VarAccessMode.READ_ONLY)])
 
     softmax_2_custom_update_model = create_custom_update_model(
@@ -283,7 +290,7 @@ def test_custom_update_neuron_reduce(backend, precision, batch_size):
         """
         SumExpX = exp(X - MaxX);
         """,
-        var_name_types=[("SumExpX", "scalar", VarAccess.REDUCE_NEURON_SUM)],
+        var_name_types=[("SumExpX", "scalar", CustomUpdateVarAccess.REDUCE_NEURON_SUM)],
         var_refs=[("X", "scalar", VarAccessMode.READ_ONLY),
                   ("MaxX", "scalar", VarAccessMode.READ_ONLY)])
 
@@ -346,11 +353,13 @@ def test_custom_update_batch_reduction(backend, precision, batch_size):
     # **TODO** once VarAccess is refactored, we should really be able to reduce neuron shared across batch dimension
     neuron_model = create_neuron_model(
         "neuron",
-        var_name_types=[("X", "scalar", VarAccess.READ_ONLY_DUPLICATE), ("SumX", "scalar", VarAccess.READ_ONLY)])
+        var_name_types=[("X", "scalar", NeuronVarAccess.READ_ONLY_DUPLICATE),
+                        ("SumX", "scalar", NeuronVarAccess.READ_ONLY)])
 
     weight_update_model = create_weight_update_model(
         "weight_update",
-        var_name_types=[("X", "scalar", VarAccess.READ_ONLY_DUPLICATE), ("SumX", "scalar", VarAccess.READ_ONLY)])
+        var_name_types=[("X", "scalar", SynapseVarAccess.READ_ONLY_DUPLICATE),
+                        ("SumX", "scalar", SynapseVarAccess.READ_ONLY)])
    
     reduction_custom_update_model = create_custom_update_model(
         "reduction_custom_update",
@@ -359,7 +368,7 @@ def test_custom_update_batch_reduction(backend, precision, batch_size):
         SumX = X;
         MaxX = X;
         """,
-        var_name_types=[("MaxX", "scalar", VarAccess.REDUCE_BATCH_MAX)],
+        var_name_types=[("MaxX", "scalar", CustomUpdateVarAccess.REDUCE_BATCH_MAX)],
         var_refs=[("X", "scalar", VarAccessMode.READ_ONLY),
                   ("SumX", "scalar", VarAccessMode.REDUCE_SUM)])
 

--- a/tests/features/test_custom_update.py
+++ b/tests/features/test_custom_update.py
@@ -51,7 +51,7 @@ def test_custom_update(backend, precision, batch_size):
 
     custom_update_model = create_custom_update_model(
         "custom_update",
-        var_name_types=[("X", "scalar", CustomUpdateVarAccess.READ_ONLY_DUPLICATE)],
+        var_name_types=[("X", "scalar", CustomUpdateVarAccess.READ_ONLY)],
         var_refs=[("R", "scalar")])
 
     set_time_custom_update_model = create_custom_update_model(
@@ -272,8 +272,8 @@ def test_custom_update_transpose(backend, precision, batch_size):
 def test_custom_update_neuron_reduce(backend, precision, batch_size):
     reduction_neuron_model = create_neuron_model(
         "reduction_neuron",
-        var_name_types=[("X", "scalar", CustomUpdateVarAccess.READ_ONLY_DUPLICATE), 
-                        ("Y", "scalar", CustomUpdateVarAccess.READ_ONLY_DUPLICATE)])
+        var_name_types=[("X", "scalar", NeuronVarAccess.READ_ONLY_DUPLICATE), 
+                        ("Y", "scalar", NeuronVarAccess.READ_ONLY_DUPLICATE)])
 
     softmax_1_custom_update_model = create_custom_update_model(
         "softmax_1",

--- a/tests/features/test_spike_propagation.py
+++ b/tests/features/test_spike_propagation.py
@@ -4,7 +4,7 @@ from pygenn import types
 
 from pygenn import GeNNModel
 
-from pygenn.genn import SpanType, VarAccess
+from pygenn.genn import NeuronVarAccess, SpanType, SynapseVarAccess
 from pygenn import (create_neuron_model,
                     create_sparse_connect_init_snippet,
                     create_var_init_snippet,
@@ -511,7 +511,7 @@ def test_reverse(backend, precision):
     pre_reverse_spike_source_model = create_neuron_model(
         "pre_reverse_spike_source",
         var_name_types=[("startSpike", "unsigned int"), 
-                        ("endSpike", "unsigned int", VarAccess.READ_ONLY_DUPLICATE),
+                        ("endSpike", "unsigned int", NeuronVarAccess.READ_ONLY_DUPLICATE),
                         ("x", "scalar")],
         extra_global_params=[("spikeTimes", "scalar*")],
         sim_code=
@@ -533,7 +533,7 @@ def test_reverse(backend, precision):
         """
         $(addToPre, $(g));
         """,
-        var_name_types=[("g", "scalar", VarAccess.READ_ONLY)])
+        var_name_types=[("g", "scalar", SynapseVarAccess.READ_ONLY)])
 
     model = GeNNModel(precision, "test_reverse", backend=backend)
     model.dt = 1.0
@@ -617,7 +617,7 @@ def test_reverse_post(backend, precision):
         """
         $(addToPre, $(g));
         """,
-        var_name_types=[("g", "scalar", VarAccess.READ_ONLY)])
+        var_name_types=[("g", "scalar", SynapseVarAccess.READ_ONLY)])
 
     model = GeNNModel(precision, "test_reverse_post", backend=backend)
     model.dt = 1.0

--- a/tests/features/test_spike_times.py
+++ b/tests/features/test_spike_times.py
@@ -4,7 +4,6 @@ from pygenn import types
 
 from pygenn import GeNNModel
 
-from pygenn.genn import SpanType, VarAccess
 from pygenn import (create_neuron_model,
                     create_sparse_connect_init_snippet,
                     create_var_init_snippet,

--- a/tests/features/test_wu_vars.py
+++ b/tests/features/test_wu_vars.py
@@ -5,7 +5,7 @@ from scipy import stats
 
 from pygenn import GeNNModel
 
-from pygenn.genn import VarAccess
+from pygenn.genn import NeuronVarAccess
 from pygenn import (create_neuron_model,
                     create_weight_update_model,
                     init_sparse_connectivity, init_var)
@@ -220,7 +220,7 @@ def test_wu_var_cont(backend, precision, fuse, delay):
     pre_learn_post_weight_update_model = create_weight_update_model(
         "pre_learn_post_weight_update",
         var_name_types=[("w", "scalar")],
-        pre_var_name_types=[("s", "scalar"), ("shift", "scalar", VarAccess.READ_ONLY)],
+        pre_var_name_types=[("s", "scalar"), ("shift", "scalar", NeuronVarAccess.READ_ONLY)],
         
         learn_post_code=
         """
@@ -234,7 +234,7 @@ def test_wu_var_cont(backend, precision, fuse, delay):
     pre_sim_weight_update_model = create_weight_update_model(
         "pre_sim_weight_update",
         var_name_types=[("w", "scalar")],
-        pre_var_name_types=[("s", "scalar"), ("shift", "scalar", VarAccess.READ_ONLY)],
+        pre_var_name_types=[("s", "scalar"), ("shift", "scalar", NeuronVarAccess.READ_ONLY)],
         
         sim_code=
         """
@@ -251,7 +251,7 @@ def test_wu_var_cont(backend, precision, fuse, delay):
     post_learn_post_weight_update_model = create_weight_update_model(
         "post_learn_post_weight_update",
         var_name_types=[("w", "scalar")],
-        post_var_name_types=[("s", "scalar"), ("shift", "scalar", VarAccess.READ_ONLY)],
+        post_var_name_types=[("s", "scalar"), ("shift", "scalar", NeuronVarAccess.READ_ONLY)],
         
         learn_post_code=
         """
@@ -265,7 +265,7 @@ def test_wu_var_cont(backend, precision, fuse, delay):
     post_sim_weight_update_model = create_weight_update_model(
         "post_sim_weight_update",
         var_name_types=[("w", "scalar")],
-        post_var_name_types=[("s", "scalar"), ("shift", "scalar", VarAccess.READ_ONLY)],
+        post_var_name_types=[("s", "scalar"), ("shift", "scalar", NeuronVarAccess.READ_ONLY)],
         
         sim_code=
         """

--- a/tests/unit/customConnectivityUpdate.cc
+++ b/tests/unit/customConnectivityUpdate.cc
@@ -19,7 +19,7 @@ class StaticPulseDendriticDelayReverse : public WeightUpdateModels::Base
 public:
     DECLARE_SNIPPET(StaticPulseDendriticDelayReverse);
 
-    SET_VARS({{"d", "uint8_t", VarAccess::READ_ONLY}, {"g", "scalar", VarAccess::READ_ONLY}});
+    SET_VARS({{"d", "uint8_t", SynapseVarAccess::READ_ONLY}, {"g", "scalar", SynapseVarAccess::READ_ONLY}});
 
     SET_SIM_CODE("addToPostDelay(g, d);\n");
 };

--- a/tests/unit/customUpdate.cc
+++ b/tests/unit/customUpdate.cc
@@ -489,7 +489,7 @@ TEST(CustomUpdates, BatchingVars)
     VarValues izkVarVals{{"V", 0.0}, {"U", 0.0}, {"a", 0.02}, {"b", 0.2}, {"c", -65.0}, {"d", 8.0}};
     auto *pop = model.addNeuronPopulation<NeuronModels::IzhikevichVariable>("Pop", 10, {}, izkVarVals);
 
-    // Create updates where variable is shared and references vary
+    // Create updates where variable has same dimensionality as references but dimensionality varies
     VarValues sumVarValues{{"sum", 1.0}};
     VarReferences sumVarReferences1{{"a", createVarRef(pop, "V")}, {"b", createVarRef(pop, "U")}};
     VarReferences sumVarReferences2{{"a", createVarRef(pop, "a")}, {"b", createVarRef(pop, "b")}};

--- a/tests/unit/customUpdate.cc
+++ b/tests/unit/customUpdate.cc
@@ -465,7 +465,7 @@ TEST(CustomUpdates, WUVarSynapseGroupChecks)
 
     VarValues sumVarValues{{"sum", 0.0}};
     WUVarReferences sumVarReferences1{{"a", createWUVarRef(sg1, "g")}, {"b", createWUVarRef(sg1, "g")}};
-    WUVarReferences sumVarReferences2{{"a", createWUVarRef(sg1, "g")}, {"b", createWUVarRef(sg2, "d")}};
+    WUVarReferences sumVarReferences2{{"a", createWUVarRef(sg1, "g")}, {"b", createWUVarRef(sg2, "g")}};
     model.addCustomUpdate<Sum>("SumWeight1", "CustomUpdate",
                                {}, sumVarValues, sumVarReferences1);
 
@@ -547,7 +547,7 @@ TEST(CustomUpdates, BatchingWriteShared)
     VarValues izkVarVals{{"V", 0.0}, {"U", 0.0}, {"a", 0.02}, {"b", 0.2}, {"c", -65.0}, {"d", 8.0}};
     auto *pop = model.addNeuronPopulation<NeuronModels::IzhikevichVariable>("Pop", 10, {}, izkVarVals);
     
-    // Create custom update which tries to create a read-write refernece to a (which isn't batched)
+    // Create custom update which tries to create a read-write reference to a (which isn't batched)
     VarReferences reduceVarReferences{{"var", createVarRef(pop, "V")}, {"reduction", createVarRef(pop, "U")}};
     try {
         model.addCustomUpdate<Reduce>("Sum1", "CustomUpdate",
@@ -570,9 +570,10 @@ TEST(CustomUpdates, WriteNeuronShared)
     // Create custom update which tries to create a read-write reference to a (which isn't per-neuron)
     VarValues sum2VarValues{{"mult", 1.0}};
     VarReferences sum2VarReferences{{"a", createVarRef(pop, "a")}, {"b", createVarRef(pop, "V")}};
+    model.addCustomUpdate<Sum2>("Sum1", "CustomUpdate",
+                                {}, sum2VarValues, sum2VarReferences);
     try {
-        model.addCustomUpdate<Sum2>("Sum1", "CustomUpdate",
-                                    {}, sum2VarValues, sum2VarReferences);
+        model.finalise();
         FAIL();
     }
     catch(const std::runtime_error &) {

--- a/tests/unit/customUpdate.cc
+++ b/tests/unit/customUpdate.cc
@@ -24,8 +24,8 @@ public:
 
     SET_PARAM_NAMES({});
     SET_VARS({{"V","scalar"}, {"U", "scalar"},
-              {"a", "scalar", VarAccess::READ_ONLY_SHARED_NEURON}, {"b", "scalar", VarAccess::READ_ONLY_SHARED_NEURON},
-              {"c", "scalar", VarAccess::READ_ONLY_SHARED_NEURON}, {"d", "scalar", VarAccess::READ_ONLY_SHARED_NEURON}});
+              {"a", "scalar", NeuronVarAccess::READ_ONLY_SHARED_NEURON}, {"b", "scalar", NeuronVarAccess::READ_ONLY_SHARED_NEURON},
+              {"c", "scalar", NeuronVarAccess::READ_ONLY_SHARED_NEURON}, {"d", "scalar", NeuronVarAccess::READ_ONLY_SHARED_NEURON}});
 };
 IMPLEMENT_SNIPPET(IzhikevichVariableShared);
 
@@ -34,10 +34,10 @@ class StaticPulseDendriticDelaySplit : public WeightUpdateModels::Base
 public:
     DECLARE_SNIPPET(StaticPulseDendriticDelaySplit);
 
-    SET_VARS({{"gCommon", "scalar", VarAccess::READ_ONLY}, 
-              {"g", "scalar", VarAccess::READ_ONLY_DUPLICATE}, 
-              {"dCommon", "scalar", VarAccess::READ_ONLY},
-              {"d", "scalar", VarAccess::READ_ONLY_DUPLICATE}});
+    SET_VARS({{"gCommon", "scalar", SynapseVarAccess::READ_ONLY}, 
+              {"g", "scalar", SynapseVarAccess::READ_ONLY_DUPLICATE}, 
+              {"dCommon", "scalar", SynapseVarAccess::READ_ONLY},
+              {"d", "scalar", SynapseVarAccess::READ_ONLY_DUPLICATE}});
 
     SET_SIM_CODE("$(addToInSynDelay, $(gCommon) + $(g), $(dCommon) + $(d));\n");
 };
@@ -61,7 +61,7 @@ class Sum2 : public CustomUpdateModels::Base
 
     SET_UPDATE_CODE("$(a) = $(mult) * ($(a) + $(b));\n");
 
-    SET_VARS({{"mult", "scalar", VarAccess::READ_ONLY}});
+    SET_VARS({{"mult", "scalar", CustomUpdateVarAccess::READ_ONLY}});
     SET_VAR_REFS({{"a", "scalar", VarAccessMode::READ_WRITE}, 
                   {"b", "scalar", VarAccessMode::READ_ONLY}});
 };
@@ -73,7 +73,7 @@ class Sum3 : public CustomUpdateModels::Base
 
     SET_UPDATE_CODE("$(sum) = $(scale) * ($(a) + $(b));\n");
 
-    SET_VARS({{"sum", "scalar"}, {"scale", "scalar", VarAccess::READ_ONLY_SHARED_NEURON}});
+    SET_VARS({{"sum", "scalar"}, {"scale", "scalar", CustomUpdateVarAccess::READ_ONLY_SHARED_NEURON}});
     SET_VAR_REFS({{"a", "scalar", VarAccessMode::READ_WRITE},
                   {"b", "scalar", VarAccessMode::READ_ONLY}});
 };
@@ -169,8 +169,8 @@ class ReduceDouble : public CustomUpdateModels::Base
         "reduction1 = var1;\n"
         "reduction2 = var2;\n");
 
-    SET_VARS({{"reduction1", "scalar", VarAccess::REDUCE_BATCH_SUM},
-              {"reduction2", "scalar", VarAccess::REDUCE_NEURON_SUM}});
+    SET_VARS({{"reduction1", "scalar", CustomUpdateVarAccess::REDUCE_BATCH_SUM},
+              {"reduction2", "scalar", CustomUpdateVarAccess::REDUCE_NEURON_SUM}});
 
     SET_VAR_REFS({{"var1", "scalar", VarAccessMode::READ_ONLY},
                   {"var2", "scalar", VarAccessMode::READ_ONLY}});
@@ -183,7 +183,7 @@ class ReduceSharedVar : public CustomUpdateModels::Base
 
     SET_UPDATE_CODE("reduction = var;\n");
 
-    SET_VARS({{"reduction", "scalar", VarAccess::REDUCE_BATCH_SUM}})
+    SET_VARS({{"reduction", "scalar", CustomUpdateVarAccess::REDUCE_BATCH_SUM}})
     SET_VAR_REFS({{"var", "scalar", VarAccessMode::READ_ONLY}});
 };
 IMPLEMENT_SNIPPET(ReduceSharedVar);
@@ -195,7 +195,7 @@ class ReduceNeuronSharedVar : public CustomUpdateModels::Base
 
     SET_UPDATE_CODE("reduction = var;\n");
 
-    SET_VARS({{"reduction", "scalar", VarAccess::REDUCE_NEURON_SUM}})
+    SET_VARS({{"reduction", "scalar", CustomUpdateVarAccess::REDUCE_NEURON_SUM}})
     SET_VAR_REFS({{"var", "scalar", VarAccessMode::READ_ONLY}});
 };
 IMPLEMENT_SNIPPET(ReduceNeuronSharedVar);
@@ -509,14 +509,14 @@ TEST(CustomUpdates, BatchingVars)
     
     model.finalise();
 
-    EXPECT_TRUE(static_cast<CustomUpdateInternal*>(sum1)->isBatched());
-    EXPECT_TRUE(static_cast<CustomUpdateInternal*>(sum1)->isPerNeuron());
-    EXPECT_FALSE(static_cast<CustomUpdateInternal*>(sum2)->isBatched());
-    EXPECT_TRUE(static_cast<CustomUpdateInternal*>(sum2)->isPerNeuron());
-    EXPECT_TRUE(static_cast<CustomUpdateInternal*>(sum3)->isBatched());
-    EXPECT_TRUE(static_cast<CustomUpdateInternal*>(sum3)->isPerNeuron());
-    EXPECT_FALSE(static_cast<CustomUpdateInternal*>(sum4)->isBatched());
-    EXPECT_TRUE(static_cast<CustomUpdateInternal*>(sum4)->isPerNeuron());
+    EXPECT_TRUE(static_cast<CustomUpdateInternal*>(sum1)->getDims() & VarAccessDim::BATCH);
+    EXPECT_TRUE(static_cast<CustomUpdateInternal*>(sum1)->getDims() & VarAccessDim::NEURON);
+    EXPECT_FALSE(static_cast<CustomUpdateInternal*>(sum2)->getDims() & VarAccessDim::BATCH);
+    EXPECT_TRUE(static_cast<CustomUpdateInternal*>(sum2)->getDims() & VarAccessDim::NEURON);
+    EXPECT_TRUE(static_cast<CustomUpdateInternal*>(sum3)->getDims() & VarAccessDim::BATCH);
+    EXPECT_TRUE(static_cast<CustomUpdateInternal*>(sum3)->getDims() & VarAccessDim::NEURON);
+    EXPECT_FALSE(static_cast<CustomUpdateInternal*>(sum4)->getDims() & VarAccessDim::BATCH);
+    EXPECT_TRUE(static_cast<CustomUpdateInternal*>(sum4)->getDims() & VarAccessDim::NEURON);
 }
 //--------------------------------------------------------------------------
 TEST(CustomUpdates, NeuronSharedVars)
@@ -534,8 +534,8 @@ TEST(CustomUpdates, NeuronSharedVars)
     model.finalise();
 
     auto *cuInternal = static_cast<CustomUpdateInternal *>(cu);
-    EXPECT_TRUE(cuInternal->isBatched());
-    EXPECT_FALSE(cuInternal->isPerNeuron());
+    EXPECT_TRUE(cuInternal->getDims() & VarAccessDim::BATCH);
+    EXPECT_FALSE(cuInternal->getDims() & VarAccessDim::NEURON);
 }
 //--------------------------------------------------------------------------
 TEST(CustomUpdates, BatchingWriteShared)
@@ -617,10 +617,10 @@ TEST(CustomUpdates, ReductionTypeDuplicateNeuron)
                                              {}, {}, reduceVarReferences);
     model.finalise();
     auto *cuInternal = static_cast<CustomUpdateInternal *>(cu);
-    ASSERT_TRUE(cuInternal->isBatched());
+    ASSERT_TRUE(cuInternal->getDims() & VarAccessDim::BATCH);
     ASSERT_FALSE(cuInternal->isBatchReduction());
     ASSERT_TRUE(cuInternal->isNeuronReduction());
-    ASSERT_TRUE(cuInternal->isPerNeuron());
+    ASSERT_TRUE(cuInternal->getDims() & VarAccessDim::NEURON);
 }
 //--------------------------------------------------------------------------
 TEST(CustomUpdates, ReductionTypeDuplicateNeuronInternal)
@@ -640,10 +640,10 @@ TEST(CustomUpdates, ReductionTypeDuplicateNeuronInternal)
                                                             {}, reduceVars, reduceVarReferences);
     model.finalise();
     auto *cuInternal = static_cast<CustomUpdateInternal *>(cu);
-    ASSERT_TRUE(cuInternal->isBatched());
+    ASSERT_TRUE(cuInternal->getDims() & VarAccessDim::BATCH);
     ASSERT_FALSE(cuInternal->isBatchReduction());
     ASSERT_TRUE(cuInternal->isNeuronReduction());
-    ASSERT_TRUE(cuInternal->isPerNeuron());
+    ASSERT_TRUE(cuInternal->getDims() & VarAccessDim::NEURON);
 }
 //--------------------------------------------------------------------------
 TEST(CustomUpdates, ReductionTypeSharedNeuronInternal)
@@ -663,10 +663,10 @@ TEST(CustomUpdates, ReductionTypeSharedNeuronInternal)
                                                             {}, reduceVars, reduceVarReferences);
     model.finalise();
     auto *cuInternal = static_cast<CustomUpdateInternal *>(cu);
-    ASSERT_FALSE(cuInternal->isBatched());
+    ASSERT_FALSE(cuInternal->getDims() & VarAccessDim::BATCH);
     ASSERT_FALSE(cuInternal->isBatchReduction());
     ASSERT_TRUE(cuInternal->isNeuronReduction());
-    ASSERT_TRUE(cuInternal->isPerNeuron());
+    ASSERT_TRUE(cuInternal->getDims() & VarAccessDim::NEURON);
 }
 //--------------------------------------------------------------------------
 TEST(CustomUpdates, ReductionTypeDuplicateBatch)
@@ -685,10 +685,10 @@ TEST(CustomUpdates, ReductionTypeDuplicateBatch)
                                              {}, {}, reduceVarReferences);
     model.finalise();
     auto *cuInternal = static_cast<CustomUpdateInternal *>(cu);
-    ASSERT_TRUE(cuInternal->isBatched());
+    ASSERT_TRUE(cuInternal->getDims() & VarAccessDim::BATCH);
     ASSERT_TRUE(cuInternal->isBatchReduction());
     ASSERT_FALSE(cuInternal->isNeuronReduction());
-    ASSERT_TRUE(cuInternal->isPerNeuron());
+    ASSERT_TRUE(cuInternal->getDims() & VarAccessDim::NEURON);
 }
 //--------------------------------------------------------------------------
 TEST(CustomUpdates, ReductionTypeDuplicateBatchInternal)
@@ -708,10 +708,10 @@ TEST(CustomUpdates, ReductionTypeDuplicateBatchInternal)
                                                       {}, reduceVars, reduceVarReferences);
     model.finalise();
     auto *cuInternal = static_cast<CustomUpdateInternal *>(cu);
-    ASSERT_TRUE(cuInternal->isBatched());
+    ASSERT_TRUE(cuInternal->getDims() & VarAccessDim::BATCH);
     ASSERT_TRUE(cuInternal->isBatchReduction());
     ASSERT_FALSE(cuInternal->isNeuronReduction());
-    ASSERT_TRUE(cuInternal->isPerNeuron());
+    ASSERT_TRUE(cuInternal->getDims() & VarAccessDim::NEURON);
 }
 //--------------------------------------------------------------------------
 TEST(CustomUpdates, NeuronSharedCustomUpdateWU)
@@ -949,9 +949,9 @@ TEST(CustomUpdates, CompareDifferentBatched)
     CustomUpdateInternal *sum1Internal = static_cast<CustomUpdateInternal*>(sum1);
     CustomUpdateInternal *sum2Internal = static_cast<CustomUpdateInternal*>(sum2);
     CustomUpdateInternal *sum3Internal = static_cast<CustomUpdateInternal*>(sum3);
-    ASSERT_TRUE(sum1Internal->isBatched());
-    ASSERT_FALSE(sum2Internal->isBatched());
-    ASSERT_TRUE(sum3Internal->isBatched());
+    ASSERT_TRUE(sum1Internal->getDims() & VarAccessDim::BATCH);
+    ASSERT_FALSE(sum2Internal->getDims() & VarAccessDim::BATCH);
+    ASSERT_TRUE(sum3Internal->getDims() & VarAccessDim::BATCH);
 
     // Check that neither initialisation nor update of batched and unbatched can be merged
     ASSERT_NE(sum1Internal->getHashDigest(), sum2Internal->getHashDigest());
@@ -1099,9 +1099,9 @@ TEST(CustomUpdates, CompareDifferentWUBatched)
     CustomUpdateWUInternal *sum1Internal = static_cast<CustomUpdateWUInternal*>(sum1);
     CustomUpdateWUInternal *sum2Internal = static_cast<CustomUpdateWUInternal*>(sum2);
     CustomUpdateWUInternal *sum3Internal = static_cast<CustomUpdateWUInternal*>(sum3);
-    ASSERT_TRUE(sum1Internal->isBatched());
-    ASSERT_FALSE(sum2Internal->isBatched());
-    ASSERT_TRUE(sum3Internal->isBatched());
+    ASSERT_TRUE(sum1Internal->getDims() & VarAccessDim::BATCH);
+    ASSERT_FALSE(sum2Internal->getDims() & VarAccessDim::BATCH);
+    ASSERT_TRUE(sum3Internal->getDims() & VarAccessDim::BATCH);
 
     // Check that neither initialisation nor update of batched and unbatched can be merged
     ASSERT_NE(sum1Internal->getHashDigest(), sum2Internal->getHashDigest());

--- a/tests/unit/neuronGroup.cc
+++ b/tests/unit/neuronGroup.cc
@@ -19,7 +19,7 @@ class StaticPulseBack : public WeightUpdateModels::Base
 public:
     DECLARE_SNIPPET(StaticPulseBack);
 
-    SET_VARS({{"g", "scalar", VarAccess::READ_ONLY}});
+    SET_VARS({{"g", "scalar", SynapseVarAccess::READ_ONLY}});
 
     SET_SIM_CODE(
         "$(addToInSyn, $(g));\n"

--- a/tests/unit/typeChecker.cc
+++ b/tests/unit/typeChecker.cc
@@ -109,7 +109,7 @@ public:
         throw TypeChecker::TypeCheckError();
     }
 
-    virtual std::vector<Type::ResolvedType> getTypes(const Token &name, ErrorHandlerBase &errorHandler) final
+    virtual std::vector<Type::ResolvedType> getTypes(const Token &name, ErrorHandlerBase&) final
     {
         const auto [typeBegin, typeEnd] = m_Library.get().equal_range(name.lexeme);
         if (typeBegin == typeEnd) {


### PR DESCRIPTION
One of the ways in which I want to simplify GeNN syntax (and reduce internal boilerplate) is by getting rid of the separate lists of different types of variable in models (e.g. presynaptic, postsynaptic and synaptic in weight update models). We were already lumbering towards the solution to this with ``VarAccessDuplication::SHARED_NEURON`` which was primarily used as the target for per-neuron reductions but this was a bit weird in that it was an error to use it in a lot of places. This change replaces the duplication enumeration with the ``VarAccessDim`` bitfield enumeration so e.g. a 'normal' neuron variable is now ``VarAccessDim::NEURON | VarAccessDim::BATCH`` and a standard synapse variable is ``VarAccessDim::PRE_NEURON | VarAccessDim::POST_NEURON |VarAccessDim::BATCH``. However, specifying these at this level is really annoying and lots of permutations aren't valid in various locations. This PR adds ``NeuronVarAccess``, ``SynapseVarAccess`` and ``CustomUpdateVarAccess`` enumerations which provide valid combinations of ``VarAccessMode`` and ``VarAccessDim`` in each context. One option would have been to replace the single ``Models::Base::Var`` class with neuron, synapse and custom update ones


This PR doesn't really change anything outwardly (aside from that you now use ``NeuronVarAccess``, ``SynapseVarAccess`` and ``CustomUpdateVarAccess`` rather than plain ``VarAccess`` but it's a building 

Custom updates were where the old system really broke down as we want custom updates:
- To be reusable on per-neuron and per-synapse variables
- To be agnostic to whether things are batched or not

(both of these properties break down a bit in more complex situations but apply in the simplest case of e.g. an adam optimiser). If you start saying what dimensions all the variables have this becomes impossible so, instead, custom update variables dimensions are declared _subtractively_ so you start by ORing together the dimensions of all the variables your custom update is referencing and then determine what shape each variable should be 