### PR TITLE
Rebuild ``remap`` and ``colLength`` after custom connectivity updates

### DIFF
--- a/include/genn/backends/cuda/backend.h
+++ b/include/genn/backends/cuda/backend.h
@@ -148,7 +148,6 @@ private:
     //------------------------------------------------------------------------
     // Members
     //------------------------------------------------------------------------
-    bool m_EnableNCCLReductions;
     VoidFunction m_NCCLGenerateUniqueID;
     BytePtrFunction m_NCCLGetUniqueID;
     NCCLInitCommunicatorFunction m_NCCLInitCommunicator;

--- a/include/genn/backends/single_threaded_cpu/backend.h
+++ b/include/genn/backends/single_threaded_cpu/backend.h
@@ -118,6 +118,10 @@ public:
     virtual void genKernelSynapseVariableInit(EnvironmentExternalBase &env, SynapseInitGroupMerged &sg, HandlerEnv handler) const final;
     virtual void genKernelCustomUpdateVariableInit(EnvironmentExternalBase &env, CustomWUUpdateInitGroupMerged &cu, HandlerEnv handler) const final;
 
+    //! Populate $(_remap) and $(_col_length) based on $(_ind), $(_row_stride) and $(_col_stride)
+    virtual void genRemap(EnvironmentExternalBase &env) const final;
+
+
     virtual void genGlobalDeviceRNG(CodeStream &definitions, CodeStream &runner, CodeStream &allocations, CodeStream &free) const final;
     virtual void genTimer(CodeStream &definitions, CodeStream &runner, CodeStream &allocations, CodeStream &free, CodeStream &stepTimeFinalise, 
                           const std::string &name, bool updateInStepTime) const final;

--- a/include/genn/backends/single_threaded_cpu/backend.h
+++ b/include/genn/backends/single_threaded_cpu/backend.h
@@ -118,10 +118,6 @@ public:
     virtual void genKernelSynapseVariableInit(EnvironmentExternalBase &env, SynapseInitGroupMerged &sg, HandlerEnv handler) const final;
     virtual void genKernelCustomUpdateVariableInit(EnvironmentExternalBase &env, CustomWUUpdateInitGroupMerged &cu, HandlerEnv handler) const final;
 
-    //! Populate $(_remap) and $(_col_length) based on $(_ind), $(_row_stride) and $(_col_stride)
-    virtual void genRemap(EnvironmentExternalBase &env) const final;
-
-
     virtual void genGlobalDeviceRNG(CodeStream &definitions, CodeStream &runner, CodeStream &allocations, CodeStream &free) const final;
     virtual void genTimer(CodeStream &definitions, CodeStream &runner, CodeStream &allocations, CodeStream &free, CodeStream &stepTimeFinalise, 
                           const std::string &name, bool updateInStepTime) const final;

--- a/include/genn/genn/code_generator/backendBase.h
+++ b/include/genn/genn/code_generator/backendBase.h
@@ -51,6 +51,7 @@ class PostsynapticUpdateGroupMerged;
 class SynapseDynamicsGroupMerged;
 class SynapseDendriticDelayUpdateGroupMerged;
 class CustomConnectivityUpdateGroupMerged;
+class CustomConnectivityRemapUpdateGroupMerged;
 class CustomUpdateGroupMerged;
 class CustomUpdateWUGroupMerged;
 class CustomUpdateTransposeWUGroupMerged;
@@ -343,6 +344,7 @@ public:
     void buildStandardEnvironment(EnvironmentGroupMergedField<CustomUpdateWUGroupMerged> &env, unsigned int batchSize) const;
     void buildStandardEnvironment(EnvironmentGroupMergedField<CustomUpdateTransposeWUGroupMerged> &env, unsigned int batchSize) const;
     void buildStandardEnvironment(EnvironmentGroupMergedField<CustomConnectivityUpdateGroupMerged> &env) const;
+    void buildStandardEnvironment(EnvironmentGroupMergedField<CustomConnectivityRemapUpdateGroupMerged> &env) const;
 
     void buildStandardEnvironment(EnvironmentGroupMergedField<NeuronInitGroupMerged> &env, unsigned int batchSize) const;
     void buildStandardEnvironment(EnvironmentGroupMergedField<SynapseInitGroupMerged> &env, unsigned int batchSize) const;

--- a/include/genn/genn/code_generator/backendBase.h
+++ b/include/genn/genn/code_generator/backendBase.h
@@ -236,9 +236,6 @@ public:
     virtual void genKernelSynapseVariableInit(EnvironmentExternalBase &env, SynapseInitGroupMerged &sg, HandlerEnv handler) const = 0;
     virtual void genKernelCustomUpdateVariableInit(EnvironmentExternalBase &env, CustomWUUpdateInitGroupMerged &cu, HandlerEnv handler) const = 0;
 
-    //! Populate $(_remap) and $(_col_length) based on $(_ind), $(_row_stride) and $(_col_stride)
-    virtual void genRemap(EnvironmentExternalBase &env) const = 0;
-
     //! Generate a single RNG instance
     /*! On single-threaded platforms this can be a standard RNG like M.T. but, on parallel platforms, it is likely to be a counter-based RNG */
     virtual void genGlobalDeviceRNG(CodeStream &definitions, CodeStream &runner, CodeStream &allocations, CodeStream &free) const = 0;

--- a/include/genn/genn/code_generator/backendBase.h
+++ b/include/genn/genn/code_generator/backendBase.h
@@ -235,6 +235,9 @@ public:
     virtual void genKernelSynapseVariableInit(EnvironmentExternalBase &env, SynapseInitGroupMerged &sg, HandlerEnv handler) const = 0;
     virtual void genKernelCustomUpdateVariableInit(EnvironmentExternalBase &env, CustomWUUpdateInitGroupMerged &cu, HandlerEnv handler) const = 0;
 
+    //! Populate $(_remap) and $(_col_length) based on $(_ind), $(_row_stride) and $(_col_stride)
+    virtual void genRemap(EnvironmentExternalBase &env) const = 0;
+
     //! Generate a single RNG instance
     /*! On single-threaded platforms this can be a standard RNG like M.T. but, on parallel platforms, it is likely to be a counter-based RNG */
     virtual void genGlobalDeviceRNG(CodeStream &definitions, CodeStream &runner, CodeStream &allocations, CodeStream &free) const = 0;
@@ -271,6 +274,7 @@ public:
     virtual void genMSBuildItemDefinitions(std::ostream &os) const = 0;
     virtual void genMSBuildCompileModule(const std::string &moduleName, std::ostream &os) const = 0;
     virtual void genMSBuildImportTarget(std::ostream &os) const = 0;
+
     //! Get list of files to copy into generated code
     /*! Paths should be relative to share/genn/backends/ */
     virtual std::vector<filesystem::path> getFilesToCopy(const ModelSpecMerged&) const{ return {}; }

--- a/include/genn/genn/code_generator/backendSIMT.h
+++ b/include/genn/genn/code_generator/backendSIMT.h
@@ -34,6 +34,7 @@ enum Kernel
     KernelSynapseDendriticDelayUpdate,
     KernelCustomUpdate,
     KernelCustomTransposeUpdate,
+    KernelCustomConnectivityColLengthUpdate,
     KernelCustomConnectivityRemapUpdate,
     KernelMax
 };
@@ -211,7 +212,8 @@ protected:
 
     void genCustomConnectivityUpdateKernel(EnvironmentExternalBase &env, ModelSpecMerged &modelMerged,
                                            BackendBase::MemorySpaces &memorySpaces, const std::string &updateGroup, size_t &idStart) const;
-
+    void genCustomConnectivityColLengthUpdateKernel(EnvironmentExternalBase &env, ModelSpecMerged &modelMerged,
+                                                    BackendBase::MemorySpaces &memorySpaces, const std::string &updateGroup, size_t &idStart) const;
     void genCustomConnectivityRemapUpdateKernel(EnvironmentExternalBase &env, ModelSpecMerged &modelMerged,
                                                 BackendBase::MemorySpaces &memorySpaces, const std::string &updateGroup, size_t &idStart) const;
 

--- a/include/genn/genn/code_generator/backendSIMT.h
+++ b/include/genn/genn/code_generator/backendSIMT.h
@@ -34,7 +34,6 @@ enum Kernel
     KernelSynapseDendriticDelayUpdate,
     KernelCustomUpdate,
     KernelCustomTransposeUpdate,
