### PR TITLE
Use warp shuffles for addToPre when using postsynaptic parallelism

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,12 +1,9 @@
 .git
 build
 dist
-documentation
-doxygen
+docs
 lib
 obj*
 tests
-userproject
-!userproject/include
 **/*.so
 **/*.lib

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@ RUN apt-get update && \
     apt-get upgrade -y
 
 # Install Python, pip and swig
-RUN apt-get install -yq --no-install-recommends python3-dev python3-pip gosu nano
+RUN apt-get install -yq --no-install-recommends python3-dev python3-pip libffi-dev pkgconf gosu nano
 
 # Set CUDA environment variable
 ENV CUDA_PATH=/usr/local/cuda

--- a/include/genn/backends/cuda/backend.h
+++ b/include/genn/backends/cuda/backend.h
@@ -179,6 +179,10 @@ public:
     //! Get the ID of the current thread block
     virtual std::string getBlockID(unsigned int axis = 0) const final;
 
+    //! How many 'lanes' does underlying hardware have?
+    /*! This is typically used for warp-shuffle algorithms */
+    virtual unsigned int getNumLanes() const final;
+
     //! Get the name of the count-leading-zeros function
     virtual std::string getCLZ() const final { return "__clz"; }
 
@@ -186,6 +190,10 @@ public:
     virtual std::string getAtomic(const Type::ResolvedType &type,
                                   AtomicOperation op = AtomicOperation::ADD, 
                                   AtomicMemSpace memSpace = AtomicMemSpace::GLOBAL) const final;
+
+    //! Generate a warp reduction across getNumLanes lanes into lane 0
+    virtual void genWarpReduction(CodeStream& os, const std::string& variable,
+                                  VarAccessMode access, const Type::ResolvedType& type) const final;
 
     //! Generate a shared memory barrier
     virtual void genSharedMemBarrier(CodeStream &os) const final;

--- a/include/genn/genn/code_generator/backendSIMT.h
+++ b/include/genn/genn/code_generator/backendSIMT.h
@@ -87,6 +87,10 @@ public:
     //! Get the ID of the current thread block
     virtual std::string getBlockID(unsigned int axis = 0) const = 0;
 
+    //! How many 'lanes' does underlying hardware have?
+    /*! This is typically used for warp-shuffle algorithms */
+    virtual unsigned int getNumLanes() const = 0;
+
     //! Get the name of the count-leading-zeros function
     virtual std::string getCLZ() const = 0;
 
@@ -94,6 +98,10 @@ public:
     virtual std::string getAtomic(const Type::ResolvedType &type,
                                   AtomicOperation op = AtomicOperation::ADD, 
                                   AtomicMemSpace memSpace = AtomicMemSpace::GLOBAL) const = 0;
+    
+    //! Generate a warp reduction across getNumLanes lanes into lane 0
+    virtual void genWarpReduction(CodeStream& os, const std::string& variable,
+                                  VarAccessMode access, const Type::ResolvedType& type) const = 0;
 
     //! Generate a shared memory barrier
     virtual void genSharedMemBarrier(CodeStream &os) const = 0;

--- a/src/genn/genn/code_generator/backendBase.cc
+++ b/src/genn/genn/code_generator/backendBase.cc
@@ -684,6 +684,7 @@ std::string BackendBase::getReductionOperation(const std::string &reduction, con
 {
     // If operation is sum, add output of custom update to sum
     assert(type.isNumeric());
+    assert(access & VarAccessModeAttribute::REDUCE);
     if(access & VarAccessModeAttribute::SUM) {
         return reduction + " += " + value;
     }
@@ -694,7 +695,7 @@ std::string BackendBase::getReductionOperation(const std::string &reduction, con
             return reduction + " = " + "max(" + reduction + ", " + value + ")";
             
         }
-        // Otherwise, generate gmax call
+        // Otherwise, generate fmax call
         else {
             return reduction + " = " + "fmax(" + reduction + ", " + value + ")";
         }

--- a/src/genn/genn/code_generator/presynapticUpdateStrategySIMT.cc
+++ b/src/genn/genn/code_generator/presynapticUpdateStrategySIMT.cc
@@ -41,6 +41,12 @@ bool isSmallSharedMemoryPop(const PresynapticUpdateGroupMerged &sg,
                            });
     }
 }
+//----------------------------------------------------------------------------
+bool isPresynapticOutputRequired(const PresynapticUpdateGroupMerged &sg, bool trueSpike)
+{
+    const auto& tokens = trueSpike ? sg.getArchetype().getWUInitialiser().getPreSpikeSynCodeTokens() : sg.getArchetype().getWUInitialiser().getPreEventSynCodeTokens();
+    return GeNN::Utils::isIdentifierReferenced("addToPre", tokens);
+}
 }   // Anonymous namespace
 
 //----------------------------------------------------------------------------
@@ -91,8 +97,8 @@ void PreSpan::genUpdate(EnvironmentExternalBase &env, PresynapticUpdateGroupMerg
         env.getStream() << "const unsigned int spike = " << env["id"] << ";" << std::endl;
     }
 
