### PR TITLE
Step 7 - Single PSM code string

### DIFF
--- a/pygenn/genn_model.py
+++ b/pygenn/genn_model.py
@@ -1020,8 +1020,8 @@ def create_neuron_model(class_name, params=None, param_names=None,
 
 def create_postsynaptic_model(class_name, params=None, param_names=None,
                               var_name_types=None, neuron_var_refs=None,
-                              derived_params=None, decay_code=None,
-                              apply_input_code=None, 
+                              derived_params=None, sim_code=None, 
+                              decay_code=None, apply_input_code=None, 
                               extra_global_params=None):
     """This helper function creates a custom PostsynapticModel class.
     See also:
@@ -1042,21 +1042,21 @@ def create_postsynaptic_model(class_name, params=None, param_names=None,
     derived_params      --  list of pairs, where the first member is string
                             with name of the derived parameter and the second
                             should be a functor returned by create_dpf_class
+    sim_code            --  string with the decay code
     decay_code          --  string with the decay code
     apply_input_code    --  string with the apply input code
     extra_global_params --  list of pairs of strings with names and
                             types of additional parameters
     """
     body = {}
-
-    if decay_code is not None:
-        body["get_decay_code"] =\
-            lambda self: dedent(upgrade_code_string(decay_code, class_name))
-
-    if apply_input_code is not None:
-        body["get_apply_input_code"] =\
-            lambda self: dedent(upgrade_code_string(apply_input_code,
-                                                    class_name))
+    if decay_code is not None or apply_input_code is not None:
+        raise RuntimeError("Creating postsynaptic models with seperate "
+                           "'decay_code' and 'apply_code' code strings is no "
+                           "longer supported. Please provide 'sim_code' using "
+                           "the injectCurrent(X) function to provide input.")
+    if sim_code is not None:
+        body["get_sim_code"] =\
+            lambda self: dedent(upgrade_code_string(sim_code, class_name))
 
     if var_name_types is not None:
         body["get_vars"] = \

--- a/pygenn/src/genn.cc
+++ b/pygenn/src/genn.cc
@@ -173,8 +173,7 @@ public:
     virtual std::vector<Models::Base::Var> getVars() const override{ PYBIND11_OVERRIDE_NAME(std::vector<Models::Base::Var>, Base, "get_vars", getVars); }
     virtual VarRefVec getNeuronVarRefs() const override { PYBIND11_OVERRIDE_NAME(VarRefVec, Base, "get_neuron_var_refs", getNeuronVarRefs); }
     
-    virtual std::string getDecayCode() const override { PYBIND11_OVERRIDE_NAME(std::string, Base, "get_decay_code", getDecayCode); }
-    virtual std::string getApplyInputCode() const override { PYBIND11_OVERRIDE_NAME(std::string, Base, "get_apply_input_code", getApplyInputCode); }
+    virtual std::string getSimCode() const override { PYBIND11_OVERRIDE_NAME(std::string, Base, "get_sim_code", getSimCode); }
 };
 
 //----------------------------------------------------------------------------
@@ -846,7 +845,7 @@ PYBIND11_MODULE(genn, m)
         .def("get_additional_input_vars", &NeuronModels::Base::getAdditionalInputVars)
         
         .def("is_auto_refractory_required", &NeuronModels::Base::isAutoRefractoryRequired);
-        
+
     //------------------------------------------------------------------------
     // genn.PostsynapticModelBase
     //------------------------------------------------------------------------
@@ -856,9 +855,8 @@ PYBIND11_MODULE(genn, m)
         .def("get_vars", &PostsynapticModels::Base::getVars)
         .def("get_neuron_var_refs", &PostsynapticModels::Base::getNeuronVarRefs)
         
-        .def("get_decay_code", &PostsynapticModels::Base::getDecayCode)
-        .def("get_apply_input_code", &PostsynapticModels::Base::getApplyInputCode);
-    
+        .def("get_sim_code", &PostsynapticModels::Base::getSimCode);
+
     //------------------------------------------------------------------------
     // genn.WeightUpdateModelBase
     //------------------------------------------------------------------------

--- a/src/genn/genn/neuronGroup.cc
+++ b/src/genn/genn/neuronGroup.cc
@@ -336,8 +336,7 @@ bool NeuronGroup::isSimRNGRequired() const
     return std::any_of(getInSyn().cbegin(), getInSyn().cend(),
                        [](const SynapseGroupInternal *sg)
                        {
-                           return (Utils::isRNGRequired(sg->getPSInitialiser().getApplyInputCodeTokens()) ||
-                                   Utils::isRNGRequired(sg->getPSInitialiser().getDecayCodeTokens()));
+                           return Utils::isRNGRequired(sg->getPSInitialiser().getSimCodeTokens());
                        });
 }
 //----------------------------------------------------------------------------