-    KernelCustomConnectivityColLengthUpdate,
     KernelCustomConnectivityRemapUpdate,
     KernelMax
 };
@@ -212,8 +211,7 @@ protected:
 
     void genCustomConnectivityUpdateKernel(EnvironmentExternalBase &env, ModelSpecMerged &modelMerged,
                                            BackendBase::MemorySpaces &memorySpaces, const std::string &updateGroup, size_t &idStart) const;
-    void genCustomConnectivityColLengthUpdateKernel(EnvironmentExternalBase &env, ModelSpecMerged &modelMerged,
-                                                    BackendBase::MemorySpaces &memorySpaces, const std::string &updateGroup, size_t &idStart) const;
+
     void genCustomConnectivityRemapUpdateKernel(EnvironmentExternalBase &env, ModelSpecMerged &modelMerged,
                                                 BackendBase::MemorySpaces &memorySpaces, const std::string &updateGroup, size_t &idStart) const;
 

--- a/include/genn/genn/code_generator/backendSIMT.h
+++ b/include/genn/genn/code_generator/backendSIMT.h
@@ -135,6 +135,9 @@ public:
     virtual void genKernelSynapseVariableInit(EnvironmentExternalBase &env, SynapseInitGroupMerged &sg, HandlerEnv handler) const final;
     virtual void genKernelCustomUpdateVariableInit(EnvironmentExternalBase &env, CustomWUUpdateInitGroupMerged &cu, HandlerEnv handler) const final;
 
+    //! Populate $(_remap) and $(_col_length) based on $(_ind), $(_row_stride) and $(_col_stride)
+    virtual void genRemap(EnvironmentExternalBase &env) const final;
+
     //! Should 'scalar' variables be implemented on device or can host variables be used directly?
     virtual bool isDeviceScalarRequired() const final { return true; }
 

--- a/include/genn/genn/code_generator/backendSIMT.h
+++ b/include/genn/genn/code_generator/backendSIMT.h
@@ -136,9 +136,6 @@ public:
     virtual void genKernelSynapseVariableInit(EnvironmentExternalBase &env, SynapseInitGroupMerged &sg, HandlerEnv handler) const final;
     virtual void genKernelCustomUpdateVariableInit(EnvironmentExternalBase &env, CustomWUUpdateInitGroupMerged &cu, HandlerEnv handler) const final;
 
-    //! Populate $(_remap) and $(_col_length) based on $(_ind), $(_row_stride) and $(_col_stride)
-    virtual void genRemap(EnvironmentExternalBase &env) const final;
-
     //! Should 'scalar' variables be implemented on device or can host variables be used directly?
     virtual bool isDeviceScalarRequired() const final { return true; }
 
@@ -480,6 +477,9 @@ private:
                       size_t index, bool trueSpike) const;
     void genCopyEventToGlobal(EnvironmentExternalBase &env, NeuronUpdateGroupMerged &ng,
                               unsigned int batchSize, size_t index, bool trueSpike) const;
+
+    //! Populate $(_remap) and $(_col_length) based on $(_ind), $(_row_stride) and $(_col_stride)
+    void genRemap(EnvironmentExternalBase &env) const;
 
     // Get appropriate presynaptic update strategy to use for this synapse group
     const PresynapticUpdateStrategySIMT::Base *getPresynapticUpdateStrategy(const SynapseGroupInternal &sg) const

--- a/include/genn/genn/code_generator/backendSIMT.h
+++ b/include/genn/genn/code_generator/backendSIMT.h
@@ -34,6 +34,7 @@ enum Kernel
     KernelSynapseDendriticDelayUpdate,
     KernelCustomUpdate,
     KernelCustomTransposeUpdate,
+    KernelCustomConnectivityRemapUpdate,
     KernelMax
 };
 
@@ -210,6 +211,9 @@ protected:
 
     void genCustomConnectivityUpdateKernel(EnvironmentExternalBase &env, ModelSpecMerged &modelMerged,
                                            BackendBase::MemorySpaces &memorySpaces, const std::string &updateGroup, size_t &idStart) const;
+
+    void genCustomConnectivityRemapUpdateKernel(EnvironmentExternalBase &env, ModelSpecMerged &modelMerged,
+                                                BackendBase::MemorySpaces &memorySpaces, const std::string &updateGroup, size_t &idStart) const;
 
     void genInitializeKernel(EnvironmentExternalBase &env, ModelSpecMerged &modelMerged, 
                              BackendBase::MemorySpaces &memorySpaces, size_t &idStart) const;

--- a/include/genn/genn/code_generator/customConnectivityUpdateGroupMerged.h
+++ b/include/genn/genn/code_generator/customConnectivityUpdateGroupMerged.h
@@ -123,8 +123,6 @@ public:
         generateRunnerBase(backend, definitions, name);
     }
 
-    void generateUpdate(const BackendBase& backend, EnvironmentExternalBase& env);
-
     //----------------------------------------------------------------------------
     // Static constants
     //----------------------------------------------------------------------------

--- a/include/genn/genn/code_generator/customConnectivityUpdateGroupMerged.h
+++ b/include/genn/genn/code_generator/customConnectivityUpdateGroupMerged.h
@@ -108,6 +108,30 @@ private:
 };
 
 //----------------------------------------------------------------------------
+// GeNN::CodeGenerator::CustomConnectivityRemapUpdateGroupMerged
+//----------------------------------------------------------------------------
+class GENN_EXPORT CustomConnectivityRemapUpdateGroupMerged : public GroupMerged<CustomConnectivityUpdateInternal>
+{
+public:
+    using GroupMerged::GroupMerged;
+
+    //----------------------------------------------------------------------------
+    // Public API
+    //----------------------------------------------------------------------------
+    void generateRunner(const BackendBase& backend, CodeStream& definitions) const
+    {
+        generateRunnerBase(backend, definitions, name);
+    }
+
+    void generateUpdate(const BackendBase& backend, EnvironmentExternalBase& env);
+
+    //----------------------------------------------------------------------------
+    // Static constants
+    //----------------------------------------------------------------------------
+    static const std::string name;
+};
+
+//----------------------------------------------------------------------------
 // GeNN::CodeGenerator::CustomConnectivityHostUpdateGroupMerged
 //----------------------------------------------------------------------------
 class GENN_EXPORT CustomConnectivityHostUpdateGroupMerged : public GroupMerged<CustomConnectivityUpdateInternal>

--- a/include/genn/genn/code_generator/modelSpecMerged.h
+++ b/include/genn/genn/code_generator/modelSpecMerged.h
@@ -119,6 +119,9 @@ public:
     //! Get merged custom connectivity update groups
     const std::vector<CustomConnectivityUpdateGroupMerged> &getMergedCustomConnectivityUpdateGroups() const { return m_MergedCustomConnectivityUpdateGroups; }
 
+    //! Get merged custom connectivity update groups which require regeneration of remap structure
+    const std::vector<CustomConnectivityRemapUpdateGroupMerged> &getMergedCustomConnectivityRemapUpdateGroups() const { return m_MergedCustomConnectivityRemapUpdateGroups; }
+
     //! Get merged custom connectivity update groups where host processing needs to be performed
     const std::vector<CustomConnectivityHostUpdateGroupMerged> &getMergedCustomConnectivityHostUpdateGroups() const { return m_MergedCustomConnectivityHostUpdateGroups; }
 
@@ -142,6 +145,8 @@ public:
                                                     GenMergedGroupFn<CustomWUUpdateHostReductionGroupMerged> generateGroup);
     void genMergedCustomConnectivityUpdateGroups(const BackendBase &backend, BackendBase::MemorySpaces &memorySpaces, const std::string &updateGroupName, 
                                                  GenMergedGroupFn<CustomConnectivityUpdateGroupMerged> generateGroup);