-    if(sg.getArchetype().isPresynapticOutputRequired()) {
-        env.getStream() << sg.getScalarType().getName() << " lOutPre = 0.0;" << std::endl;
+    if(isPresynapticOutputRequired(sg, trueSpike)) {
+        env.getStream() << sg.getScalarType().getName() << " lOutPre = " << Type::writeNumeric(0.0, sg.getScalarType()) << ";" << std::endl;
     }
     
     env.print("if (spike < $(_src_spk_cnt" + eventSuffix + ")[" + sg.getPreSlot(batchSize) + "])");
@@ -143,7 +149,7 @@ void PreSpan::genUpdate(EnvironmentExternalBase &env, PresynapticUpdateGroupMerg
         }
 
         // Add lOutPre to global memory
-        if(sg.getArchetype().isPresynapticOutputRequired()) {
+        if(isPresynapticOutputRequired(sg, trueSpike)) {
             env.printLine(backend.getAtomic(sg.getScalarType()) + "(&$(_out_pre)[" + sg.getPreISynIndex(batchSize, "preInd") + "], lOutPre);");
         }
         
@@ -246,11 +252,20 @@ void PostSpan::genUpdate(EnvironmentExternalBase &env, PresynapticUpdateGroupMer
         env.getStream() << "for (unsigned int j = 0; j < numSpikesInBlock; j++)";
         {
             CodeStream::Scope b(env.getStream());
-            env.getStream() << "// only work on existing neurons" << std::endl;
-            env.print("if ($(id) < $(_row_stride))");
+            EnvironmentGroupMergedField<PresynapticUpdateGroupMerged> spikeEnv(env, sg);
+
+            spikeEnv.add(Type::Uint32.addConst(), "id_pre", "$(_sh_spk" + eventSuffix + ")[j]");
+
+            // Create local variable to hold presynaptic output from all threads in warp
+            if (isPresynapticOutputRequired(sg, trueSpike)) {
+                spikeEnv.getStream() << sg.getScalarType().getName() << " lOutPre = " << Type::writeNumeric(0.0, sg.getScalarType()) << ";" << std::endl;
+            }
+
+            spikeEnv.getStream() << "// only work on existing neurons" << std::endl;
+            spikeEnv.print("if ($(id) < $(_row_stride))");
             {
-                CodeStream::Scope b(env.getStream());
-                EnvironmentGroupMergedField<PresynapticUpdateGroupMerged> synEnv(env, sg);
+                CodeStream::Scope b(spikeEnv.getStream());
+                EnvironmentGroupMergedField<PresynapticUpdateGroupMerged> synEnv(spikeEnv, sg);
 
                 const auto indexType = backend.getSynapseIndexType(sg);
                 const auto indexTypeName = indexType.getName();
@@ -265,8 +280,6 @@ void PostSpan::genUpdate(EnvironmentExternalBase &env, PresynapticUpdateGroupMer
                     synEnv.getStream() << CodeStream::OB(135);
                 }
 
-
-                synEnv.add(Type::Uint32.addConst(), "id_pre", "$(_sh_spk" + eventSuffix + ")[j]");
                 synEnv.add(indexType.addConst(), "id_syn", "synAddress",
                            {synEnv.addInitialiser( "const " + indexTypeName + " synAddress = ((" + indexTypeName + ")$(_sh_spk" + eventSuffix + ")[j] * $(_row_stride)) + $(id);")});
 
@@ -301,11 +314,9 @@ void PostSpan::genUpdate(EnvironmentExternalBase &env, PresynapticUpdateGroupMer
                                backend.getAtomic(sg.getScalarType()) + "(&$(_out_post)[" + sg.getPostISynIndex(batchSize, "$(id_post)") + "], $(0))");
                 }
 
-                // Use global memory atomic for presynaptic output
-                // **NOTE** this could use per-block shared memory
-                synEnv.add(Type::AddToPre, "addToPre",
-                            backend.getAtomic(sg.getScalarType()) + "(&$(_out_pre)[" + sg.getPreISynIndex(batchSize, "$(id_pre)") + "], $(0))");
-                
+                // Add presynaptic output to local variable
+                synEnv.add(Type::AddToPre, "addToPre", "lOutPre += $(0)");
+
                 if(trueSpike) {
                     sg.generateSpikeUpdate(synEnv, batchSize, dt);
                 }
@@ -319,6 +330,21 @@ void PostSpan::genUpdate(EnvironmentExternalBase &env, PresynapticUpdateGroupMer
 
                 if(sg.getArchetype().getMatrixType() & SynapseMatrixConnectivity::BITMASK) {
                     synEnv.getStream() << CodeStream::CB(135); // end if (B(dd_gp" << sg.getName() << "[gid / 32], gid
+                }
+            }
+
+            if (isPresynapticOutputRequired(sg, trueSpike)) {
+                // Perform warp reduction into first lane
+                // **YUCK** CUDA-specific
+                for (unsigned int i = 16; i > 0; i /= 2) {
+                    spikeEnv.printLine("lOutPre += __shfl_down_sync(0xFFFFFFFF, lOutPre, " + std::to_string(i) + ");");
+                }
+
+                // Issue atomic add on first lane of warp
+                spikeEnv.print("if((" + backend.getThreadID() + " % 32) == 0)");
+                {
+                    CodeStream::Scope b(spikeEnv.getStream());
+                    spikeEnv.printLine(backend.getAtomic(sg.getScalarType()) + "(&$(_out_pre)[" + sg.getPreISynIndex(batchSize, "$(id_pre)") + "], lOutPre);");
                 }
             }
         }
@@ -422,8 +448,8 @@ void PreSpanProcedural::genUpdate(EnvironmentExternalBase &env, PresynapticUpdat
     {
         CodeStream::Scope b(groupEnv.getStream());
         
-        if(sg.getArchetype().isPresynapticOutputRequired()) {
-            groupEnv.getStream() << "scalar lOutPre = 0.0;" << std::endl;
+        if(isPresynapticOutputRequired(sg, trueSpike)) {
+            groupEnv.getStream() << sg.getScalarType().getName() << " lOutPre = " << Type::writeNumeric(0.0, sg.getScalarType()) << ";" << std::endl;
         }
 
         // Create environment and add presynaptic index
@@ -528,7 +554,7 @@ void PreSpanProcedural::genUpdate(EnvironmentExternalBase &env, PresynapticUpdat
         }
 
         // Write sum of presynaptic output to global memory
-        if(sg.getArchetype().isPresynapticOutputRequired()) {
+        if(isPresynapticOutputRequired(sg, trueSpike)) {
             groupEnv.printLine(backend.getAtomic(sg.getScalarType()) + "(&$(_out_pre)[" + sg.getPreISynIndex(batchSize, "$(id_pre)") + "], lOutPre);");
         }
 

--- a/tests/features/test_event_propagation.py
+++ b/tests/features/test_event_propagation.py
@@ -40,13 +40,6 @@ decoder_dense_model = create_var_init_snippet(
     value = (((id_pre + 1) & jValue) != 0) ? 1.0 : 0.0;
     """)
 
-decoder_value_model = create_var_init_snippet(
-    "decoder_value",
-    var_init_code=
-    """
-    value = (1 << id_post);
-    """)
-
 static_event_pulse_model = create_weight_update_model(
     "static_event_pulse",
     var_name_types=[("g", "scalar")],
@@ -556,6 +549,13 @@ def test_forward_kernel_procedural(make_model, backend, precision):
 @pytest.mark.parametrize("backend", ["single_threaded_cpu", "cuda"])
 @pytest.mark.parametrize("precision", [types.Double, types.Float])
 def test_reverse(make_model, backend, precision):
+    decoder_value_model = create_var_init_snippet(
+        "decoder_value",
+        var_init_code=
+        """
+        value = (1 << id_post);
+        """)
+
     pre_reverse_spike_source_model = create_neuron_model(
         "pre_reverse_spike_source",
         var_name_types=[("startSpike", "unsigned int"), 
@@ -596,7 +596,7 @@ def test_reverse(make_model, backend, precision):
         "static_pulse_reverse_constant_weight",
         sim_code=
         """
-        addToPre(pow(2.0, id_post));
+        addToPre(1 << id_post);
         """)
 
     static_event_pulse_reverse_model = create_weight_update_model(


### PR DESCRIPTION
Profiling confirmed my suspicion that using global memory atomic adds here was very innefficient and becomes more so with large hidden layers. Copy-pasted my trusty CUDA playground (https://github.com/neworderofjamie/dense_out_pre_kernels) I tried a few things but:
- The CUDA compiler is smart enough to 'lift' repeated loads of postsynaptic lambda variables out of the loop/they just sit in L1 cache making them fast to access i.e. https://github.com/neworderofjamie/dense_out_pre_kernels/blob/master/kernel.cu#L213-L240 performs the same as https://github.com/neworderofjamie/dense_out_pre_kernels/blob/master/kernel.cu#L260-L292
- Switching to _shared memory_ atomics, the stalling the profiler shows just moves from global memory "long scoreboard" to shared memory "short scoreboard" and performance actually gets worse (I suspect due to the extra synchronisation required)
- Warp shuffles can massively improve the performance

![Figure_2](https://github.com/genn-team/genn/assets/6793242/217d1ad2-b725-422e-ae85-b85596c151ca)

On _real_ models, the performance gains are sadly somewhat less because, in single hidden layer models, input->hidden (where no gradient transport is required) tends to have the largest number of connections and the cost of making the weight updates/propagating spikes is also significant. Nonetheless, the new kernel is never slower than the old one and with larger batch sizes (where the memory subsystem is being thrashed harder) and larger hidden layers (where more postsynaptic neurons are issuing simultaneous colliding atomic adds) the savings can still be significant (these times are per-epoch of SHD training): 
![Figure_1](https://github.com/genn-team/genn/assets/6793242/ff28666a-2acd-4b41-ae72-327c62baef20)

Note, another factor behind the difference in speedup might well be that the low-level benchmarking was done on my laptop (A500 GPU with 96 GB/s memory bandwidth) and the SHD tests were done on Cortex (3080 GPU with 760 GB/s)