--- a/src/genn/genn/postsynapticModels.cc
+++ b/src/genn/genn/postsynapticModels.cc
@@ -22,8 +22,7 @@ boost::uuids::detail::sha1::digest_type Base::getHashDigest() const
     Snippet::Base::updateHash(hash);
     Utils::updateHash(getVars(), hash);
     Utils::updateHash(getNeuronVarRefs(), hash);
-    Utils::updateHash(getDecayCode(), hash);
-    Utils::updateHash(getApplyInputCode(), hash);
+    Utils::updateHash(getSimCode(), hash);
     return hash.get_digest();
 }
 //----------------------------------------------------------------------------
@@ -60,13 +59,12 @@ Init::Init(const Base *snippet, const std::unordered_map<std::string, Type::Nume
     Models::checkVarReferenceTypes(getNeuronVarReferences(), getSnippet()->getNeuronVarRefs());
 
     // Scan code tokens
-    m_DecayCodeTokens = Utils::scanCode(getSnippet()->getDecayCode(), "Postsynaptic model decay code");
-    m_ApplyInputCodeTokens = Utils::scanCode(getSnippet()->getApplyInputCode(), "Postsynaptic model apply input code");
+    m_SimCodeTokens = Utils::scanCode(getSnippet()->getSimCode(), "Postsynaptic model sim code");
 }
 //----------------------------------------------------------------------------
 bool Init::isRNGRequired() const
 {
-    return (Utils::isRNGRequired(m_DecayCodeTokens) || Utils::isRNGRequired(m_ApplyInputCodeTokens));
+    return Utils::isRNGRequired(m_SimCodeTokens);
 }
 //----------------------------------------------------------------------------
 bool Init::isVarInitRequired() const