+    void genMergedCustomConnectivityRemapUpdateGroups(const BackendBase &backend, BackendBase::MemorySpaces &memorySpaces, const std::string &updateGroupName, 
+                                                     GenMergedGroupFn<CustomConnectivityRemapUpdateGroupMerged> generateGroup);
     void genMergedCustomConnectivityHostUpdateGroups(const BackendBase &backend, BackendBase::MemorySpaces &memorySpaces, const std::string &updateGroupName, 
                                                      GenMergedGroupFn<CustomConnectivityHostUpdateGroupMerged> generateGroup);
     void genMergedNeuronSpikeQueueUpdateGroups(const BackendBase &backend, BackendBase::MemorySpaces &memorySpaces, 
@@ -198,6 +203,7 @@ public:
     void genMergedCustomUpdateHostReductionStructs(CodeStream &os, const BackendBase &backend) const { genMergedStructures(os, backend, m_MergedCustomUpdateHostReductionGroups); }
     void genMergedCustomWUUpdateHostReductionStructs(CodeStream &os, const BackendBase &backend) const { genMergedStructures(os, backend, m_MergedCustomWUUpdateHostReductionGroups); }
     void genMergedCustomConnectivityUpdateStructs(CodeStream &os, const BackendBase &backend) const { genMergedStructures(os, backend, m_MergedCustomConnectivityUpdateGroups); }
+    void genMergedCustomConnectivityRemapUpdateStructs(CodeStream &os, const BackendBase &backend) const { genMergedStructures(os, backend, m_MergedCustomConnectivityRemapUpdateGroups); }
     void genMergedCustomConnectivityHostUpdateStructs(CodeStream &os, const BackendBase &backend) const { genMergedStructures(os, backend, m_MergedCustomConnectivityHostUpdateGroups); }
 
 
@@ -225,6 +231,7 @@ public:
     void genMergedCustomUpdateHostReductionHostStructArrayPush(CodeStream &os, const BackendBase &backend) const { genHostMergedStructArrayPush(os, backend, m_MergedCustomUpdateHostReductionGroups); }
     void genMergedCustomWUUpdateHostReductionHostStructArrayPush(CodeStream &os, const BackendBase &backend) const { genHostMergedStructArrayPush(os, backend, m_MergedCustomWUUpdateHostReductionGroups); }
     void genMergedCustomConnectivityUpdateHostStructArrayPush(CodeStream &os, const BackendBase &backend) const { genHostMergedStructArrayPush(os, backend, m_MergedCustomConnectivityUpdateGroups); }
+    void genMergedCustomConnectivityRemapUpdateHostStructArrayPush(CodeStream &os, const BackendBase &backend) const { genHostMergedStructArrayPush(os, backend, m_MergedCustomConnectivityRemapUpdateGroups); }
     void genMergedCustomConnectivityHostUpdateStructArrayPush(CodeStream &os, const BackendBase &backend) const { genHostMergedStructArrayPush(os, backend, m_MergedCustomConnectivityHostUpdateGroups); }
 
 
@@ -469,6 +476,9 @@ private:
 
     //! Merged custom connectivity update groups
     std::vector<CustomConnectivityUpdateGroupMerged> m_MergedCustomConnectivityUpdateGroups;
+
+    //! Merged custom connectivity update groups which require remap data structure regenerating
+    std::vector<CustomConnectivityRemapUpdateGroupMerged> m_MergedCustomConnectivityRemapUpdateGroups;
 
     //! Merged custom connectivity update groups where host processing needs to be performed
     std::vector<CustomConnectivityHostUpdateGroupMerged> m_MergedCustomConnectivityHostUpdateGroups;

--- a/include/genn/genn/customConnectivityUpdate.h
+++ b/include/genn/genn/customConnectivityUpdate.h
@@ -87,6 +87,9 @@ public:
     //! Is var init code required for any postsynaptic variables in this custom connectivity update group?
     bool isPostVarInitRequired() const;
 
+    //! Can this custom connectivty update actually modify connectivity
+    bool canModifyConnectivity() const;
+
 protected:
     CustomConnectivityUpdate(const std::string &name, const std::string &updateGroupName, SynapseGroupInternal *synapseGroup,
                              const CustomConnectivityUpdateModels::Base *customConnectivityUpdateModel,
@@ -118,6 +121,10 @@ protected:
     //! Updates hash with custom update.
     /*! \note this can only be called after model is finalized */
     boost::uuids::detail::sha1::digest_type getHashDigest() const;
+
+    //! Updates hash with custom update.
+    /*! \note this can only be called after model is finalized */
+    boost::uuids::detail::sha1::digest_type getRemapHashDigest() const;
 
     //! Updates hash with custom update.
     /*! \note this can only be called after model is finalized */

--- a/include/genn/genn/customConnectivityUpdateInternal.h
+++ b/include/genn/genn/customConnectivityUpdateInternal.h
@@ -36,6 +36,7 @@ public:
     using CustomConnectivityUpdate::getDependentVariables;
     using CustomConnectivityUpdate::finalise;
     using CustomConnectivityUpdate::getHashDigest;
+    using CustomConnectivityUpdate::getRemapHashDigest;
     using CustomConnectivityUpdate::getInitHashDigest;
     using CustomConnectivityUpdate::getPreDelayNeuronGroup;
     using CustomConnectivityUpdate::getPostDelayNeuronGroup;

--- a/include/genn/genn/runtime/runtime.h
+++ b/include/genn/genn/runtime/runtime.h
@@ -329,6 +329,7 @@ public:
     double getInitSparseTime() const{ return *(double*)getSymbol("initSparseTime"); }
     double getCustomUpdateTime(const std::string &name) const{ return *(double*)getSymbol("customUpdate" + name + "Time"); }
     double getCustomUpdateTransposeTime(const std::string &name) const{ return *(double*)getSymbol("customUpdate" + name + "TransposeTime"); }
+    double getCustomUpdateRemapTime(const std::string &name) const{ return *(double*)getSymbol("customUpdate" + name + "RemapTime"); }
     
     void pullRecordingBuffersFromDevice() const;
 

--- a/include/genn/genn/runtime/runtime.h
+++ b/include/genn/genn/runtime/runtime.h
@@ -307,10 +307,7 @@ public:
     void stepTime();
 
     //! Perform named custom update
-    void customUpdate(const std::string &name)
-    { 
-        m_CustomUpdateFunctions.at(name)(getTimestep());
-    }
+    void customUpdate(const std::string &name);
 
     //! Get current simulation timestep
     uint64_t getTimestep() const{ return m_Timestep; }
@@ -694,6 +691,9 @@ private:
 
     //! Functions to perform custom updates
     std::unordered_map<std::string, CustomUpdateFunction> m_CustomUpdateFunctions;
+
+    //! Arrays containing column length arrays which should be zeroed before updating connectivity
+    std::unordered_map<std::string, std::vector<ArrayBase*>> m_CustomUpdateColLengthArrays;
 
     //! Map containing mapping of dynamic arrays to their locations within merged groups
     MergedDynamicArrayMap m_MergedDynamicArrays;

--- a/pygenn/genn_model.py
+++ b/pygenn/genn_model.py
@@ -332,6 +332,15 @@ class GeNNModel(ModelSpec):
             name:   Name of custom update
         """
         return self._runtime.get_custom_update_transpose_time(name)
+    
+    def get_custom_update_remap_time(self, name: str) -> float:
+        """Get time in seconds spent in remap custom update.
+        Only available if :attr:`.ModelSpec.timing_enabled` is set.
+    
+        Args:
+            name:   Name of custom update
+        """
+        return self._runtime.get_custom_update_remap_time(name)
 
     def add_neuron_population(self, pop_name: str, num_neurons: int, 
                               neuron: Union[NeuronModelBase, str],

--- a/pygenn/src/runtime.cc
+++ b/pygenn/src/runtime.cc
@@ -92,6 +92,7 @@ PYBIND11_MODULE(_runtime, m)
 
         .def("get_custom_update_time", &Runtime::getCustomUpdateTime)
         .def("get_custom_update_transpose_time", &Runtime::getCustomUpdateTransposeTime)
+        .def("get_custom_update_remap_time", &Runtime::getCustomUpdateRemapTime)
         
         .def("get_recorded_spikes", 
              [](const Runtime &r, const GeNN::NeuronGroup &group)

--- a/src/genn/backends/cuda/backend.cc
+++ b/src/genn/backends/cuda/backend.cc
@@ -1001,28 +1001,13 @@ void Backend::genCustomUpdate(CodeStream &os, ModelSpecMerged &modelMerged, Back
             }
         }
 
-       
-        size_t idCustomConnectivityColLengthUpdateStart = 0;
         size_t idCustomConnectivityRemapUpdateStart = 0;
         if (std::any_of(modelMerged.getMergedCustomConnectivityRemapUpdateGroups().cbegin(), modelMerged.getMergedCustomConnectivityRemapUpdateGroups().cend(),
                         [&g](const auto &cg) { return (cg.getArchetype().getUpdateGroupName() == g); }))
         {
-            // **TODO** need seperate group start IDs
             genFilteredMergedKernelDataStructures(os, totalConstMem, modelMerged.getMergedCustomConnectivityRemapUpdateGroups(),
                                                   [&model, this](const CustomConnectivityUpdateInternal &cg) { return padKernelSize(cg.getSynapseGroup()->getMaxConnections(), KernelCustomUpdate); },
                                                   [g](const CustomConnectivityRemapUpdateGroupMerged &cg) { return cg.getArchetype().getUpdateGroupName() == g; });
-
-            customUpdateEnv.getStream() << "extern \"C\" __global__ void " << KernelNames[KernelCustomConnectivityColLengthUpdate] << g << "()" << std::endl;
-            {
-                CodeStream::Scope b(customUpdateEnv.getStream());
-
-                EnvironmentExternal funcEnv(customUpdateEnv);
-                funcEnv.getStream() << "const unsigned int id = " << getKernelBlockSize(KernelCustomUpdate) << " * blockIdx.x + threadIdx.x; " << std::endl;
-
-                funcEnv.getStream() << "// ------------------------------------------------------------------------" << std::endl;
-                funcEnv.getStream() << "// Custom connectivity col length updates" << std::endl;
-                genCustomConnectivityColLengthUpdateKernel(funcEnv, modelMerged, memorySpaces, g, idCustomConnectivityColLengthUpdateStart);
-            }
 
             customUpdateEnv.getStream() << "extern \"C\" __global__ void " << KernelNames[KernelCustomConnectivityRemapUpdate] << g << "()" << std::endl;
             {
@@ -1032,7 +1017,7 @@ void Backend::genCustomUpdate(CodeStream &os, ModelSpecMerged &modelMerged, Back
                 funcEnv.getStream() << "const unsigned int id = " << getKernelBlockSize(KernelCustomUpdate) << " * blockIdx.x + threadIdx.x; " << std::endl;
 
                 funcEnv.getStream() << "// ------------------------------------------------------------------------" << std::endl;
-                funcEnv.getStream() << "// Custom connectivity remap updates" << std::endl;
+                funcEnv.getStream() << "// Custom connectiviy remap updates" << std::endl;
                 genCustomConnectivityRemapUpdateKernel(funcEnv, modelMerged, memorySpaces, g, idCustomConnectivityRemapUpdateStart);
             }
         }
@@ -1069,15 +1054,6 @@ void Backend::genCustomUpdate(CodeStream &os, ModelSpecMerged &modelMerged, Back
                 genKernelDimensions(funcEnv.getStream(), KernelCustomTransposeUpdate, idCustomTransposeUpdateStart, 1, 8);
                 Timer t(funcEnv.getStream(), "customUpdate" + g + "Transpose", model.isTimingEnabled());
                 funcEnv.printLine(KernelNames[KernelCustomTransposeUpdate]  + g + "<<<grid, threads>>>($(t));");
-                funcEnv.printLine("CHECK_CUDA_ERRORS(cudaPeekAtLastError());");
-            }
-
-            // Launch custom connectivity col-length update kernel if required
-            if (idCustomConnectivityColLengthUpdateStart > 0) {
-                CodeStream::Scope b(funcEnv.getStream());
-                genKernelDimensions(funcEnv.getStream(), KernelCustomUpdate, idCustomConnectivityColLengthUpdateStart, 1);
-                Timer t(funcEnv.getStream(), "customUpdate" + g + "ColLength", model.isTimingEnabled());
-                funcEnv.printLine(KernelNames[KernelCustomConnectivityColLengthUpdate] + g + "<<<grid, threads>>>();");
                 funcEnv.printLine("CHECK_CUDA_ERRORS(cudaPeekAtLastError());");
             }
 

--- a/src/genn/backends/single_threaded_cpu/backend.cc
+++ b/src/genn/backends/single_threaded_cpu/backend.cc
@@ -1260,23 +1260,7 @@ void Backend::genInit(CodeStream &os, ModelSpecMerged &modelMerged, BackendBase:
 
                         // If postsynaptic learning is required
                         if(s.getArchetype().isPostSpikeRequired() || s.getArchetype().isPostSpikeEventRequired()) {
-                            groupEnv.printLine("// Loop through synapses in corresponding matrix row");
-                            groupEnv.print("for(unsigned int j = 0; j < $(_row_length)[i]; j++)");
-                            {
-                                CodeStream::Scope b(groupEnv.getStream());
-
-                                // Calculate column length and remapping
-                                groupEnv.printLine("// Calculate index of this synapse in the row-major matrix");
-                                groupEnv.printLine("const unsigned int rowMajorIndex = (i * $(_row_stride)) + j;");
-                                groupEnv.printLine("// Using this, lookup postsynaptic target");
-                                groupEnv.printLine("const unsigned int postIndex = $(_ind)[rowMajorIndex];");
-                                groupEnv.printLine("// From this calculate index of this synapse in the column-major matrix)");
-                                groupEnv.printLine("const unsigned int colMajorIndex = (postIndex * $(_col_stride)) + $(_col_length)[postIndex];");
-                                groupEnv.printLine("// Increment column length corresponding to this postsynaptic neuron");
-                                groupEnv.printLine("$(_col_length)[postIndex]++;");
-                                groupEnv.printLine("// Add remapping entry");
-                                groupEnv.printLine("$(_remap)[colMajorIndex] = rowMajorIndex;");
-                            }
+                            genRemap(groupEnv);
                         }
                     }
                 }
@@ -1560,6 +1544,31 @@ void Backend::genKernelSynapseVariableInit(EnvironmentExternalBase &env, Synapse
 void Backend::genKernelCustomUpdateVariableInit(EnvironmentExternalBase &env, CustomWUUpdateInitGroupMerged &cu, HandlerEnv handler) const
 {
     genKernelIteration(env, cu, cu.getArchetype().getSynapseGroup()->getKernelSize().size(), handler);
+}
+//--------------------------------------------------------------------------
+void Backend::genRemap(EnvironmentExternalBase &env) const
+{
+    env.printLine("// Loop through synapses in corresponding matrix row");
+    env.print("for(unsigned int j = 0; j < $(_row_length)[i]; j++)");
+    {
+        CodeStream::Scope b(env.getStream());
+
+        // Calculate column length and remapping
+        env.printLine("// Calculate index of this synapse in the row-major matrix");
+        env.printLine("const unsigned int rowMajorIndex = (i * $(_row_stride)) + j;");
+
+        env.printLine("// Using this, lookup postsynaptic target");
+        env.printLine("const unsigned int postIndex = $(_ind)[rowMajorIndex];");
+
+        env.printLine("// From this calculate index of this synapse in the column-major matrix)");
+        env.printLine("const unsigned int colMajorIndex = (postIndex * $(_col_stride)) + $(_col_length)[postIndex];");
+
+        env.printLine("// Increment column length corresponding to this postsynaptic neuron");
+        env.printLine("$(_col_length)[postIndex]++;");
+
+        env.printLine("// Add remapping entry");
+        env.printLine("$(_remap)[colMajorIndex] = rowMajorIndex;");
+    }
 }
 //--------------------------------------------------------------------------
 void Backend::genGlobalDeviceRNG(CodeStream&, CodeStream&, CodeStream&, CodeStream&) const

--- a/src/genn/genn/code_generator/backendBase.cc
+++ b/src/genn/genn/code_generator/backendBase.cc
@@ -605,6 +605,11 @@ void BackendBase::buildStandardEnvironment(EnvironmentGroupMergedField<CustomCon
     buildStandardCustomConnectivityUpdateEnvironment(*this, env);
 }
 //-----------------------------------------------------------------------
+void BackendBase::buildStandardEnvironment(EnvironmentGroupMergedField<CustomConnectivityRemapUpdateGroupMerged> &env) const
+{
+    buildStandardCustomConnectivityUpdateEnvironment(*this, env);
+}
+//-----------------------------------------------------------------------
 void BackendBase::buildStandardEnvironment(EnvironmentGroupMergedField<NeuronInitGroupMerged> &env, unsigned int batchSize) const
 {
     buildStandardNeuronEnvironment(env, batchSize);

--- a/src/genn/genn/code_generator/backendBase.cc
+++ b/src/genn/genn/code_generator/backendBase.cc
@@ -431,6 +431,8 @@ void buildStandardCustomConnectivityUpdateEnvironment(const BackendBase &backend
                  });
     env.addField(Type::Uint32, "_row_stride", "rowStride", 
                  [&backend](const auto&, const auto &cg, size_t) { return backend.getSynapticMatrixRowStride(*cg.getSynapseGroup()); });
+    env.addField(Type::Uint32, "_col_stride", "colStride", 
+                 [&backend](const auto&, const auto &cg, size_t) { return cg.getSynapseGroup()->getMaxSourceConnections(); });
     
     // Connectivity fields
     auto *sg = env.getGroup().getArchetype().getSynapseGroup();
@@ -439,6 +441,10 @@ void buildStandardCustomConnectivityUpdateEnvironment(const BackendBase &backend
                      [](const auto &runtime, const auto &cg, size_t) { return runtime.getArray(*cg.getSynapseGroup(), "rowLength"); });
         env.addField(sg->getSparseIndType().createPointer(), "_ind", "ind",
                      [](const auto &runtime, const auto &cg, size_t) { return runtime.getArray(*cg.getSynapseGroup(), "ind"); });
+        env.addField(Type::Uint32.createPointer(), "_col_length", "colLength", 
+                     [](const auto &runtime, const auto &cg, size_t) { return runtime.getArray(*cg.getSynapseGroup(), "colLength"); });
+        env.addField(Type::Uint32.createPointer(), "_remap", "remap", 
+                     [](const auto &runtime, const auto &cg, size_t) { return runtime.getArray(*cg.getSynapseGroup(), "remap"); });
     }
 
     // If there are delays on presynaptic variable references

--- a/src/genn/genn/code_generator/backendSIMT.cc
+++ b/src/genn/genn/code_generator/backendSIMT.cc
@@ -1331,9 +1331,13 @@ void BackendSIMT::genCustomConnectivityUpdateKernel(EnvironmentExternalBase &env
 void BackendSIMT::genCustomConnectivityRemapUpdateKernel(EnvironmentExternalBase &env, ModelSpecMerged &modelMerged,
                                                          BackendBase::MemorySpaces &memorySpaces, const std::string &updateGroup, size_t &idStart) const
 {
+    EnvironmentExternal envKernel(env);
+    envKernel.add(Type::Void, "_sh_row_length", "shRowLength",
+                  { envKernel.addInitialiser(getSharedPrefix() + "unsigned int shRowLength[" + std::to_string(getKernelBlockSize(KernelInitializeSparse)) + "];") });
+
     // Parallelise across presynaptic neurons
     genParallelGroup<CustomConnectivityRemapUpdateGroupMerged>(
-        env, modelMerged, memorySpaces, updateGroup, idStart, &ModelSpecMerged::genMergedCustomConnectivityRemapUpdateGroups,
+        envKernel, modelMerged, memorySpaces, updateGroup, idStart, &ModelSpecMerged::genMergedCustomConnectivityRemapUpdateGroups,
         [this](const CustomConnectivityUpdateInternal &cg) { return padKernelSize(cg.getSynapseGroup()->getMaxConnections(), KernelCustomUpdate); },
         [&modelMerged, this](EnvironmentExternalBase &env, CustomConnectivityRemapUpdateGroupMerged &cg)
         {

--- a/src/genn/genn/code_generator/backendSIMT.cc
+++ b/src/genn/genn/code_generator/backendSIMT.cc
@@ -45,7 +45,6 @@ const char *BackendSIMT::KernelNames[KernelMax] = {
     "synapseDendriticDelayUpdateKernel",
     "customUpdate",
     "customTransposeUpdate",
-    "customConnectivityColLengthUpdate",
     "customConnectivityRemapUpdate" };
 //--------------------------------------------------------------------------
 std::vector<PresynapticUpdateStrategySIMT::Base*> BackendSIMT::s_PresynapticUpdateStrategies = {
@@ -1325,29 +1324,6 @@ void BackendSIMT::genCustomConnectivityUpdateKernel(EnvironmentExternalBase &env
                 /*if(Utils::isRNGRequired(cg.getArchetype().getRowUpdateCodeTokens())) {
                     genPopulationRNGPostamble(groupEnv.getStream(), rng);
                 }*/
-            }
-        });
-}
-//--------------------------------------------------------------------------
-void BackendSIMT::genCustomConnectivityColLengthUpdateKernel(EnvironmentExternalBase &env, ModelSpecMerged &modelMerged,
-                                                             BackendBase::MemorySpaces &memorySpaces, const std::string &updateGroup, size_t &idStart) const
-{
-    // Parallelise across postsynaptic neurons
-    // **TODO** this subtly incorrect as genMergedCustomConnectivityRemapUpdateGroups will double-account for memory usage of groups
-    genParallelGroup<CustomConnectivityRemapUpdateGroupMerged>(
-        env, modelMerged, memorySpaces, updateGroup, idStart, &ModelSpecMerged::genMergedCustomConnectivityRemapUpdateGroups,
-        [this](const CustomConnectivityUpdateInternal &cg) { return padKernelSize(cg.getSynapseGroup()->getTrgNeuronGroup()->getNumNeurons(), KernelCustomUpdate); },
-        [&modelMerged, this](EnvironmentExternalBase &env, CustomConnectivityRemapUpdateGroupMerged &cg)
-        {
-            EnvironmentGroupMergedField<CustomConnectivityRemapUpdateGroupMerged> groupEnv(env, cg);
-            buildStandardEnvironment(groupEnv);
-
-            groupEnv.getStream() << "// only do this for existing postsynaptic neurons" << std::endl;
-            groupEnv.print("if($(id) < $(num_post))");
-            {
-                CodeStream::Scope b(groupEnv.getStream());
-
-                groupEnv.printLine("$(_col_length)[$(id)] = 0;");
             }
         });
 }

--- a/src/genn/genn/code_generator/customConnectivityUpdateGroupMerged.cc
+++ b/src/genn/genn/code_generator/customConnectivityUpdateGroupMerged.cc
@@ -364,6 +364,14 @@ bool CustomConnectivityUpdateGroupMerged::isDerivedParamHeterogeneous(const std:
     return isParamValueHeterogeneous(name, [](const CustomConnectivityUpdateInternal &cg) { return cg.getDerivedParams(); });
 }
 
+// ----------------------------------------------------------------------------
+// CustomConnectivityRemapUpdateGroupMerged
+// ----------------------------------------------------------------------------
+const std::string CustomConnectivityRemapUpdateGroupMerged::name = "CustomConnectivityRemapUpdate";
+//----------------------------------------------------------------------------
+void CustomConnectivityRemapUpdateGroupMerged::generateUpdate(const BackendBase &backend, EnvironmentExternalBase &env)
+{
+}
 //----------------------------------------------------------------------------
 // CodeGenerator::CustomConnectivityHostUpdateGroupMerged
 //----------------------------------------------------------------------------

--- a/src/genn/genn/code_generator/customConnectivityUpdateGroupMerged.cc
+++ b/src/genn/genn/code_generator/customConnectivityUpdateGroupMerged.cc
@@ -368,10 +368,7 @@ bool CustomConnectivityUpdateGroupMerged::isDerivedParamHeterogeneous(const std:
 // CustomConnectivityRemapUpdateGroupMerged
 // ----------------------------------------------------------------------------
 const std::string CustomConnectivityRemapUpdateGroupMerged::name = "CustomConnectivityRemapUpdate";
-//----------------------------------------------------------------------------
-void CustomConnectivityRemapUpdateGroupMerged::generateUpdate(const BackendBase &backend, EnvironmentExternalBase &env)
-{
-}
+
 //----------------------------------------------------------------------------
 // CodeGenerator::CustomConnectivityHostUpdateGroupMerged
 //----------------------------------------------------------------------------

--- a/src/genn/genn/code_generator/generateRunner.cc
+++ b/src/genn/genn/code_generator/generateRunner.cc
@@ -206,6 +206,8 @@ void GeNN::CodeGenerator::generateRunner(const filesystem::path &outputPath, Mod
                              runnerStepTimeFinalise, "customUpdate" + g, false);
             backend.genTimer(definitionsVar, runnerVarDecl, runnerVarAlloc, runnerVarFree,
                              runnerStepTimeFinalise, "customUpdate" + g + "Transpose", false);
+            backend.genTimer(definitionsVar, runnerVarDecl, runnerVarAlloc, runnerVarFree,
+                             runnerStepTimeFinalise, "customUpdate" + g + "Remap", false);
         }
 
         // Create init timer
@@ -434,6 +436,11 @@ void GeNN::CodeGenerator::generateRunner(const filesystem::path &outputPath, Mod
 
     // Loop through custom connectivity update groups
     for(const auto &m : modelMerged.getMergedCustomConnectivityUpdateGroups()) {
+        m.generateRunner(backend, definitions);
+    }
+
+    // Loop through custom connectivity remap update groups
+    for (const auto &m : modelMerged.getMergedCustomConnectivityRemapUpdateGroups()) {
         m.generateRunner(backend, definitions);
     }
 

--- a/src/genn/genn/code_generator/generateRunner.cc
+++ b/src/genn/genn/code_generator/generateRunner.cc
@@ -174,6 +174,7 @@ void GeNN::CodeGenerator::generateRunner(const filesystem::path &outputPath, Mod
     for(const auto &g : customUpdateGroups) {
         genHostScalar(definitionsVar, runnerVarDecl, Type::Double, "customUpdate" + g + "Time", "0.0");
         genHostScalar(definitionsVar, runnerVarDecl, Type::Double, "customUpdate" + g + "TransposeTime", "0.0");
+        genHostScalar(definitionsVar, runnerVarDecl, Type::Double, "customUpdate" + g + "RemapTime", "0.0");
     }
     
     // If timing is actually enabled

--- a/src/genn/genn/code_generator/modelSpecMerged.cc
+++ b/src/genn/genn/code_generator/modelSpecMerged.cc
@@ -65,14 +65,14 @@ using namespace GeNN::CodeGenerator;
 
     // If the current backend requires postsynaptic
     if (backend.isPostsynapticRemapRequired()) {
-        // Build map of (arbitrary) custom connectivity updates associated with each 
+        // Build map of (arbitrary) custom connectivity updates associated with name of each 
         // synapse group which requires postsynaptic remap in each custom update group!
-        std::map<std::pair<std::string, const SynapseGroupInternal*>, std::reference_wrapper<const CustomConnectivityUpdateInternal>> customConnectUpdateMap;
+        std::map<std::pair<std::string, std::string>, std::reference_wrapper<const CustomConnectivityUpdateInternal>> customConnectUpdateMap;
         for (const auto& c : getModel().getCustomConnectivityUpdates()) {
             const auto* sg = c.second.getSynapseGroup();
             if (c.second.canModifyConnectivity() && (sg->isPostSpikeRequired() || sg->isPostSpikeEventRequired())) {
                 customConnectUpdateMap.emplace(std::piecewise_construct,
-                                               std::forward_as_tuple(c.second.getUpdateGroupName(), sg), 
+                                               std::forward_as_tuple(c.second.getUpdateGroupName(), sg->getName()), 
                                                std::forward_as_tuple(c.second));
             }
         }

--- a/src/genn/genn/customConnectivityUpdate.cc
+++ b/src/genn/genn/customConnectivityUpdate.cc
@@ -100,6 +100,12 @@ bool CustomConnectivityUpdate::isPostVarInitRequired() const
                        [](const auto &v){ return !Utils::areTokensEmpty(v.second.getCodeTokens()); });
 }
 //------------------------------------------------------------------------
+bool CustomConnectivityUpdate::canModifyConnectivity() const
+{
+    return (Utils::isIdentifierReferenced("remove_synapse", getRowUpdateCodeTokens())
+            || Utils::isIdentifierReferenced("add_synapse", getRowUpdateCodeTokens()));
+}
+//------------------------------------------------------------------------
 CustomConnectivityUpdate::CustomConnectivityUpdate(const std::string &name, const std::string &updateGroupName, SynapseGroupInternal *synapseGroup,
                                                    const CustomConnectivityUpdateModels::Base *customConnectivityUpdateModel,
                                                    const std::map<std::string, Type::NumericValue> &params, const std::map<std::string, InitVarSnippet::Init> &varInitialisers,
@@ -325,6 +331,19 @@ boost::uuids::detail::sha1::digest_type CustomConnectivityUpdate::getHashDigest(
     for(const auto &v : getVarReferences()) {
         Utils::updateHash(v.second.getVarDims(), hash);
     }
+
+    return hash.get_digest();
+}
+//------------------------------------------------------------------------
+boost::uuids::detail::sha1::digest_type CustomConnectivityUpdate::getRemapHashDigest() const
+{
+    boost::uuids::detail::sha1 hash;
+
+    Utils::updateHash(getUpdateGroupName(), hash);
+
+    Utils::updateHash(getSynapseMatrixConnectivity(getSynapseGroup()->getMatrixType()), hash);
+    Type::updateHash(getSynapseGroup()->getSparseIndType(), hash);
+    
 
     return hash.get_digest();
 }

--- a/src/genn/genn/runtime/runtime.cc
+++ b/src/genn/genn/runtime/runtime.cc
@@ -452,22 +452,22 @@ void Runtime::allocate(std::optional<size_t> numRecordingTimesteps)
     for(const auto &c : getModel().getCustomConnectivityUpdates()) {
         // Allocate presynaptic variables
         LOGD_RUNTIME << "Allocating memory for custom connectivity update '" << c.first << "'";
+        const auto* sg = c.second.getSynapseGroup();
         createNeuronVarArrays<CustomConnectivityUpdatePreVarAdapter>(
-            &c.second, c.second.getSynapseGroup()->getSrcNeuronGroup()->getNumNeurons(),
+            &c.second, sg->getSrcNeuronGroup()->getNumNeurons(),
             batchSize, 1, false);
         
         // Allocate postsynaptic variables
         createNeuronVarArrays<CustomConnectivityUpdatePostVarAdapter>(
-            &c.second, c.second.getSynapseGroup()->getTrgNeuronGroup()->getNumNeurons(),
+            &c.second, sg->getTrgNeuronGroup()->getNumNeurons(),
             batchSize, 1, false);
 
         // Allocate variables
         createVarArrays<CustomConnectivityUpdateVarAdapter>(
                 &c.second, batchSize, false, 
-                [&c, this](const std::string&, VarAccessDim varDims)
+                [sg, this](const std::string&, VarAccessDim varDims)
                 {
-                    return getNumSynapseVarElements(varDims, m_Backend.get(), 
-                                                    *c.second.getSynapseGroup());
+                    return getNumSynapseVarElements(varDims, m_Backend.get(), *sg);
                 });
         
         // Create arrays for custom connectivity update extra global parameters
@@ -479,8 +479,7 @@ void Runtime::allocate(std::optional<size_t> numRecordingTimesteps)
 
         // If custom connectivity update group needs per-row RNGs
         if(Utils::isRNGRequired(c.second.getRowUpdateCodeTokens())) {
-            auto rng = m_Backend.get().createPopulationRNG(
-                c.second.getSynapseGroup()->getSrcNeuronGroup()->getNumNeurons());
+            auto rng = m_Backend.get().createPopulationRNG(sg->getSrcNeuronGroup()->getNumNeurons());
             if(rng) {
                 const auto r = m_CustomConnectivityUpdateArrays[&c.second].try_emplace("rowRNG", std::move(rng));
                 if(!r.second) {
@@ -648,6 +647,14 @@ void Runtime::allocate(std::optional<size_t> numRecordingTimesteps)
         addMergedArrays(m);
         pushMergedGroup(m);
     }
+
+    // Loop through merged custom connectivity remap update groups and add 
+    // Column length arrays associated with each synapse group to map
+    for (const auto &m : m_ModelMerged.get().getMergedCustomConnectivityRemapUpdateGroups()) {
+        auto &colLengthArrays = m_CustomUpdateColLengthArrays[m.getArchetype().getUpdateGroupName()];
+        std::transform(m.getGroups().cbegin(), m.getGroups().cend(), std::back_inserter(colLengthArrays),
+                       [this](auto r){ return getArray(*r.get().getSynapseGroup(), "colLength"); });
+    }
 }
 //----------------------------------------------------------------------------
 void Runtime::initialize()
@@ -683,6 +690,27 @@ void Runtime::stepTime()
 
     // Advance time
     m_Timestep++;
+}
+//----------------------------------------------------------------------------
+void Runtime::customUpdate(const std::string &name)
+{
+    // If there are column length arrays that must be zeroed 
+    // before making connectivity update in this group
+    auto colLengthArrays = m_CustomUpdateColLengthArrays.find(name);
+    if(colLengthArrays != m_CustomUpdateColLengthArrays.cend()) {
+        // Loop through arrays and zero
+        for(auto *a : colLengthArrays->second) {
+            if(m_Backend.get().isArrayDeviceObjectRequired()) {
+                a->memsetDeviceObject(0);
+            }
+            else {
+                a->memsetHostPointer(0);
+            }
+        }
+    }
+
+    // Run custom update
+    m_CustomUpdateFunctions.at(name)(getTimestep());
 }
 //----------------------------------------------------------------------------
 double Runtime::getTime() const

--- a/src/genn/genn/runtime/runtime.cc
+++ b/src/genn/genn/runtime/runtime.cc
@@ -637,6 +637,12 @@ void Runtime::allocate(std::optional<size_t> numRecordingTimesteps)
         pushMergedGroup(m);
     }
 
+    // Push custom connectivity remap update groups
+    for (const auto &m : m_ModelMerged.get().getMergedCustomConnectivityRemapUpdateGroups()) {
+        addMergedArrays(m);
+        pushMergedGroup(m);
+    }
+
     // Push custom connectivity host update groups
     for(const auto &m : m_ModelMerged.get().getMergedCustomConnectivityHostUpdateGroups()) {
         addMergedArrays(m);

--- a/tests/features/test_custom_connectivity_update.py
+++ b/tests/features/test_custom_connectivity_update.py
@@ -417,3 +417,135 @@ def test_custom_connectivity_update_delay(make_model, backend, precision):
     _check_connectivity(s_pop_2, lambda i: 63,
                         lambda i: _clear_bit(dense_bitarray, 60),
                         [(s_pop_2, "g", False)])
+
+@pytest.mark.parametrize("backend", ["single_threaded_cpu"])#, "cuda"])
+@pytest.mark.parametrize("precision", [types.Double, types.Float])
+def test_reverse_post_remap(make_model, backend, precision):
+    """
+    for j in range(16):
+        for i in range(4):
+            i_value = 1 << i
+            if ((j + 1) & i_value) != 0:
+                pre_inds.append(i)
+                post_inds.append(j)
+    """
+    decoder_model = create_sparse_connect_init_snippet(
+        "decoder",
+        row_build_code=
+        """
+        const unsigned int iValue = 1 << id_pre;
+        for(unsigned int j = 0; j < num_post; j++) {
+            if(((j + 1) & iValue) != 0) {
+                addSynapse(j);
+            }
+        }
+        """)
+    pre_reverse_model = create_neuron_model(
+        "pre_reverse",
+        var_name_types=[("x", "scalar")],
+        sim_code=
+        """
+        x = Isyn;
+        """)
+
+    static_pulse_reverse_post_model = create_weight_update_model(
+        "static_pulse_reverse_post",
+        post_spike_syn_code=
+        """
+        addToPre(g);
+        """,
+        var_name_types=[("g", "scalar", VarAccess.READ_ONLY)])
+    
+    remove_ones_model = create_custom_connectivity_update_model(
+        "remove_synapse",
+        row_update_code=
+        """
+        if(id_pre == 0) {
+            for_each_synapse {
+                remove_synapse();
+            }
+        }
+        """)
+        
+    model = make_model(precision, "test_reverse_post_modification", backend=backend)
+    model.dt = 1.0
+
+    # Add presynaptic populations to sum reverse input
+    sparse_pre_n_pop = model.add_neuron_population(
+        "SparsePost", 4, pre_reverse_model,
+        {}, {"x": 0.0})
+
+    # Create spike source array to generate one-hot pattern to decode
+    post_n_pop = model.add_neuron_population(
+        "SpikeSource", 16, "SpikeSourceArray",
+        {}, {"startSpike": np.arange(16), "endSpike": np.arange(1, 17)})
+    post_n_pop.extra_global_params["spikeTimes"].set_init_values(np.arange(16.0))
+
+    # Add connectivity
+    sparse_s_pop = model.add_synapse_population(
+        "SparseSynapse", "SPARSE",
+        sparse_pre_n_pop, post_n_pop,
+        init_weight_update(static_pulse_reverse_post_model, {}, {"g": 1.0}),
+        init_postsynaptic("DeltaCurr"),
+        init_sparse_connectivity(decoder_model))
+    
+    # Add custom update to remove a row
+    model.add_custom_connectivity_update(
+        "RemoveOnes", "RemoveSynapse", sparse_s_pop,
+        remove_ones_model)
+
+    # Build model and load
+    model.build()
+    model.load()
+
+    sparse_s_pop.pull_connectivity_from_device()
+    pre_inds = sparse_s_pop.get_sparse_pre_inds()
+    post_inds = sparse_s_pop.get_sparse_post_inds()
+    print("Before", pre_inds, post_inds)
+
+    # Simulate 16 timesteps
+    output_place_values = 2 ** np.arange(4)
+    while model.timestep < 16:
+        model.step_time()
+        
+        # Pull state variable
+        sparse_pre_n_pop.vars["x"].pull_from_device()
+
+        # Convert to binary mask
+        output_binary = np.isclose(np.ones(4), sparse_pre_n_pop.vars["x"].view)
+
+        # Sum up active place values
+        output_value = np.sum(output_place_values[output_binary])
+        print(output_value)
+        if output_value != (model.timestep - 1):
+            assert False, f"{sparse_pre_n_pop.name} decoding incorrect ({output_value} rather than {model.timestep - 1})"
+    
+    # Run update to remove synapses
+    model.custom_update("RemoveSynapse")
+    
+    sparse_s_pop.pull_connectivity_from_device()
+    pre_inds = sparse_s_pop.get_sparse_pre_inds()
+    post_inds = sparse_s_pop.get_sparse_post_inds()
+    print("After",pre_inds, post_inds)
+    
+    # Reset time and start spike
+    model.timestep = 0
+    post_n_pop.vars["startSpike"].view[:] = np.arange(16)
+    post_n_pop.vars["startSpike"].push_to_device()
+
+    # Simulate another 16 timesteps
+    while model.timestep < 16:
+        model.step_time()
+        
+        # Pull state variable
+        sparse_pre_n_pop.vars["x"].pull_from_device()
+
+        # Convert to binary mask
+        output_binary = np.isclose(np.ones(4), sparse_pre_n_pop.vars["x"].view)
+
+        # Sum up active place values
+        output_value = np.sum(output_place_values[output_binary])
+        print(output_value)
+        #if output_value != (model.timestep - 1):
+        #    assert False, f"{sparse_pre_n_pop.name} decoding incorrect ({output_value} rather than {model.timestep - 1})"
+    

--- a/tests/unit/customConnectivityUpdate.cc
+++ b/tests/unit/customConnectivityUpdate.cc
@@ -103,6 +103,22 @@ public:
 };
 IMPLEMENT_SNIPPET(RemoveSynapsePost);
 
+class CountPositive : public CustomConnectivityUpdateModels::Base
+{
+public:
+    DECLARE_SNIPPET(CountPositive);
+    
+    SET_VAR_REFS({{"g", "scalar"}});
+    SET_PRE_VARS({{"num", "unsigned int"}});
+    SET_ROW_UPDATE_CODE(
+        "for_each_synapse {\n"
+        "   if(g > 0.0) {\n"
+        "       num++;\n"
+        "   }\n"
+        "};\n");
+};
+IMPLEMENT_SNIPPET(CountPositive);
+
 class Cont : public WeightUpdateModels::Base
 {
 public:
@@ -128,6 +144,49 @@ public:
         "addToPost(g * V);\n");
 };
 IMPLEMENT_SNIPPET(ContPost);
+
+class STDPAdditive : public WeightUpdateModels::Base
+{
+public:
+    DECLARE_SNIPPET(STDPAdditive);
+
+    SET_PARAMS({
+      "tauPlus",  // 0 - Potentiation time constant (ms)
+      "tauMinus", // 1 - Depression time constant (ms)
+      "Aplus",    // 2 - Rate of potentiation
+      "Aminus",   // 3 - Rate of depression
+      "Wmin",     // 4 - Minimum weight
+      "Wmax"});   // 5 - Maximum weight
+
+    SET_VARS({{"g", "scalar"}});
+    SET_PRE_VARS({{"preTrace", "scalar"}});
+    SET_POST_VARS({{"postTrace", "scalar"}});
+
+    SET_PRE_SPIKE_CODE(
+        "scalar dt = t - st_pre;\n"
+        "preTrace = (preTrace * exp(-dt / tauPlus)) + 1.0;\n");
+
+    SET_POST_SPIKE_CODE(
+        "scalar dt = t - st_post;\n"
+        "postTrace = (postTrace * exp(-dt / tauMinus)) + 1.0;\n");
+
+    SET_PRE_SPIKE_SYN_CODE(
+        "addToPost(g);\n"
+        "scalar dt = t - st_post; \n"
+        "if (dt > 0) {\n"
+        "    const scalar timing = postTrace * exp(-dt / tauMinus);\n"
+        "    const scalar newWeight = g - (Aminus * timing);\n"
+        "    g = fmax(Wmin, newWeight);\n"
+        "}\n");
+    SET_POST_SPIKE_SYN_CODE(
+        "scalar dt = t - st_pre;\n"
+        "if (dt > 0) {\n"
+        "    const scalar timing = postTrace * exp(-dt / tauPlus);\n"
+        "    const scalar newWeight = g + (Aplus * timing);\n"
+        "    g = fmin(Wmax, newWeight);\n"
+        "}\n");
+};
+IMPLEMENT_SNIPPET(STDPAdditive);
 
 /*bool hasVarRef(const std::vector<Models::WUVarReference> &varRefs, const std::string &targetName, const std::string &varName)
 {
@@ -358,6 +417,94 @@ TEST(CustomConnectivityUpdate, CompareDifferentDependentVars)
     ASSERT_EQ(modelSpecMerged.getMergedCustomConnectivityUpdatePreInitGroups().size(), 0);
     ASSERT_EQ(modelSpecMerged.getMergedCustomConnectivityUpdatePostInitGroups().size(), 0);
     ASSERT_EQ(modelSpecMerged.getMergedCustomConnectivityUpdateSparseInitGroups().size(), 1);
+}
+//--------------------------------------------------------------------------
+TEST(CustomConnectivityUpdate, CompareRemap)
+{
+     ModelSpecInternal model;
+    
+    // Add two neuron group to model
+    ParamValues paramVals{{"a", 0.02}, {"b", 0.2}, {"c", -65.0}, {"d", 8.0}};   
+    VarValues varVals{{"V", 0.0}, {"U", 0.0}};
+    auto *pre = model.addNeuronPopulation<NeuronModels::Izhikevich>("Pre", 10, paramVals, varVals);
+    auto *post = model.addNeuronPopulation<NeuronModels::Izhikevich>("Post", 10, paramVals, varVals);
+
+    ParamValues stdpParams{{"tauPlus", 20.0}, {"tauMinus", 20.0}, {"Aplus", 0.001}, {"Aminus", -0.001}, {"Wmin", 0.0}, {"Wmax", 1.0}};
+    VarValues stdpVarValues{{"g", 0.5}};
+    VarValues stdpPreVarValues{{"preTrace", 0.0}};
+    VarValues stdpPostVarValues{{"postTrace", 0.0}};
+
+    VarValues countPreVarValues{{"num", 0}};
+
+    auto *staticSG =  model.addSynapsePopulation(
+        "StaticSynapse", SynapseMatrixType::SPARSE,
+        pre, post,
+        initWeightUpdate<WeightUpdateModels::StaticPulse>({}, {{"g", 1.0}}),
+        initPostsynaptic<PostsynapticModels::DeltaCurr>());
+
+    auto *stdpSG1 =  model.addSynapsePopulation(
+        "STDPSynapse1", SynapseMatrixType::SPARSE,
+        pre, post,
+        initWeightUpdate<STDPAdditive>(stdpParams, stdpVarValues, stdpPreVarValues, stdpPostVarValues),
+        initPostsynaptic<PostsynapticModels::DeltaCurr>());
+
+    auto *stdpSG2 =  model.addSynapsePopulation(
+        "STDPSynapse2", SynapseMatrixType::SPARSE,
+        pre, post,
+        initWeightUpdate<STDPAdditive>(stdpParams, stdpVarValues, stdpPreVarValues, stdpPostVarValues),
+        initPostsynaptic<PostsynapticModels::DeltaCurr>());
+    
+    // Create  custom updates to passively count synapse in static and STDP - neither should result in remap
+    auto *staticCountCCU = model.addCustomConnectivityUpdate<CountPositive>("StaticCountCCU", "Count", staticSG,
+                                                                       {}, {}, countPreVarValues, {},
+                                                                       {{"g", createWUVarRef(staticSG, "g")}});
+    auto *stdp1CountCCU = model.addCustomConnectivityUpdate<CountPositive>("STDP1CountCCU", "Count", stdpSG1,
+                                                                      {}, {}, countPreVarValues, {},
+                                                                      {{"g", createWUVarRef(stdpSG1, "g")}});
+    
+    // **TODO** narrow index
+
+    // Create custom update to remove connections from static synapse - no need for remap
+    auto *staticRemove1CCU = model.addCustomConnectivityUpdate<RemoveSynapse>("StaticRemove1CCU", "Remove1", staticSG,
+                                                                             {}, {{"a", 1.0}});
+
+    // Create two custom updates to remove connections from STDP sg 1 - needs one remap
+    auto *stdp1Remove1CCU1 = model.addCustomConnectivityUpdate<RemoveSynapse>("STDP1Remove1CCU1", "Remove1", stdpSG1,
+                                                                             {}, {{"a", 1.0}});
+    auto *stdp1Remove1CCU2 = model.addCustomConnectivityUpdate<RemoveSynapse>("STDP1Remove1CCU2", "Remove1", stdpSG1,
+                                                                            {}, {{"a", 1.0}});
+
+    // Create custom update to remove connections from STDP sg 1 in different group - needs one remap
+    auto *stdp1Remove2CCU = model.addCustomConnectivityUpdate<RemoveSynapse>("STDP1Remove2CCU", "Remove2", stdpSG1,
+                                                                             {}, {{"a", 1.0}});
+    
+    // Create custom update to remove connections from STDP sg 2 in different group - needs one remap
+    auto *stdp2Remove1CCU = model.addCustomConnectivityUpdate<RemoveSynapse>("STDP2Remove1CCU", "Remove1", stdpSG2,
+                                                                             {}, {{"a", 1.0}});
+    //auto *ccu1 = model.addCustomConnectivityUpdate<RemoveSynapse>("CustomConnectivityUpdate1", "Test2", sg1,
+    //                                                              {}, {{"a", 1.0}});
+    model.finalise();
+
+    // Create a backend
+    CodeGenerator::SingleThreadedCPU::Preferences preferences;
+    CodeGenerator::SingleThreadedCPU::Backend backend(preferences);
+
+    // Merge model
+    CodeGenerator::ModelSpecMerged modelSpecMerged(backend, model);
+
+    // Check correct groups are merged - ones in remove 1 and remove 2
+    ASSERT_EQ(modelSpecMerged.getMergedCustomConnectivityRemapUpdateGroups().size(), 2);
+
+     // Find which merged group is the one containing 2 groups i.e. the 2 groups with unique synapse groups in remove1 group
+    const auto remove1MergedUpdateGroup = std::find_if(modelSpecMerged.getMergedCustomConnectivityRemapUpdateGroups().cbegin(), modelSpecMerged.getMergedCustomConnectivityRemapUpdateGroups().cend(),
+                                                       [](const auto &ng) { return (ng.getGroups().size() == 2); });
+    
+    // Check update group name is correct
+    ASSERT_EQ(remove1MergedUpdateGroup->getArchetype().getUpdateGroupName(), "Remove1");
+
+    // **TODO** check synapse groups are correct
+
+    // Check OTHER update group name is "Remove2"
 }
 //--------------------------------------------------------------------------
 TEST(CustomConnectivityUpdate, BitmaskConnectivity)


### PR DESCRIPTION
When combining STDP with a postsynaptic spike-driven and custom connectivity, there was previously a problem - the transpose ragged matrix data structure (``remap`` and ``colLength``) wasn't being updated when connectivity changes were made.

Sadly the transpose matrix can't be efficiently updated at the same time as the forward matrix so we simply re-generate it after the custom connectivity update is complete using the same code that's already used to build the transpose matrices at initialisation time. Figuring out exactly which synapse groups transpose matrices need updating is a little fiddly but I have unit tested this reasonably well and added a feature test for the whole system. Before re-generating the transpose matrix, ``colLength`` needs to be zeroed - the most _efficient_ approach would be to add yet another kernel which does all of these in parallel but that's a lot of effort so instead I just implemented this in the runtime.