--- a/src/genn/genn/synapseGroup.cc
+++ b/src/genn/genn/synapseGroup.cc
@@ -575,13 +575,8 @@ bool SynapseGroup::canPSBeFused(const NeuronGroup *ng) const
     // **NOTE** this is kind of silly as, if it's not referenced in either of 
     // these code strings, there wouldn't be a lot of point in a PSM EGP existing!
     for(const auto &egp : getPSInitialiser().getSnippet()->getExtraGlobalParams()) {
-        // If this EGP is referenced in decay code, return false
-        if(Utils::isIdentifierReferenced(egp.name, getPSInitialiser().getDecayCodeTokens())) {
-            return false;
-        }
-        
-        // If this EGP is referenced in apply input code, return false
-        if(Utils::isIdentifierReferenced(egp.name, getPSInitialiser().getApplyInputCodeTokens())) {
+        // If this EGP is referenced in sim code, return false
+        if(Utils::isIdentifierReferenced(egp.name, getPSInitialiser().getSimCodeTokens())) {
             return false;
         }
     }
@@ -590,13 +585,8 @@ bool SynapseGroup::canPSBeFused(const NeuronGroup *ng) const
     for(const auto &p : getPSInitialiser().getSnippet()->getParams()) {
         // If parameter is dynamic
         if(isPSParamDynamic(p.name)) {
-            // If this parameter is referenced in decay code, return false
-            if(Utils::isIdentifierReferenced(p.name, getPSInitialiser().getDecayCodeTokens())) {
-                return false;
-            }
-        
-            // If this parameter is referenced in apply input code, return false
-            if(Utils::isIdentifierReferenced(p.name, getPSInitialiser().getApplyInputCodeTokens())) {
+            // If this parameter is referenced in sim code, return false
+            if(Utils::isIdentifierReferenced(p.name, getPSInitialiser().getSimCodeTokens())) {
                 return false;
             }
         }

--- a/tests/features/test_dynamic_param.py
+++ b/tests/features/test_dynamic_param.py
@@ -28,14 +28,11 @@ def test_dynamic_param(make_model, backend, precision):
     
     postsynaptic_model = create_postsynaptic_model(
         "postsynaptic",
-        decay_code=
+        sim_code=
         """
+        injectCurrent(inSyn);
         psmX = t + psmShift + psmInput;
         $(inSyn) = 0;
-        """,
-        apply_input_code=
-        """
-        $(Isyn) += $(inSyn);
         """,
         params=["psmInput"],
         var_name_types=[("psmX", "scalar"), ("psmShift", "scalar")])

--- a/tests/unit/modelSpec.cc
+++ b/tests/unit/modelSpec.cc
@@ -16,11 +16,10 @@ class AlphaCurr : public PostsynapticModels::Base
 public:
     DECLARE_SNIPPET(AlphaCurr);
 
-    SET_DECAY_CODE(
-        "x = (DT * expDecay * inSyn * init) + (expDecay * x);\n"
-        "inSyn*=expDecay;\n");
-
-    SET_CURRENT_CONVERTER_CODE("x");
+    SET_SIM_CODE(
+        "injectCurrent(x);\n"
+        "x = (dt * expDecay * inSyn * init) + (expDecay * x);\n"
+        "inSyn *= expDecay;\n");
 
     SET_PARAMS({"tau"});
 

--- a/tests/unit/modelSpecMerged.cc
+++ b/tests/unit/modelSpecMerged.cc
@@ -24,11 +24,10 @@ class AlphaCurr : public PostsynapticModels::Base
 public:
     DECLARE_SNIPPET(AlphaCurr);
 
-    SET_DECAY_CODE(
+     SET_SIM_CODE(
+        "injectCurrent(x);\n"
         "x = (dt * expDecay * inSyn * init) + (expDecay * x);\n"
         "inSyn *= expDecay;\n");
-
-    SET_CURRENT_CONVERTER_CODE("x");
 
     SET_PARAMS({"tau"});
 

--- a/tests/unit/models.cc
+++ b/tests/unit/models.cc
@@ -16,11 +16,10 @@ class AlphaCurr : public PostsynapticModels::Base
 public:
     DECLARE_SNIPPET(AlphaCurr);
 
-    SET_DECAY_CODE(
+    SET_SIM_CODE(
+        "injectCurrent(x);\n"
         "x = (dt * expDecay * inSyn * init) + (expDecay * x);\n"
         "inSyn *= expDecay;\n");
-
-    SET_CURRENT_CONVERTER_CODE("x");
 
     SET_PARAMS({"tau"});
 

--- a/tests/unit/neuronGroup.cc
+++ b/tests/unit/neuronGroup.cc
@@ -88,11 +88,10 @@ class AlphaCurr : public PostsynapticModels::Base
 public:
     DECLARE_SNIPPET(AlphaCurr);
 
-    SET_DECAY_CODE(
+    SET_SIM_CODE(
+        "injectCurrent(x);\n"
         "x = (dt * expDecay * inSyn * init) + (expDecay * x);\n"
-        "inSyn*=expDecay;\n");
-
-    SET_CURRENT_CONVERTER_CODE("x");
+        "inSyn *= expDecay;\n");
 
     SET_PARAMS({"tau"});
 

--- a/tests/unit/postsynapticModels.cc
+++ b/tests/unit/postsynapticModels.cc
@@ -13,9 +13,9 @@ using namespace GeNN;
 class ExpCurrCopy : public PostsynapticModels::Base
 {
 public:
-    SET_DECAY_CODE("inSyn *= expDecay;");
-
-    SET_CURRENT_CONVERTER_CODE("init * inSyn");
+    SET_SIM_CODE(
+        "injectCurrent(init * inSyn);\n"
+        "inSyn *= expDecay;\n");
 
     SET_PARAMS({"tau"});
 


### PR DESCRIPTION
This is the last syntax change I want to make. Previously, postsynaptic models had two code strings "decay code" and "apply input code" (the latter of which could also be configured via "custom converter code" in C++ for backward compatibility). This separation doesn't really make any sense and it's not obvious (if you'd asked me before I made this change, I couldn't tell you) what order they're run in. With this change:

```python
exp_curr_model = create_postsynaptic_model(
        "exp_curr",
        decay_code=
        """
        inSyn *= expDecay;
        """,
        apply_input_code=
        """
        Isyn += init * inSyn;
        """,
        params=["tau"],
        derived_params=[....])
```

becomes:

```python
exp_curr_model = create_postsynaptic_model(
        "exp_curr",
        sim_code=
        """
        injectCurrent(init * inSyn);
        inSyn *= expDecay;
        """,
        params=["tau"],
        derived_params=[....])
```
The user is no longer expected to know that ``Isyn`` is a magical thing you can only meaningfully add to (and can be renamed by setting post_target_var on the synapse group) and the injection of current uses the same syntax as current sources.