### PR TITLE
Access to postsynaptic variables with heterogeneous delay

### DIFF
--- a/include/genn/genn/code_generator/environment.h
+++ b/include/genn/genn/code_generator/environment.h
@@ -704,7 +704,7 @@ public:
             const auto resolvedType = v.type.resolve(this->getGroup().getTypeContext());
             const auto qualifiedType = (readOnly || (getVarAccessMode(v.access) & VarAccessModeAttribute::READ_ONLY)) ? resolvedType.addConst() : resolvedType;
             const auto name = hidden ? ("_" + v.name) : v.name;
-            if(archetypeAdaptor.isVarDelayedInSynCode(v.name)) {
+            if(archetypeAdaptor.isVarHeterogeneouslyDelayed(v.name)) {
                 addField(Type::getArraySubscript(resolvedType), name,
                          resolvedType.createPointer(), v.name + fieldSuffix,
                          [v](auto &runtime, const auto &g, size_t) 
@@ -765,7 +765,7 @@ public:
             const auto resolvedType = v.type.resolve(this->getGroup().getTypeContext());
             const auto qualifiedType = (readOnly || (v.access & VarAccessModeAttribute::READ_ONLY)) ? resolvedType.addConst() : resolvedType;
             const auto name = hidden ? ("_" + v.name) : v.name;
-            if(archetypeAdaptor.isVarDelayedInSynCode(v.name)) {
+            if(archetypeAdaptor.isVarHeterogeneouslyDelayed(v.name)) {
                 addField(Type::getArraySubscript(resolvedType), name,
                          resolvedType.createPointer(), v.name + fieldSuffix,
                          [v](auto &runtime, const auto &g, size_t) 

--- a/include/genn/genn/code_generator/environment.h
+++ b/include/genn/genn/code_generator/environment.h
@@ -714,6 +714,39 @@ public:
         }
     }
 
+    /*(template<typename A>
+    void addVarRefsHet(GetVarRefIndexFn<A> getIndexFn,  const std::string &fieldSuffix = "",
+                       bool readOnly = false, bool hidden = false)
+    {
+        // Loop through variable references
+        const A archetypeAdaptor(this->getGroup().getArchetype());
+        for(const auto &v : archetypeAdaptor.getDefs()) {
+            // If variable access is read-only, qualify type with const
+            const auto resolvedType = v.type.resolve(this->getGroup().getTypeContext());
+            const auto qualifiedType = (readOnly || (v.access & VarAccessModeAttribute::READ_ONLY)) ? resolvedType.addConst() : resolvedType;
+            
+            const auto name = hidden ? ("_" + v.name) : v.name;
+            if(het) {
+                addField(Type::getArraySubscript(resolvedType), name,
+                         resolvedType.createPointer(), v.name + fieldSuffix,
+                         [v](auto &runtime, const auto &g, size_t) 
+                         { 
+                             return A(g).getInitialisers().at(v.name).getTargetArray(runtime); 
+                         },
+                         getIndexFn(v.access, archetypeAdaptor.getInitialisers().at(v.name)));
+            }
+            else {
+                addField(qualifiedType, name,
+                         resolvedType.createPointer(), v.name + fieldSuffix,
+                         [v](auto &runtime, const auto &g, size_t) 
+                         { 
+                             return A(g).getInitialisers().at(v.name).getTargetArray(runtime); 
+                         },
+                         getIndexFn(v.access, archetypeAdaptor.getInitialisers().at(v.name)));
+            }
+        }
+    }*/
+
     template<typename A>
     void addVarRefs(const std::string &indexSuffix, const std::string &fieldSuffix = "",
                     bool readOnly = false, bool hidden = false)

--- a/include/genn/genn/code_generator/environment.h
+++ b/include/genn/genn/code_generator/environment.h
@@ -714,9 +714,9 @@ public:
         }
     }
 
-    /*(template<typename A>
-    void addVarRefsHet(GetVarRefIndexFn<A> getIndexFn,  const std::string &fieldSuffix = "",
-                       bool readOnly = false, bool hidden = false)
+    template<typename A>
+    void addVarRefsHet(GetVarRefIndexFn<A> getIndexFn, GetVarRefIndexFn<A> getDelayedIndexFn, 
+                       const std::string &fieldSuffix = "", bool readOnly = false, bool hidden = false)
     {
         // Loop through variable references
         const A archetypeAdaptor(this->getGroup().getArchetype());
@@ -726,14 +726,14 @@ public:
             const auto qualifiedType = (readOnly || (v.access & VarAccessModeAttribute::READ_ONLY)) ? resolvedType.addConst() : resolvedType;
             
             const auto name = hidden ? ("_" + v.name) : v.name;
-            if(het) {
+            if(archetypeAdaptor.isVarDelayedInSynCode(v.name)) {
                 addField(Type::getArraySubscript(resolvedType), name,
                          resolvedType.createPointer(), v.name + fieldSuffix,
                          [v](auto &runtime, const auto &g, size_t) 
                          { 
                              return A(g).getInitialisers().at(v.name).getTargetArray(runtime); 
                          },
-                         getIndexFn(v.access, archetypeAdaptor.getInitialisers().at(v.name)));
+                         getDelayedIndexFn(v.access, archetypeAdaptor.getInitialisers().at(v.name)));
             }
             else {
                 addField(qualifiedType, name,
@@ -745,7 +745,7 @@ public:
                          getIndexFn(v.access, archetypeAdaptor.getInitialisers().at(v.name)));
             }
         }
-    }*/
+    }
 
     template<typename A>
     void addVarRefs(const std::string &indexSuffix, const std::string &fieldSuffix = "",

--- a/include/genn/genn/code_generator/synapseUpdateGroupMerged.h
+++ b/include/genn/genn/code_generator/synapseUpdateGroupMerged.h
@@ -89,6 +89,9 @@ public:
         return ((batchSize == 1) ? "" : "$(_pre_batch_offset) + ") + index;
     }
 
+    std::string getPostVarHetDelayIndex(unsigned int batchSize, VarAccessDim varDims,
+                                        const std::string &index) const;
+
     std::string getSynVarIndex(unsigned int batchSize, VarAccessDim varDims, const std::string &index) const;
     std::string getKernelVarIndex(unsigned int batchSize, VarAccessDim varDims, const std::string &index) const;
     

--- a/include/genn/genn/code_generator/synapseUpdateGroupMerged.h
+++ b/include/genn/genn/code_generator/synapseUpdateGroupMerged.h
@@ -54,16 +54,6 @@ public:
         return getPostVarIndex(getArchetype().getTrgNeuronGroup()->isDelayRequired(), batchSize, varDims, index);
     }
 
-    std::string getPreWUVarIndex(unsigned int batchSize, VarAccessDim varDims, const std::string &index) const
-    {
-        return getPreVarIndex(getArchetype().getAxonalDelaySteps() != 0, batchSize, varDims, index);
-    }
-    
-    std::string getPostWUVarIndex(unsigned int batchSize, VarAccessDim varDims, const std::string &index) const
-    {
-        return getPostVarIndex(getArchetype().getBackPropDelaySteps() != 0, batchSize, varDims, index);
-    }
-
     std::string getPostDenDelayIndex(unsigned int batchSize, const std::string &index, const std::string &offset) const;
 
     std::string getPreVarIndex(bool delay, unsigned int batchSize, VarAccessDim varDims, const std::string &index) const

--- a/include/genn/genn/code_generator/synapseUpdateGroupMerged.h
+++ b/include/genn/genn/code_generator/synapseUpdateGroupMerged.h
@@ -41,18 +41,8 @@ public:
     //! Should the Toeplitz connectivity initialization parameter be implemented heterogeneously?
     bool isToeplitzConnectivityInitDerivedParamHeterogeneous(const std::string &paramName) const;
 
-    std::string getPreSlot(unsigned int batchSize) const;
-    std::string getPostSlot(unsigned int batchSize) const;
-
-    std::string getPreVarIndex(unsigned int batchSize, VarAccessDim varDims, const std::string &index) const
-    {
-        return getPreVarIndex(getArchetype().getSrcNeuronGroup()->isDelayRequired(), batchSize, varDims, index);
-    }
-    
-    std::string getPostVarIndex(unsigned int batchSize, VarAccessDim varDims, const std::string &index) const
-    {
-        return getPostVarIndex(getArchetype().getTrgNeuronGroup()->isDelayRequired(), batchSize, varDims, index);
-    }
+    std::string getPreSlot(bool delay, unsigned int batchSize) const;
+    std::string getPostSlot(bool delay, unsigned int batchSize) const;
 
     std::string getPostDenDelayIndex(unsigned int batchSize, const std::string &index, const std::string &offset) const;
 

--- a/include/genn/genn/customConnectivityUpdateInternal.h
+++ b/include/genn/genn/customConnectivityUpdateInternal.h
@@ -85,13 +85,13 @@ public:
     //----------------------------------------------------------------------------
     VarLocation getLoc(const std::string &varName) const{ return m_CU.getPreVarLocation(varName); }
 
-    std::vector<Models::Base::Var> getDefs() const{ return m_CU.getModel()->getPreVars(); }
+    auto getDefs() const{ return m_CU.getModel()->getPreVars(); }
 
-    const std::map<std::string, InitVarSnippet::Init> &getInitialisers() const{ return m_CU.getPreVarInitialisers(); }
+    const auto &getInitialisers() const{ return m_CU.getPreVarInitialisers(); }
 
-    bool isVarDelayed(const std::string &) const { return false; }
+    bool isVarDelayed(const std::string&) const { return false; }
 
-    const CustomConnectivityUpdate &getTarget() const{ return m_CU; }
+    const auto &getTarget() const{ return m_CU; }
 
     VarAccessDim getVarDims(const Models::Base::Var &var) const{ return getVarAccessDim(var.access); }
 
@@ -116,13 +116,13 @@ public:
     //----------------------------------------------------------------------------
     VarLocation getLoc(const std::string &varName) const{ return m_CU.getPostVarLocation(varName); }
 
-    std::vector<Models::Base::Var> getDefs() const{ return m_CU.getModel()->getPostVars(); }
+    auto getDefs() const{ return m_CU.getModel()->getPostVars(); }
 
-    const std::map<std::string, InitVarSnippet::Init> &getInitialisers() const{ return m_CU.getPostVarInitialisers(); }
+    const auto &getInitialisers() const{ return m_CU.getPostVarInitialisers(); }
 
-    bool isVarDelayed(const std::string &) const { return false; }
+    bool isVarDelayed(const std::string&) const { return false; }
 
-    const CustomConnectivityUpdate &getTarget() const{ return m_CU; }
+    const auto &getTarget() const{ return m_CU; }
 
     VarAccessDim getVarDims(const Models::Base::Var &var) const{ return getVarAccessDim(var.access); }
     

--- a/include/genn/genn/gennUtils.h
+++ b/include/genn/genn/gennUtils.h
@@ -46,6 +46,9 @@ GENN_EXPORT bool areTokensEmpty(const std::vector<Transpiler::Token> &tokens);
 //! Checks whether the sequence of token references a given identifier
 GENN_EXPORT bool isIdentifierReferenced(const std::string &identifierName, const std::vector<Transpiler::Token> &tokens);
 
+//! Checks whether the sequence of tokens references a given identifier with a delay
+GENN_EXPORT bool isIdentifierDelayed(const std::string &identifierName, const std::vector<Transpiler::Token> &tokens);
+
 //! Checks whether the sequence of token includes an RNG function identifier
 GENN_EXPORT bool isRNGRequired(const std::vector<Transpiler::Token> &tokens);
 

--- a/include/genn/genn/neuronGroup.h
+++ b/include/genn/genn/neuronGroup.h
@@ -154,6 +154,9 @@ protected:
     // Set a variable as requiring queueing
     void setVarQueueRequired(const std::string &varName){ m_VarQueueRequired.insert(varName); }
 
+    void setSpikeQueueRequired(){ m_SpikeQueueRequired = true; }
+    void setSpikeEventQueueRequired(){ m_SpikeEventQueueRequired = true; }
+
     void addInSyn(SynapseGroupInternal *synapseGroup){ m_InSyn.push_back(synapseGroup); }
     void addOutSyn(SynapseGroupInternal *synapseGroup){ m_OutSyn.push_back(synapseGroup); }
 
@@ -224,6 +227,13 @@ protected:
 
     bool isVarQueueRequired(const std::string &var) const;
 
+    bool isSpikeQueueRequired() const{ return m_SpikeQueueRequired; }
+
+    bool isSpikeEventQueueRequired() const{ return m_SpikeEventQueueRequired; }
+
+    bool isSpikeDelayRequired() const{ return isDelayRequired() && isSpikeQueueRequired(); }
+    bool isSpikeEventDelayRequired() const{ return isDelayRequired() && isSpikeEventQueueRequired(); }
+
     //! Updates hash with neuron group
     /*! \note this can only be called after model is finalized */
     boost::uuids::detail::sha1::digest_type getHashDigest() const;
@@ -272,6 +282,12 @@ private:
 
     //! Set of names of variable requiring queueing
     std::set<std::string> m_VarQueueRequired;
+
+    //! Is queueing required for spikes?
+    bool m_SpikeQueueRequired;
+
+    //! Is queueing required for spike-like events?
+    bool m_SpikeEventQueueRequired;
     
     //! Should zero-copy memory (if available) be used 
     //! for spike and spike-like event recording?

--- a/include/genn/genn/neuronGroupInternal.h
+++ b/include/genn/genn/neuronGroupInternal.h
@@ -23,6 +23,8 @@ public:
     
     using NeuronGroup::checkNumDelaySlots;
     using NeuronGroup::setVarQueueRequired;
+    using NeuronGroup::setSpikeQueueRequired;
+    using NeuronGroup::setSpikeEventQueueRequired;
     using NeuronGroup::addInSyn;
     using NeuronGroup::addOutSyn;
     using NeuronGroup::finalise;
@@ -49,6 +51,10 @@ public:
     using NeuronGroup::isRecordingEnabled;
     using NeuronGroup::isVarInitRequired;
     using NeuronGroup::isVarQueueRequired;
+    using NeuronGroup::isSpikeQueueRequired;
+    using NeuronGroup::isSpikeEventQueueRequired;
+    using NeuronGroup::isSpikeDelayRequired;
+    using NeuronGroup::isSpikeEventDelayRequired;
     using NeuronGroup::getHashDigest;
     using NeuronGroup::getInitHashDigest;
     using NeuronGroup::getSpikeQueueUpdateHashDigest;

--- a/include/genn/genn/synapseGroup.h
+++ b/include/genn/genn/synapseGroup.h
@@ -333,6 +333,12 @@ protected:
     //! Is this synapse group's output dendritically delayed?
     bool isDendriticOutputDelayRequired() const;
 
+    //! Is the named postsynaptic weight update model variable heterogeneously delayed?
+    bool isWUPostVarHeterogeneouslyDelayed(const std::string &var) const;
+
+    //! Are any postsynaptic weight update model variable heterogeneously delayed?
+    bool areAnyWUPostVarHeterogeneouslyDelayed() const;
+
     //! Does this synapse group provide presynaptic output?
     bool isPresynapticOutputRequired() const; 
 
@@ -503,6 +509,10 @@ private:
     //! Initialiser used for creating toeplitz connectivity
     InitToeplitzConnectivitySnippet::Init m_ToeplitzConnectivityInitialiser;
 
+    //! Set of names of postsynaptic weight update 
+    //! model variables which are heterogeneously delayed
+    std::set<std::string> m_HeterogeneouslyDelayedWUPostVars;
+    
     //! Location of individual per-synapse state variables.
     /*! This is ignored for simulations on hardware with a single memory space */
     LocationContainer m_WUVarLocation;

--- a/include/genn/genn/synapseGroup.h
+++ b/include/genn/genn/synapseGroup.h
@@ -1,6 +1,7 @@
 #pragma once
 
 // Standard includes
+#include <optional>
 #include <map>
 #include <string>
 #include <vector>
@@ -150,7 +151,7 @@ public:
     unsigned int getAxonalDelaySteps() const{ return m_AxonalDelaySteps; }
     unsigned int getMaxConnections() const{ return m_MaxConnections; }
     unsigned int getMaxSourceConnections() const{ return m_MaxSourceConnections; }
-    unsigned int getMaxDendriticDelayTimesteps() const{ return m_MaxDendriticDelayTimesteps; }
+    unsigned int getMaxDendriticDelayTimesteps() const{ return m_MaxDendriticDelayTimesteps.value_or(1); }
     SynapseMatrixType getMatrixType() const{ return m_MatrixType; }
     const auto &getKernelSize() const { return m_KernelSize; }
     size_t getKernelSizeFlattened() const;
@@ -465,7 +466,7 @@ private:
     unsigned int m_MaxSourceConnections;
 
     //! Maximum dendritic delay timesteps supported for synapses in this population
-    unsigned int m_MaxDendriticDelayTimesteps;
+    std::optional<unsigned int> m_MaxDendriticDelayTimesteps;
 
     //! Kernel size 
     std::vector<unsigned int> m_KernelSize;

--- a/include/genn/genn/synapseGroup.h
+++ b/include/genn/genn/synapseGroup.h
@@ -330,8 +330,8 @@ protected:
     //! model been fused with those from other synapse groups?
     bool isWUPostModelFused() const { return m_FusedWUPostTarget != nullptr; }
 
-    //! Does this synapse group require dendritic delay?
-    bool isDendriticDelayRequired() const;
+    //! Is this synapse group's output dendritically delayed?
+    bool isDendriticOutputDelayRequired() const;
 
     //! Does this synapse group provide presynaptic output?
     bool isPresynapticOutputRequired() const; 

--- a/include/genn/genn/synapseGroupInternal.h
+++ b/include/genn/genn/synapseGroupInternal.h
@@ -59,6 +59,8 @@ public:
     using SynapseGroup::isWUPreModelFused;
     using SynapseGroup::isWUPostModelFused;
     using SynapseGroup::isDendriticOutputDelayRequired;
+    using SynapseGroup::isWUPostVarHeterogeneouslyDelayed;
+    using SynapseGroup::areAnyWUPostVarHeterogeneouslyDelayed;
     using SynapseGroup::isPresynapticOutputRequired; 
     using SynapseGroup::isPostsynapticOutputRequired;
     using SynapseGroup::isProceduralConnectivityRNGRequired;
@@ -247,7 +249,7 @@ public:
 
     const SynapseGroup &getTarget() const{ return m_SG.getFusedWUPostTarget(); }
 
-    bool isVarDelayed(const std::string &name) const{ return (m_SG.getBackPropDelaySteps() != 0) || m_SG.getWUInitialiser().isVarHeterogeneouslyDelayedInSynCode(name); }
+    bool isVarDelayed(const std::string &name) const{ return (m_SG.getBackPropDelaySteps() != 0) || m_SG.isWUPostVarHeterogeneouslyDelayed(name); }
 
     VarAccessDim getVarDims(const Models::Base::Var &var) const{ return getVarAccessDim(var.access); }
 

--- a/include/genn/genn/synapseGroupInternal.h
+++ b/include/genn/genn/synapseGroupInternal.h
@@ -249,6 +249,8 @@ public:
 
     bool isVarDelayed(const std::string&) const{ return (m_SG.getBackPropDelaySteps() != 0); }
 
+    bool isVarDelayedInSynCode(const std::string &name) const{ return m_SG.getWUInitialiser().isIdentifierDelayedInSynCode(name); }
+
     VarAccessDim getVarDims(const Models::Base::Var &var) const{ return getVarAccessDim(var.access); }
 
 private:
@@ -323,6 +325,8 @@ public:
     auto getDefs() const{ return m_SG.getWUInitialiser().getSnippet()->getPostNeuronVarRefs(); }
 
     const auto &getInitialisers() const{ return m_SG.getWUInitialiser().getPostNeuronVarReferences(); }
+
+    bool isVarDelayedInSynCode(const std::string &name) const{ return m_SG.getWUInitialiser().isIdentifierDelayedInSynCode(name); }
 
 private:
     //----------------------------------------------------------------------------

--- a/include/genn/genn/synapseGroupInternal.h
+++ b/include/genn/genn/synapseGroupInternal.h
@@ -58,7 +58,7 @@ public:
     using SynapseGroup::isPreSpikeFused;
     using SynapseGroup::isWUPreModelFused;
     using SynapseGroup::isWUPostModelFused;
-    using SynapseGroup::isDendriticDelayRequired;
+    using SynapseGroup::isDendriticOutputDelayRequired;
     using SynapseGroup::isPresynapticOutputRequired; 
     using SynapseGroup::isPostsynapticOutputRequired;
     using SynapseGroup::isProceduralConnectivityRNGRequired;

--- a/include/genn/genn/synapseGroupInternal.h
+++ b/include/genn/genn/synapseGroupInternal.h
@@ -247,9 +247,7 @@ public:
 
     const SynapseGroup &getTarget() const{ return m_SG.getFusedWUPostTarget(); }
 
-    bool isVarDelayed(const std::string &name) const{ return (m_SG.getBackPropDelaySteps() != 0) || isVarHeterogeneouslyDelayed(name); }
-
-    bool isVarHeterogeneouslyDelayed(const std::string &name) const{ return m_SG.getWUInitialiser().isVarHeterogeneouslyDelayedInSynCode(name); }
+    bool isVarDelayed(const std::string &name) const{ return (m_SG.getBackPropDelaySteps() != 0) || m_SG.getWUInitialiser().isVarHeterogeneouslyDelayedInSynCode(name); }
 
     VarAccessDim getVarDims(const Models::Base::Var &var) const{ return getVarAccessDim(var.access); }
 
@@ -325,8 +323,6 @@ public:
     auto getDefs() const{ return m_SG.getWUInitialiser().getSnippet()->getPostNeuronVarRefs(); }
 
     const auto &getInitialisers() const{ return m_SG.getWUInitialiser().getPostNeuronVarReferences(); }
-
-    bool isVarHeterogeneouslyDelayed(const std::string &name) const{ return m_SG.getWUInitialiser().isVarHeterogeneouslyDelayedInSynCode(name); }
 
 private:
     //----------------------------------------------------------------------------

--- a/include/genn/genn/synapseGroupInternal.h
+++ b/include/genn/genn/synapseGroupInternal.h
@@ -247,9 +247,9 @@ public:
 
     const SynapseGroup &getTarget() const{ return m_SG.getFusedWUPostTarget(); }
 
-    bool isVarDelayed(const std::string&) const{ return (m_SG.getBackPropDelaySteps() != 0); }
+    bool isVarDelayed(const std::string &name) const{ return (m_SG.getBackPropDelaySteps() != 0) || isVarHeterogeneouslyDelayed(name); }
 
-    bool isVarDelayedInSynCode(const std::string &name) const{ return m_SG.getWUInitialiser().isIdentifierDelayedInSynCode(name); }
+    bool isVarHeterogeneouslyDelayed(const std::string &name) const{ return m_SG.getWUInitialiser().isVarHeterogeneouslyDelayedInSynCode(name); }
 
     VarAccessDim getVarDims(const Models::Base::Var &var) const{ return getVarAccessDim(var.access); }
 
@@ -326,7 +326,7 @@ public:
 
     const auto &getInitialisers() const{ return m_SG.getWUInitialiser().getPostNeuronVarReferences(); }
 
-    bool isVarDelayedInSynCode(const std::string &name) const{ return m_SG.getWUInitialiser().isIdentifierDelayedInSynCode(name); }
+    bool isVarHeterogeneouslyDelayed(const std::string &name) const{ return m_SG.getWUInitialiser().isVarHeterogeneouslyDelayedInSynCode(name); }
 
 private:
     //----------------------------------------------------------------------------

--- a/include/genn/genn/type.h
+++ b/include/genn/genn/type.h
@@ -426,6 +426,12 @@ inline ResolvedType getAddToPrePost(ResolvedType weightType) { return ResolvedTy
 //! Get type to add a weight type with delay
 inline ResolvedType getAddToPrePostDelay(ResolvedType weightType) { return ResolvedType::createFunction(Void, {weightType, Uint32}); }
 
+//! Get type for array subscript overload functions
+inline ResolvedType getArraySubscript(ResolvedType valueType) { return ResolvedType::createFunction(valueType, {Int32}, FunctionFlags::ARRAY_SUBSCRIPT_OVERRIDE); }
+
+//----------------------------------------------------------------------------
+// Type helper functions
+//----------------------------------------------------------------------------
 //! Apply C type promotion rules to numeric type
 GENN_EXPORT ResolvedType getPromotedType(const ResolvedType &type);
 

--- a/include/genn/genn/type.h
+++ b/include/genn/genn/type.h
@@ -416,14 +416,15 @@ inline static const ResolvedType Void = ResolvedType();
 //----------------------------------------------------------------------------
 // Standard function types
 //----------------------------------------------------------------------------
-inline static const ResolvedType AddToPre = ResolvedType::createFunction(Void, {Uint32});
-inline static const ResolvedType AddToPost = ResolvedType::createFunction(Void, {Uint32});
-inline static const ResolvedType AddToPostDenDelay = ResolvedType::createFunction(Void, {Uint32, Uint32});
 inline static const ResolvedType AllocatePushPullEGP = ResolvedType::createFunction(Void, {Uint32});
 inline static const ResolvedType PushPull = ResolvedType::createFunction(Void, {});
-
-
 inline static const ResolvedType Assert = ResolvedType::createFunction(Void, {Bool});
+
+//! Get type to add a weight type
+inline ResolvedType getAddToPrePost(ResolvedType weightType) { return ResolvedType::createFunction(Void, {weightType}); }
+
+//! Get type to add a weight type with delay
+inline ResolvedType getAddToPrePostDelay(ResolvedType weightType) { return ResolvedType::createFunction(Void, {weightType, Uint32}); }
 
 //! Apply C type promotion rules to numeric type
 GENN_EXPORT ResolvedType getPromotedType(const ResolvedType &type);

--- a/include/genn/genn/type.h
+++ b/include/genn/genn/type.h
@@ -29,23 +29,23 @@
 #define CREATE_NUMERIC(TYPE, RANK, FFI_TYPE, L_SUFFIX) ResolvedType::createNumeric<TYPE>(#TYPE, RANK, FFI_TYPE, L_SUFFIX)
 
 //----------------------------------------------------------------------------
-// GeNN::Type::Qualifier
+// GeNN::Type::Flags
 //----------------------------------------------------------------------------
 namespace GeNN::Type
 {
-enum class Qualifier : unsigned int
+enum class Flags : unsigned int
 {
-    CONSTANT   = (1 << 0)
+    INDEXABLE   = (1 << 0)  //! [] operator can be applied to this type
 };
 
-inline bool operator & (Qualifier a, Qualifier b)
+inline bool operator & (Flags a, Flags b)
 {
     return (static_cast<unsigned int>(a) & static_cast<unsigned int>(b)) != 0;
 }
 
-inline Qualifier operator | (Qualifier a, Qualifier b)
+inline Flags operator | (Flags a, Flags b)
 {
-    return static_cast<Qualifier>(static_cast<unsigned int>(a) | static_cast<unsigned int>(b));
+    return static_cast<Flags>(static_cast<unsigned int>(a) | static_cast<unsigned int>(b));
 }
 
 //----------------------------------------------------------------------------
@@ -247,24 +247,24 @@ struct GENN_EXPORT ResolvedType
         }
     };
     
-    ResolvedType(const Value &value, Qualifier qualifiers = Qualifier{0})
-    :   qualifiers(qualifiers), detail(value)
+    ResolvedType(const Value &value, bool isConst = false)
+    :   isConst(isConst), detail(value)
     {}
-    ResolvedType(const Pointer &pointer, Qualifier qualifiers = Qualifier{0})
-    :   qualifiers(qualifiers), detail(pointer)
+    ResolvedType(const Pointer &pointer, bool isConst = false)
+    :   isConst(isConst), detail(pointer)
     {}
     ResolvedType(const Function &function)
-    :   qualifiers(Qualifier{0}), detail(function)
+    :   isConst(false), detail(function)
     {}
-    ResolvedType(const ResolvedType &other, Qualifier qualifiers) : qualifiers(qualifiers), detail(other.detail)
+    ResolvedType(const ResolvedType &other, bool isConst) : isConst(isConst), detail(other.detail)
     {}
-    explicit ResolvedType(Qualifier qualifiers = Qualifier{0}) : qualifiers(qualifiers), detail(std::monostate{})
+    explicit ResolvedType(bool isConst = false) : isConst(isConst), detail(std::monostate{})
     {}
 
     //------------------------------------------------------------------------
     // Members
     //------------------------------------------------------------------------
-    Qualifier qualifiers;
+    bool isConst;
 
     std::variant<Value, Pointer, Function, std::monostate> detail;
     
@@ -283,19 +283,16 @@ struct GENN_EXPORT ResolvedType
     const Function &getFunction() const{ return std::get<Function>(detail); }
     const Numeric &getNumeric() const{ return *getValue().numeric; }
 
-    ResolvedType addQualifier(Qualifier qualifier) const{ return ResolvedType(*this, qualifiers | qualifier); }
-    ResolvedType removeQualifiers() const{ return ResolvedType(*this, Qualifier{0}); }
-    ResolvedType addConst() const{ return addQualifier(Qualifier::CONSTANT); }
-    bool hasQualifier(Qualifier qualifier) const{ return (qualifiers & qualifier); }
-
+    ResolvedType addConst() const{ return ResolvedType(*this, true); }
+    ResolvedType removeConst() const{ return ResolvedType(*this, false); }
     std::string getName() const;
     size_t getSize(size_t pointerBytes) const;
 
     ffi_type *getFFIType() const;
 
-    ResolvedType createPointer(Qualifier qualifiers = Qualifier{0}) const
+    ResolvedType createPointer(bool isConst = false) const
     {
-        return ResolvedType(Pointer{*this}, qualifiers);
+        return ResolvedType(Pointer{*this}, isConst);
     }
 
     //------------------------------------------------------------------------
@@ -303,17 +300,17 @@ struct GENN_EXPORT ResolvedType
     //------------------------------------------------------------------------
     bool operator == (const ResolvedType &other) const
     {
-        return (std::tie(qualifiers, detail) == std::tie(other.qualifiers, other.detail));
+        return (std::tie(isConst, detail) == std::tie(other.isConst, other.detail));
     }
 
     bool operator != (const ResolvedType &other) const
     {
-        return (std::tie(qualifiers, detail) != std::tie(other.qualifiers, other.detail));
+        return (std::tie(isConst, detail) != std::tie(other.isConst, other.detail));
     }
 
     bool operator < (const ResolvedType &other) const
     {
-        return (std::tie(qualifiers, detail) < std::tie(other.qualifiers, other.detail));
+        return (std::tie(isConst, detail) < std::tie(other.isConst, other.detail));
     }
 
     //------------------------------------------------------------------------
@@ -321,24 +318,24 @@ struct GENN_EXPORT ResolvedType
     //------------------------------------------------------------------------
     template<typename T>
     static ResolvedType createNumeric(const std::string &name, int rank, ffi_type *ffiType, 
-                                      const std::string &literalSuffix = "", Qualifier qualifiers = Qualifier{0}, bool device = false)
+                                      const std::string &literalSuffix = "", bool isConst = false, bool device = false)
     {
         return ResolvedType{Value{name, sizeof(T), ffiType, device, Numeric{rank, std::numeric_limits<T>::min(), std::numeric_limits<T>::max(),
                                                                             std::numeric_limits<T>::lowest(), std::numeric_limits<T>::max_digits10,
                                                                             std::is_signed<T>::value, std::is_integral<T>::value, literalSuffix}},
-                            qualifiers};
+                            isConst};
     }
 
     template<typename T>
-    static ResolvedType createValue(const std::string &name, Qualifier qualifiers = Qualifier{0}, 
+    static ResolvedType createValue(const std::string &name, bool isConst = false, 
                                     ffi_type *ffiType = nullptr, bool device = false)
     {
-        return ResolvedType{Value{name, sizeof(T), ffiType, device, std::nullopt}, qualifiers};
+        return ResolvedType{Value{name, sizeof(T), ffiType, device, std::nullopt}, isConst};
     }
 
     static ResolvedType createFunction(const ResolvedType &returnType, const std::vector<ResolvedType> &argTypes, bool variadic=false)
     {
-        return ResolvedType{Function{returnType, argTypes, variadic}, Qualifier{0}};
+        return ResolvedType{Function{returnType, argTypes, variadic}, false};
     }
 };
 

--- a/include/genn/genn/weightUpdateModels.h
+++ b/include/genn/genn/weightUpdateModels.h
@@ -183,7 +183,7 @@ public:
     const auto &getPreDynamicsCodeTokens() const{ return m_PreDynamicsCodeTokens; }
     const auto &getPostDynamicsCodeTokens() const{ return m_PostDynamicsCodeTokens; }
 
-    bool isIdentifierDelayedInSynCode(const std::string &name) const;
+    bool isVarHeterogeneouslyDelayedInSynCode(const std::string &name) const;
     
     void finalise(double dt);
     

--- a/include/genn/genn/weightUpdateModels.h
+++ b/include/genn/genn/weightUpdateModels.h
@@ -184,7 +184,7 @@ public:
     const auto &getPostDynamicsCodeTokens() const{ return m_PostDynamicsCodeTokens; }
 
     bool isVarHeterogeneouslyDelayedInSynCode(const std::string &name) const;
-    
+
     void finalise(double dt);
     
 private:

--- a/include/genn/genn/weightUpdateModels.h
+++ b/include/genn/genn/weightUpdateModels.h
@@ -183,6 +183,8 @@ public:
     const auto &getPreDynamicsCodeTokens() const{ return m_PreDynamicsCodeTokens; }
     const auto &getPostDynamicsCodeTokens() const{ return m_PostDynamicsCodeTokens; }
 
+    bool isIdentifierDelayedInSynCode(const std::string &name) const;
+    
     void finalise(double dt);
     
 private:

--- a/pygenn/genn_groups.py
+++ b/pygenn/genn_groups.py
@@ -607,15 +607,15 @@ class SynapseGroupMixin(GroupMixin):
         # If population's postsynaptic weight update hasn't been 
         # fused, load weight update model postsynaptic variables
         if not self._wu_post_model_fused:
-            post_delay_group = (None if (self.back_prop_delay_steps == 0)
-                                else self.trg)
             self._load_vars(
                 wu_snippet.get_post_vars(),
                 lambda v, d: _get_neuron_var_shape(
                     get_var_access_dim(v.access), self.trg.num_neurons,
                     self._model.batch_size, d),
                 self.post_vars, self.get_wu_post_var_location,
-                lambda v: post_delay_group)
+                lambda v: (self.trg if self.back_prop_delay_steps > 0 
+                           or self._is_wu_post_var_heterogeneously_delayed(v.name)
+                           else None))
         
         # If this synapse group's postsynaptic model hasn't been fused
         if not self._ps_model_fused:

--- a/pygenn/src/genn.cc
+++ b/pygenn/src/genn.cc
@@ -666,8 +666,11 @@ PYBIND11_MODULE(_genn, m)
              pybind11::arg("param_name"), pybind11::arg("dynamic") = true,
              DOC(SynapseGroup, setPSParamDynamic))
         WRAP_METHOD("get_ps_var_location", SynapseGroup, getPSVarLocation)
-        WRAP_METHOD("set_ps_var_location", SynapseGroup, setPSVarLocation);
-    
+        WRAP_METHOD("set_ps_var_location", SynapseGroup, setPSVarLocation)
+        
+        // **NOTE** we use the 'publicist' pattern to expose some protected methods
+        .def("_is_wu_post_var_heterogeneously_delayed", &SynapseGroupInternal::isWUPostVarHeterogeneouslyDelayed);
+        
     //------------------------------------------------------------------------
     // genn.NumericValue
     //------------------------------------------------------------------------

--- a/src/genn/backends/cuda/backend.cc
+++ b/src/genn/backends/cuda/backend.cc
@@ -57,8 +57,8 @@ const EnvironmentLibrary::Library backendFunctions = {
 //--------------------------------------------------------------------------
 // CUDADeviceType
 //--------------------------------------------------------------------------
-const Type::ResolvedType CURandState = Type::ResolvedType::createValue<curandState>("curandState", Type::Qualifier{0}, nullptr, true);
-const Type::ResolvedType CURandStatePhilox43210 = Type::ResolvedType::createValue<curandStatePhilox4_32_10_t>("curandStatePhilox4_32_10_t", Type::Qualifier{0}, nullptr, true);
+const Type::ResolvedType CURandState = Type::ResolvedType::createValue<curandState>("curandState", false, nullptr, true);
+const Type::ResolvedType CURandStatePhilox43210 = Type::ResolvedType::createValue<curandStatePhilox4_32_10_t>("curandStatePhilox4_32_10_t", false, nullptr, true);
 
 //--------------------------------------------------------------------------
 // Timer

--- a/src/genn/backends/cuda/optimiser.cc
+++ b/src/genn/backends/cuda/optimiser.cc
@@ -263,7 +263,7 @@ void calcGroupSizes(const CUDA::Preferences &preferences, const ModelSpecInterna
         }
 
         // If this synapse group requires dendritic delay, it requires a pre-synapse reset
-        if(s.second.isDendriticDelayRequired()) {
+        if(s.second.isDendriticOutputDelayRequired()) {
             numPreSynapseResetGroups++;
         }
     }

--- a/src/genn/backends/single_threaded_cpu/backend.cc
+++ b/src/genn/backends/single_threaded_cpu/backend.cc
@@ -375,7 +375,7 @@ void Backend::genNeuronUpdate(CodeStream &os, ModelSpecMerged &modelMerged, Back
 
                                 // Update event time
                                 if(n.getArchetype().isSpikeTimeRequired()) {
-                                    const std::string queueOffset = n.getArchetype().isDelayRequired() ? "$(_write_delay_offset) + " : "";
+                                    const std::string queueOffset = n.getArchetype().isSpikeDelayRequired() ? "$(_write_delay_offset) + " : "";
                                     env.printLine("$(_st)[" + queueOffset + "$(id)] = $(t);");
                                 }
 
@@ -398,7 +398,7 @@ void Backend::genNeuronUpdate(CodeStream &os, ModelSpecMerged &modelMerged, Back
                                         genEmitEvent(env, n, false);
 
                                         if(n.getArchetype().isSpikeEventTimeRequired()) {
-                                            const std::string queueOffset = n.getArchetype().isDelayRequired() ? "$(_write_delay_offset) + " : "";
+                                            const std::string queueOffset = n.getArchetype().isSpikeEventDelayRequired() ? "$(_write_delay_offset) + " : "";
                                             env.printLine("$(_set)[" + queueOffset + "$(id)] = $(t);");
                                         }
 
@@ -1788,6 +1788,8 @@ void Backend::genPresynapticUpdate(EnvironmentExternalBase &env, PresynapticUpda
     // Get suffix based on type of events
     const std::string eventSuffix = trueSpike ? "" : "_event";
 
+    const bool delayRequired = (trueSpike ? sg.getArchetype().getSrcNeuronGroup()->isSpikeDelayRequired()
+                                : sg.getArchetype().getSrcNeuronGroup()->isSpikeEventDelayRequired());
     if(sg.getArchetype().getMatrixType() & SynapseMatrixConnectivity::TOEPLITZ) {
         // Create environment for generating presynaptic update code into seperate CodeStream
         std::ostringstream preUpdateStream;
@@ -1847,11 +1849,11 @@ void Backend::genPresynapticUpdate(EnvironmentExternalBase &env, PresynapticUpda
                     env.define(Transpiler::Token{Transpiler::Token::Type::IDENTIFIER, "addSynapse", 0}, addSynapseType, errorHandler);
                     env.define(Transpiler::Token{Transpiler::Token::Type::IDENTIFIER, "id_pre", 0}, Type::Uint32.addConst(), errorHandler);
                 },
-                [addSynapseType, trueSpike, &eventSuffix, &preUpdateStream, &sg](auto &env, auto generateBody)
+                [addSynapseType, delayRequired, trueSpike, &eventSuffix, &preUpdateStream](auto &env, auto generateBody)
                 {
                     // Detect spike events or spikes and do the update
                     env.getStream() << "// process presynaptic events: " << (trueSpike ? "True Spikes" : "Spike type events") << std::endl;
-                    if(sg.getArchetype().getSrcNeuronGroup()->isDelayRequired()) {
+                    if(delayRequired) {
                         env.print("for (unsigned int i = 0; i < $(_src_spk_cnt" + eventSuffix + ")[$(_pre_delay_slot)]; i++)");
                     }
                     else {
@@ -1861,7 +1863,7 @@ void Backend::genPresynapticUpdate(EnvironmentExternalBase &env, PresynapticUpda
                         CodeStream::Scope b(env.getStream());
                         EnvironmentExternal bodyEnv(env);
 
-                        const std::string queueOffset = sg.getArchetype().getSrcNeuronGroup()->isDelayRequired() ? "$(_pre_delay_offset) + " : "";
+                        const std::string queueOffset = delayRequired ? "$(_pre_delay_offset) + " : "";
                         bodyEnv.printLine("const unsigned int ipre = $(_src_spk" + eventSuffix + ")[" + queueOffset + "i];");
                         
                         // Add presynaptic index
@@ -1879,7 +1881,7 @@ void Backend::genPresynapticUpdate(EnvironmentExternalBase &env, PresynapticUpda
     else {
         // Detect spike events or spikes and do the update
         env.getStream() << "// process presynaptic events: " << (trueSpike ? "True Spikes" : "Spike type events") << std::endl;
-        if(sg.getArchetype().getSrcNeuronGroup()->isDelayRequired()) {
+        if(delayRequired) {
             env.print("for (unsigned int i = 0; i < $(_src_spk_cnt" + eventSuffix + ")[$(_pre_delay_slot)]; i++)");
         }
         else {
@@ -1890,7 +1892,7 @@ void Backend::genPresynapticUpdate(EnvironmentExternalBase &env, PresynapticUpda
             EnvironmentGroupMergedField<PresynapticUpdateGroupMerged> groupEnv(env, sg);
 
 
-            const std::string queueOffset = sg.getArchetype().getSrcNeuronGroup()->isDelayRequired() ? "$(_pre_delay_offset) + " : "";
+            const std::string queueOffset = delayRequired ? "$(_pre_delay_offset) + " : "";
             groupEnv.add(Type::Uint32.addConst(), "id_pre", "idPre",
                          {groupEnv.addInitialiser("const unsigned int idPre = $(_src_spk" + eventSuffix + ")[" + queueOffset + "i];")});
 
@@ -2028,7 +2030,9 @@ void Backend::genPostsynapticUpdate(EnvironmentExternalBase &env, PostsynapticUp
     const std::string eventSuffix = trueSpike ? "" : "_event";
 
     // Get number of postsynaptic spikes
-    if (sg.getArchetype().getTrgNeuronGroup()->isDelayRequired()) {
+    const bool delayRequired = (trueSpike ? sg.getArchetype().getTrgNeuronGroup()->isSpikeDelayRequired()
+                                : sg.getArchetype().getTrgNeuronGroup()->isSpikeEventDelayRequired());
+    if (delayRequired) {
         env.printLine("const unsigned int numSpikes = $(_trg_spk_cnt" + eventSuffix + ")[$(_post_delay_slot)];");
     }
     else {
@@ -2041,7 +2045,7 @@ void Backend::genPostsynapticUpdate(EnvironmentExternalBase &env, PostsynapticUp
         CodeStream::Scope b(env.getStream());
 
         // **TODO** prod types
-        const std::string offsetTrueSpkPost = sg.getArchetype().getTrgNeuronGroup()->isDelayRequired() ? "$(_post_delay_offset) + " : "";
+        const std::string offsetTrueSpkPost = delayRequired ? "$(_post_delay_offset) + " : "";
         env.printLine("const unsigned int spike = $(_trg_spk" + eventSuffix + ")[" + offsetTrueSpkPost + "j];");
 
         // Loop through column of presynaptic neurons
@@ -2091,7 +2095,7 @@ void Backend::genPrevEventTimeUpdate(EnvironmentExternalBase &env, NeuronPrevSpi
 {
     const std::string suffix = trueSpike ? "" : "_event";
     const std::string time = trueSpike ? "st" : "set";
-    if(ng.getArchetype().isDelayRequired()) {
+    if(trueSpike ? ng.getArchetype().isSpikeDelayRequired() : ng.getArchetype().isSpikeEventDelayRequired()) {
         // Loop through neurons which spiked last timestep and set their spike time to time of previous timestep
         env.print("for(unsigned int i = 0; i < $(_spk_cnt" + suffix + ")[lastTimestepDelaySlot]; i++)");
         {
@@ -2111,10 +2115,12 @@ void Backend::genPrevEventTimeUpdate(EnvironmentExternalBase &env, NeuronPrevSpi
 //--------------------------------------------------------------------------
 void Backend::genEmitEvent(EnvironmentExternalBase &env, NeuronUpdateGroupMerged &ng, bool trueSpike) const
 {
-    const std::string queueOffset = ng.getArchetype().isDelayRequired() ? "$(_write_delay_offset) + " : "";
+    const bool delayRequired = (trueSpike ? ng.getArchetype().isSpikeDelayRequired()
+                                : ng.getArchetype().isSpikeEventDelayRequired());
+    const std::string queueOffset = delayRequired ? "$(_write_delay_offset) + " : "";
     const std::string suffix = trueSpike ? "" : "_event";
     env.print("$(_spk" + suffix + ")[" + queueOffset + "$(_spk_cnt" + suffix + ")");
-    if(ng.getArchetype().isDelayRequired()) {
+    if(delayRequired) {
         env.print("[*$(_spk_que_ptr)]++]");
     }
     else {

--- a/src/genn/backends/single_threaded_cpu/backend.cc
+++ b/src/genn/backends/single_threaded_cpu/backend.cc
@@ -535,9 +535,9 @@ void Backend::genSynapseUpdate(CodeStream &os, ModelSpecMerged &modelMerged, Bac
                                 }
 
                                 // Add correct functions for apply synaptic input
-                                synEnv.add(Type::AddToPostDenDelay, "addToPostDelay", "$(_den_delay)[" + s.getPostDenDelayIndex(1, "$(id_post)", "$(1)") + "] += $(0)");
-                                synEnv.add(Type::AddToPost, "addToPost", "$(_out_post)[" + s.getPostISynIndex(1, "$(id_post)") + "] += $(0)");
-                                synEnv.add(Type::AddToPre, "addToPre", "$(_out_pre)[" + s.getPreISynIndex(1, "$(id_pre)") + "] += $(0)");
+                                synEnv.add(Type::getAddToPrePostDelay(s.getScalarType()), "addToPostDelay", "$(_den_delay)[" + s.getPostDenDelayIndex(1, "$(id_post)", "$(1)") + "] += $(0)");
+                                synEnv.add(Type::getAddToPrePost(s.getScalarType()), "addToPost", "$(_out_post)[" + s.getPostISynIndex(1, "$(id_post)") + "] += $(0)");
+                                synEnv.add(Type::getAddToPrePost(s.getScalarType()), "addToPre", "$(_out_pre)[" + s.getPreISynIndex(1, "$(id_pre)") + "] += $(0)");
                                 
                                 // Call synapse dynamics handler
                                 s.generateSynapseUpdate(synEnv, 1, modelMerged.getModel().getDT());
@@ -1812,9 +1812,9 @@ void Backend::genPresynapticUpdate(EnvironmentExternalBase &env, PresynapticUpda
             }
                     
             // Add correct functions for apply synaptic input
-            preUpdateEnv.add(Type::AddToPostDenDelay, "addToPostDelay", "$(_den_delay)[" + sg.getPostDenDelayIndex(1, "$(id_post)", "$(1)") + "] += $(0)");
-            preUpdateEnv.add(Type::AddToPost, "addToPost", "$(_out_post)[" + sg.getPostISynIndex(1, "$(id_post)") + "] += $(0)");
-            preUpdateEnv.add(Type::AddToPre, "addToPre", "$(_out_pre)[" + sg.getPreISynIndex(1, "$(id_pre)") + "] += $(0)");
+            preUpdateEnv.add(Type::getAddToPrePostDelay(sg.getScalarType()), "addToPostDelay", "$(_den_delay)[" + sg.getPostDenDelayIndex(1, "$(id_post)", "$(1)") + "] += $(0)");
+            preUpdateEnv.add(Type::getAddToPrePost(sg.getScalarType()), "addToPost", "$(_out_post)[" + sg.getPostISynIndex(1, "$(id_post)") + "] += $(0)");
+            preUpdateEnv.add(Type::getAddToPrePost(sg.getScalarType()), "addToPre", "$(_out_pre)[" + sg.getPreISynIndex(1, "$(id_pre)") + "] += $(0)");
 
             // Generate spike update
             if(trueSpike) {
@@ -1910,9 +1910,9 @@ void Backend::genPresynapticUpdate(EnvironmentExternalBase &env, PresynapticUpda
                                {synEnv.addInitialiser("const unsigned int idPost = $(_ind)[$(id_syn)];")});
                     
                     // Add correct functions for apply synaptic input
-                    synEnv.add(Type::AddToPostDenDelay, "addToPostDelay", "$(_den_delay)[" + sg.getPostDenDelayIndex(1, "$(id_post)", "$(1)") + "] += $(0)");
-                    synEnv.add(Type::AddToPost, "addToPost", "$(_out_post)[" + sg.getPostISynIndex(1, "$(id_post)") + "] += $(0)");
-                    synEnv.add(Type::AddToPre, "addToPre", "$(_out_pre)[" + sg.getPreISynIndex(1, "$(id_pre)") + "] += $(0)");
+                    synEnv.add(Type::getAddToPrePostDelay(sg.getScalarType()), "addToPostDelay", "$(_den_delay)[" + sg.getPostDenDelayIndex(1, "$(id_post)", "$(1)") + "] += $(0)");
+                    synEnv.add(Type::getAddToPrePost(sg.getScalarType()), "addToPost", "$(_out_post)[" + sg.getPostISynIndex(1, "$(id_post)") + "] += $(0)");
+                    synEnv.add(Type::getAddToPrePost(sg.getScalarType()), "addToPre", "$(_out_pre)[" + sg.getPreISynIndex(1, "$(id_pre)") + "] += $(0)");
 
                     if(trueSpike) {
                         sg.generateSpikeUpdate(synEnv, 1, dt);
@@ -1942,9 +1942,9 @@ void Backend::genPresynapticUpdate(EnvironmentExternalBase &env, PresynapticUpda
                     groupEnv.add(Type::Uint32.addConst(), "id_post", "ipost");
                     
                     // Add correct functions for apply synaptic input
-                    groupEnv.add(Type::AddToPostDenDelay, "addToPostDelay", "$(_den_delay)[" + sg.getPostDenDelayIndex(1, "$(id_post)", "$(1)") + "] += $(0)");
-                    groupEnv.add(Type::AddToPost, "addToPost", "$(_out_post)[" + sg.getPostISynIndex(1, "$(id_post)") + "] += $(0)");
-                    groupEnv.add(Type::AddToPre, "addToPre", "$(_out_pre)[" + sg.getPreISynIndex(1, "$(id_pre)") + "] += $(0)");
+                    groupEnv.add(Type::getAddToPrePostDelay(sg.getScalarType()), "addToPostDelay", "$(_den_delay)[" + sg.getPostDenDelayIndex(1, "$(id_post)", "$(1)") + "] += $(0)");
+                    groupEnv.add(Type::getAddToPrePost(sg.getScalarType()), "addToPost", "$(_out_post)[" + sg.getPostISynIndex(1, "$(id_post)") + "] += $(0)");
+                    groupEnv.add(Type::getAddToPrePost(sg.getScalarType()), "addToPre", "$(_out_pre)[" + sg.getPreISynIndex(1, "$(id_pre)") + "] += $(0)");
 
                     // While there any bits left
                     groupEnv.getStream() << "while(connectivityWord != 0)";
@@ -1988,9 +1988,9 @@ void Backend::genPresynapticUpdate(EnvironmentExternalBase &env, PresynapticUpda
                     synEnv.add(Type::Uint32, "id_post", "ipost");
                     
                     // Add correct functions for apply synaptic input
-                    synEnv.add(Type::AddToPostDenDelay, "addToPostDelay", "$(_den_delay)[" + sg.getPostDenDelayIndex(1, "$(id_post)", "$(1)") + "] += $(0)");
-                    synEnv.add(Type::AddToPost, "addToPost", "$(_out_post)[" + sg.getPostISynIndex(1, "$(id_post)") + "] += $(0)");
-                    synEnv.add(Type::AddToPre, "addToPre", "$(_out_pre)[" + sg.getPreISynIndex(1, "$(id_pre)") + "] += $(0)");
+                    synEnv.add(Type::getAddToPrePostDelay(sg.getScalarType()), "addToPostDelay", "$(_den_delay)[" + sg.getPostDenDelayIndex(1, "$(id_post)", "$(1)") + "] += $(0)");
+                    synEnv.add(Type::getAddToPrePost(sg.getScalarType()), "addToPost", "$(_out_post)[" + sg.getPostISynIndex(1, "$(id_post)") + "] += $(0)");
+                    synEnv.add(Type::getAddToPrePost(sg.getScalarType()), "addToPre", "$(_out_pre)[" + sg.getPreISynIndex(1, "$(id_pre)") + "] += $(0)");
 
                     const auto indexType = getSynapseIndexType(sg);
                     const auto indexTypeName = indexType.getName();
@@ -2075,7 +2075,7 @@ void Backend::genPostsynapticUpdate(EnvironmentExternalBase &env, PostsynapticUp
             }
 
             synEnv.add(Type::Uint32.addConst(), "id_post", "spike");
-            synEnv.add(Type::AddToPre, "addToPre", "$(_out_pre)[" + sg.getPreISynIndex(1, "$(id_pre)") + "] += $(0)");
+            synEnv.add(Type::getAddToPrePost(sg.getScalarType()), "addToPre", "$(_out_pre)[" + sg.getPreISynIndex(1, "$(id_pre)") + "] += $(0)");
             
             if(trueSpike) {
                 sg.generateSpikeUpdate(synEnv, 1, dt);

--- a/src/genn/genn/code_generator/backendBase.cc
+++ b/src/genn/genn/code_generator/backendBase.cc
@@ -353,7 +353,7 @@ void buildStandardSynapseEnvironment(const BackendBase &backend, EnvironmentGrou
 
         if(batchSize > 1) {
             env.add(Uint32, "_post_batch_delay_slot", "postBatchDelaySlot",
-                    {env.addInitialiser("const unsigned int postBatchDelaySlot =$(_post_delay_slot) + ($(batch) * " + std::to_string(numTrgDelaySlots) + ");")});
+                    {env.addInitialiser("const unsigned int postBatchDelaySlot = $(_post_delay_slot) + ($(batch) * " + std::to_string(numTrgDelaySlots) + ");")});
             env.add(Uint32, "_post_batch_delay_offset", "postBatchDelayOffset",
                     {env.addInitialiser("const unsigned int postBatchDelayOffset = $(_post_delay_offset) + ($(_post_batch_offset) * " + std::to_string(numTrgDelaySlots) + ");")});
         }
@@ -366,6 +366,13 @@ void buildStandardSynapseEnvironment(const BackendBase &backend, EnvironmentGrou
             env.add(Uint32, "_post_prev_spike_time_batch_delay_offset", "postPrevSpikeTimeBatchDelayOffset",
                     {env.addInitialiser("const unsigned int postPrevSpikeTimeBatchDelayOffset = $(_post_prev_spike_time_delay_offset) + ($(_post_batch_offset) * " + std::to_string(numTrgDelaySlots) + ");")});
         }
+    }
+
+    // If synapse group has dendritic delay and batching is enabled
+    const unsigned int maxDendriticDelayTimesteps = env.getGroup().getArchetype().getMaxDendriticDelayTimesteps();
+    if(maxDendriticDelayTimesteps > 1 && batchSize > 1) {
+         env.add(Uint32, "_post_batch_den_delay_offset", "postBatchDenDelayOffset",
+                {env.addInitialiser("const unsigned int postBatchDenDelayOffset = $(_post_batch_offset) * " + std::to_string(maxDendriticDelayTimesteps) + ";")});
     }
 }
 //--------------------------------------------------------------------------

--- a/src/genn/genn/code_generator/backendSIMT.cc
+++ b/src/genn/genn/code_generator/backendSIMT.cc
@@ -561,19 +561,16 @@ void BackendSIMT::genNeuronUpdateKernel(EnvironmentExternalBase &env, ModelSpecM
 
                         // Create an environment which caches neuron variable fields in local variables if they are accessed
                         // **NOTE** we do this right at the top so that local copies can be used by child groups
-                        // **NOTE** always copy variables if variable is delayed
                         EnvironmentLocalVarCache<NeuronVarAdapter, NeuronUpdateGroupMerged> wuVarEnv(
                             ng, ng, ng.getTypeContext(), wuEnv, "", "l", true,
-                            [batchSize, &ng](const std::string &varName, VarAccess d)
+                            [batchSize, &ng](const std::string &varName, VarAccess d, bool delayed)
                             {
-                                const bool delayed = (ng.getArchetype().isVarQueueRequired(varName) && ng.getArchetype().isDelayRequired());
                                 return ng.getReadVarIndex(delayed, batchSize, getVarAccessDim(d), "$(id)") ;
                             },
-                            [batchSize, &ng](const std::string &varName, VarAccess d)
+                            [batchSize, &ng](const std::string &varName, VarAccess d, bool delayed)
                             {
-                                const bool delayed = (ng.getArchetype().isVarQueueRequired(varName) && ng.getArchetype().isDelayRequired());
                                 return ng.getWriteVarIndex(delayed, batchSize, getVarAccessDim(d), "$(id)") ;
-                            });
+                            }, false);
                         ng.generateWUVarUpdate(wuEnv, batchSize);
                     }
 

--- a/src/genn/genn/code_generator/backendSIMT.cc
+++ b/src/genn/genn/code_generator/backendSIMT.cc
@@ -851,11 +851,11 @@ void BackendSIMT::genSynapseDynamicsKernel(EnvironmentExternalBase &env, ModelSp
 
                 synEnv.add(Type::Uint32.addConst(), "id_syn", "$(id)");
 
-                synEnv.add(Type::AddToPostDenDelay, "addToPostDelay", 
+                synEnv.add(Type::getAddToPrePostDelay(sg.getScalarType()), "addToPostDelay",
                            getAtomic(modelMerged.getModel().getPrecision()) + "(&$(_den_delay)[" + sg.getPostDenDelayIndex(batchSize, "$(id_post)", "$(1)") + "], $(0))");
-                synEnv.add(Type::AddToPost, "addToPost", 
+                synEnv.add(Type::getAddToPrePost(sg.getScalarType()), "addToPost",
                            getAtomic(modelMerged.getModel().getPrecision()) + "(&$(_out_post)[" + sg.getPostISynIndex(batchSize, "$(id_post)") + "], $(0))");
-                synEnv.add(Type::AddToPre, "addToPre",
+                synEnv.add(Type::getAddToPrePost(sg.getScalarType()), "addToPre",
                             getAtomic(modelMerged.getModel().getPrecision()) + "(&$(_out_pre)[" + sg.getPreISynIndex(batchSize, "$(id_pre)") + "], $(0))");
                 
                 sg.generateSynapseUpdate(synEnv, batchSize, modelMerged.getModel().getDT());
@@ -1881,7 +1881,8 @@ void BackendSIMT::genPostsynapticUpdate(EnvironmentExternalBase &env, Postsynapt
 
                 synEnv.add(Type::Uint32.addConst(), "id_post", "$(_sh_spk)[j]");
 
-                synEnv.add(Type::AddToPre, "addToPre", getAtomic(sg.getScalarType()) + "(&$(_out_pre)[" + sg.getPreISynIndex(batchSize, "$(id_pre)") + "], $(0))");
+                synEnv.add(Type::getAddToPrePost(sg.getScalarType()), "addToPre", 
+                           getAtomic(sg.getScalarType()) + "(&$(_out_pre)[" + sg.getPreISynIndex(batchSize, "$(id_pre)") + "], $(0))");
 
                 if(trueSpike) {
                     sg.generateSpikeUpdate(synEnv, batchSize, dt);

--- a/src/genn/genn/code_generator/backendSIMT.cc
+++ b/src/genn/genn/code_generator/backendSIMT.cc
@@ -563,11 +563,11 @@ void BackendSIMT::genNeuronUpdateKernel(EnvironmentExternalBase &env, ModelSpecM
                         // **NOTE** we do this right at the top so that local copies can be used by child groups
                         EnvironmentLocalVarCache<NeuronVarAdapter, NeuronUpdateGroupMerged> wuVarEnv(
                             ng, ng, ng.getTypeContext(), wuEnv, "", "l", true,
-                            [batchSize, &ng](const std::string &varName, VarAccess d, bool delayed)
+                            [batchSize, &ng](const std::string&, VarAccess d, bool delayed)
                             {
                                 return ng.getReadVarIndex(delayed, batchSize, getVarAccessDim(d), "$(id)") ;
                             },
-                            [batchSize, &ng](const std::string &varName, VarAccess d, bool delayed)
+                            [batchSize, &ng](const std::string&, VarAccess d, bool delayed)
                             {
                                 return ng.getWriteVarIndex(delayed, batchSize, getVarAccessDim(d), "$(id)") ;
                             }, false);

--- a/src/genn/genn/code_generator/backendSIMT.cc
+++ b/src/genn/genn/code_generator/backendSIMT.cc
@@ -574,20 +574,19 @@ void BackendSIMT::genNeuronUpdateKernel(EnvironmentExternalBase &env, ModelSpecM
                         ng.generateWUVarUpdate(wuEnv, batchSize);
                     }
 
-                    const std::string queueOffset = ng.getWriteVarIndex(ng.getArchetype().isDelayRequired(), batchSize, 
-                                                                        VarAccessDim::BATCH | VarAccessDim::ELEMENT, "");
-
+                    const std::string spikeQueueOffset = ng.getWriteVarIndex(ng.getArchetype().isSpikeDelayRequired(), batchSize,
+                                                                             VarAccessDim::BATCH | VarAccessDim::ELEMENT, "");
                     // Update event time
                     if(ng.getArchetype().isSpikeTimeRequired()) {
-                        groupEnv.printLine("$(_st)[" + queueOffset + "n] = $(t);");
+                        groupEnv.printLine("$(_st)[" + spikeQueueOffset + "n] = $(t);");
                     }
                    
                     // Generate code to copy spikes into global memory
                     ng.generateSpikes(
                         groupEnv,
-                        [&queueOffset, this](EnvironmentExternalBase &env)
+                        [&spikeQueueOffset, this](EnvironmentExternalBase &env)
                         {
-                            env.printLine("$(_spk)[" + queueOffset + "$(_sh_spk_pos)[0] + " + getThreadID() + "] = n;");
+                            env.printLine("$(_spk)[" + spikeQueueOffset + "$(_sh_spk_pos)[0] + " + getThreadID() + "] = n;");
                         });
                 }
             }
@@ -601,15 +600,13 @@ void BackendSIMT::genNeuronUpdateKernel(EnvironmentExternalBase &env, ModelSpecM
                         CodeStream::Scope b(env.getStream());
                         env.printLine("const unsigned int n = $(_sh_spk_event)[" + std::to_string(sg.getIndex()) + "][" + getThreadID() + "];");
 
-                        if(ng.getArchetype().isSpikeEventTimeRequired()) {
-                            const std::string queueOffset = ng.getWriteVarIndex(ng.getArchetype().isDelayRequired(), batchSize, 
-                                                                                VarAccessDim::BATCH | VarAccessDim::ELEMENT, "");
-                            env.printLine("$(_set)[" + queueOffset + "n] = $(t);");
+                        const std::string spikeEventQueueOffset = ng.getWriteVarIndex(ng.getArchetype().isSpikeEventDelayRequired(), batchSize,
+                                                                                      VarAccessDim::BATCH | VarAccessDim::ELEMENT, "");
+                        if(ng.getArchetype().isSpikeEventTimeRequired()) { 
+                            env.printLine("$(_set)[" + spikeEventQueueOffset + "n] = $(t);");
                         }
 
-                        const std::string queueOffset = ng.getWriteVarIndex(ng.getArchetype().isDelayRequired(), batchSize, 
-                                                                            VarAccessDim::BATCH | VarAccessDim::ELEMENT, "");
-                        env.printLine("$(_spk_event)[" + queueOffset + "$(_sh_spk_pos_event)[" + std::to_string(sg.getIndex()) + "] + " + getThreadID() + "] = n;");
+                        env.printLine("$(_spk_event)[" + spikeEventQueueOffset + "$(_sh_spk_pos_event)[" + std::to_string(sg.getIndex()) + "] + " + getThreadID() + "] = n;");
                     }
                 });
 
@@ -1825,8 +1822,10 @@ void BackendSIMT::genPostsynapticUpdate(EnvironmentExternalBase &env, Postsynapt
 {
     // Get suffix based on type of events
     const std::string eventSuffix = trueSpike ? "" : "_event";
+    const bool delay = (trueSpike ? sg.getArchetype().getTrgNeuronGroup()->isSpikeQueueRequired()
+                        : sg.getArchetype().getTrgNeuronGroup()->isSpikeEventQueueRequired());
 
-    env.printLine("const unsigned int numSpikes = $(_trg_spk_cnt" + eventSuffix + ")[" + sg.getPostSlot(batchSize) + "];");
+    env.printLine("const unsigned int numSpikes = $(_trg_spk_cnt" + eventSuffix + ")[" + sg.getPostSlot(delay, batchSize) + "];");
             
     env.getStream() << "const unsigned int numSpikeBlocks = (numSpikes + " << getKernelBlockSize(KernelPostsynapticUpdate) - 1 << ") / " << getKernelBlockSize(KernelPostsynapticUpdate) << ";" << std::endl;
     env.getStream() << "for (unsigned int r = 0; r < numSpikeBlocks; r++)";
@@ -1838,7 +1837,7 @@ void BackendSIMT::genPostsynapticUpdate(EnvironmentExternalBase &env, Postsynapt
         {
             CodeStream::Scope b(env.getStream());
             const std::string index = "(r * " + std::to_string(getKernelBlockSize(KernelPostsynapticUpdate)) + ") + " + getThreadID();
-            env.printLine("const unsigned int spk = $(_trg_spk" + eventSuffix + ")[" + sg.getPostVarIndex(batchSize, VarAccessDim::BATCH | VarAccessDim::ELEMENT, index) + "];");
+            env.printLine("const unsigned int spk = $(_trg_spk" + eventSuffix + ")[" + sg.getPostVarIndex(delay, batchSize, VarAccessDim::BATCH | VarAccessDim::ELEMENT, index) + "];");
             env.getStream() << "shSpk[" << getThreadID() << "] = spk;" << std::endl;
 
             if(sg.getArchetype().getMatrixType() & SynapseMatrixConnectivity::SPARSE) {
@@ -1901,7 +1900,7 @@ void BackendSIMT::genPrevEventTimeUpdate(EnvironmentExternalBase &env, NeuronPre
 {
     const std::string suffix = trueSpike ? "" : "_event";
     const std::string time = trueSpike ? "st" : "set";
-    if(ng.getArchetype().isDelayRequired()) {
+    if(trueSpike ? ng.getArchetype().isSpikeDelayRequired() : ng.getArchetype().isSpikeEventDelayRequired()) {
         // If there is a spike for this thread, set previous spike time to time of last timestep
         // **NOTE** spkQuePtr is updated below so this already points to last timestep
         env.print("if($(id) < $(_spk_cnt" + suffix + ")[lastTimestepDelaySlot])");
@@ -1959,7 +1958,7 @@ void BackendSIMT::genCopyEventToGlobal(EnvironmentExternalBase &env, NeuronUpdat
     const std::string suffix = trueSpike ? "" : "_event";
 
     env.print("$(_sh_spk_pos" + suffix + ")[" + indexStr + "] = " + getAtomic(Type::Uint32) + "(&$(_spk_cnt" + suffix + ")");
-    if(ng.getArchetype().isDelayRequired()) {
+    if(trueSpike ? ng.getArchetype().isSpikeDelayRequired() : ng.getArchetype().isSpikeEventDelayRequired()) {
         env.print("[*$(_spk_que_ptr)");
         if(batchSize > 1) {
             env.getStream() << " + (batch * " << ng.getArchetype().getNumDelaySlots() << ")";

--- a/src/genn/genn/code_generator/customUpdateGroupMerged.cc
+++ b/src/genn/genn/code_generator/customUpdateGroupMerged.cc
@@ -66,7 +66,7 @@ void CustomUpdateGroupMerged::generateCustomUpdate(EnvironmentExternalBase &env,
     // Create an environment which caches variables in local variables if they are accessed
     EnvironmentLocalVarCache<CustomUpdateVarAdapter, CustomUpdateGroupMerged> varEnv(
         *this, *this, getTypeContext(), cuEnv, "", "l", false,
-        [this, batchSize](const std::string&, CustomUpdateVarAccess d)
+        [this, batchSize](const std::string&, CustomUpdateVarAccess d, bool)
         {
             return getVarIndex(batchSize, getVarAccessDim(d, getArchetype().getDims()), "$(id)");
         });
@@ -199,7 +199,7 @@ void CustomUpdateWUGroupMergedBase::generateCustomUpdate(EnvironmentExternalBase
     // Create an environment which caches variables in local variables if they are accessed
     EnvironmentLocalVarCache<CustomUpdateVarAdapter, CustomUpdateWUGroupMergedBase> varEnv(
         *this, *this, getTypeContext(), cuEnv, "", "l", false,
-        [this, batchSize](const std::string&, CustomUpdateVarAccess d)
+        [this, batchSize](const std::string&, CustomUpdateVarAccess d, bool)
         {
             return getVarIndex(batchSize, getVarAccessDim(d, getArchetype().getDims()), "$(id_syn)");
         });

--- a/src/genn/genn/code_generator/initGroupMerged.cc
+++ b/src/genn/genn/code_generator/initGroupMerged.cc
@@ -62,7 +62,7 @@ void genScalarFill(EnvironmentExternalBase &env, const std::string &target, cons
 //--------------------------------------------------------------------------
 template<typename G>
 void genInitEvents(const BackendBase &backend, EnvironmentGroupMergedField<G, NeuronInitGroupMerged> &env, 
-                   NeuronInitGroupMerged &ng, const std::string &fieldSuffix, bool trueSpike, unsigned int batchSize)
+                   NeuronInitGroupMerged &ng, const std::string &fieldSuffix, bool trueSpike, bool delayRequired, unsigned int batchSize)
 {
     // Add spike count
     const std::string suffix = trueSpike ? "" : "Event";
@@ -74,24 +74,24 @@ void genInitEvents(const BackendBase &backend, EnvironmentGroupMergedField<G, Ne
 
     // Generate code to zero spikes across all delay slots and batches
     backend.genVariableInit(env, "num_neurons", "id",
-        [batchSize, &ng] (EnvironmentExternalBase &varEnv)
+        [batchSize, delayRequired, &ng] (EnvironmentExternalBase &varEnv)
         {
             genVariableFill(varEnv, "_event", "0", "id", "$(num_neurons)", VarAccessDim::BATCH | VarAccessDim::ELEMENT,
-                            batchSize, ng.getArchetype().isDelayRequired(), ng.getArchetype().getNumDelaySlots());
+                            batchSize, delayRequired, ng.getArchetype().getNumDelaySlots());
         });
     
     // Generate code to zero spike count across all delay slots and batches
     backend.genPopVariableInit(env,
-        [batchSize, &ng] (EnvironmentExternalBase &spikeCountEnv)
+        [batchSize, delayRequired, &ng] (EnvironmentExternalBase &spikeCountEnv)
         {
             genScalarFill(spikeCountEnv, "_event_cnt", "0", VarAccessDim::BATCH | VarAccessDim::ELEMENT, 
-                          batchSize, ng.getArchetype().isDelayRequired(), ng.getArchetype().getNumDelaySlots());
+                          batchSize, delayRequired, ng.getArchetype().getNumDelaySlots());
         });
 }
 //------------------------------------------------------------------------
 template<typename G>
 void genInitEventTime(const BackendBase &backend, EnvironmentExternalBase &env, G &group, NeuronInitGroupMerged &fieldGroup, 
-                      const std::string &fieldSuffix, const std::string &varName, unsigned int batchSize)
+                      const std::string &fieldSuffix, const std::string &varName, bool delayRequired, unsigned int batchSize)
 {
     EnvironmentGroupMergedField<G, NeuronInitGroupMerged> timeEnv(env, group, fieldGroup);
     timeEnv.addField(group.getTimeType().createPointer(), "_time", varName + fieldSuffix,
@@ -100,22 +100,22 @@ void genInitEventTime(const BackendBase &backend, EnvironmentExternalBase &env, 
 
     // Generate variable initialisation code
     backend.genVariableInit(timeEnv, "num_neurons", "id",
-        [batchSize, varName, &fieldGroup] (EnvironmentExternalBase &varEnv)
+        [batchSize, delayRequired, varName, &fieldGroup] (EnvironmentExternalBase &varEnv)
         {
             genVariableFill(varEnv, "_time", "-TIME_MAX", "id", "$(num_neurons)", VarAccessDim::BATCH | VarAccessDim::ELEMENT, 
-                            batchSize, fieldGroup.getArchetype().isDelayRequired(), fieldGroup.getArchetype().getNumDelaySlots());
+                            batchSize, delayRequired, fieldGroup.getArchetype().getNumDelaySlots());
         });
 }
 //------------------------------------------------------------------------
 void genInitEventTime(const BackendBase &backend, EnvironmentExternalBase &env, NeuronInitGroupMerged &group, 
-                      const std::string &varName, unsigned int batchSize)
+                      const std::string &varName, bool delayRequired, unsigned int batchSize)
 {
     // Generate variable initialisation code
     backend.genVariableInit(env, "num_neurons", "id",
-        [batchSize, varName, &group] (EnvironmentExternalBase &varEnv)
+        [batchSize, delayRequired, varName, &group] (EnvironmentExternalBase &varEnv)
         {
             genVariableFill(varEnv, varName, "-TIME_MAX", "id", "$(num_neurons)", VarAccessDim::BATCH | VarAccessDim::ELEMENT, 
-                            batchSize, group.getArchetype().isDelayRequired(), group.getArchetype().getNumDelaySlots());
+                            batchSize, delayRequired, group.getArchetype().getNumDelaySlots());
         });
 }
 //------------------------------------------------------------------------
@@ -274,7 +274,9 @@ void NeuronInitGroupMerged::SynSpike::generate(const BackendBase &backend, Envir
     EnvironmentGroupMergedField<SynSpike, NeuronInitGroupMerged> groupEnv(env, *this, ng);
 
     // Initialise spikes
-    genInitEvents(backend, groupEnv, ng, fieldSuffix, true, batchSize);
+    genInitEvents(backend, groupEnv, ng, fieldSuffix, true, 
+                  ng.getArchetype().isSpikeDelayRequired(), 
+                  batchSize);
 }
 
 //----------------------------------------------------------------------------
@@ -289,16 +291,19 @@ void NeuronInitGroupMerged::SynSpikeEvent::generate(const BackendBase &backend, 
     EnvironmentGroupMergedField<SynSpikeEvent, NeuronInitGroupMerged> groupEnv(env, *this, ng);
 
     // Initialise spike-like events
-    genInitEvents(backend, groupEnv, ng, fieldSuffix, false, batchSize);
+    genInitEvents(backend, groupEnv, ng, fieldSuffix, false, 
+                  ng.getArchetype().isSpikeEventDelayRequired(), batchSize);
 
     // Initialize spike-like-event times
     if(ng.getArchetype().isSpikeEventTimeRequired()) {
-        genInitEventTime(backend, groupEnv, *this, ng, fieldSuffix, "SET", batchSize);
+        genInitEventTime(backend, groupEnv, *this, ng, fieldSuffix, "SET",
+                         ng.getArchetype().isSpikeEventDelayRequired(), batchSize);
     }
 
     // Initialize previous spike-like-event times
     if(ng.getArchetype().isPrevSpikeEventTimeRequired()) {
-        genInitEventTime(backend, groupEnv, *this, ng, fieldSuffix, "PrevSET", batchSize);
+        genInitEventTime(backend, groupEnv, *this, ng, fieldSuffix, "PrevSET",
+                         ng.getArchetype().isSpikeEventDelayRequired(), batchSize);
     }
 }
 
@@ -490,12 +495,14 @@ void NeuronInitGroupMerged::generateInit(const BackendBase &backend, Environment
 
     // Initialize spike times
     if(getArchetype().isSpikeTimeRequired()) {
-        genInitEventTime(backend, groupEnv, *this, "_st", batchSize);
+        genInitEventTime(backend, groupEnv, *this, "_st",
+                         getArchetype().isSpikeDelayRequired(), batchSize);
     }
 
     // Initialize previous spike times
     if(getArchetype().isPrevSpikeTimeRequired()) {
-        genInitEventTime(backend, groupEnv, *this, "_prev_st", batchSize);
+        genInitEventTime(backend, groupEnv, *this, "_prev_st",
+                         getArchetype().isSpikeDelayRequired(), batchSize);
     }
 
     // Initialise neuron variables

--- a/src/genn/genn/code_generator/initGroupMerged.cc
+++ b/src/genn/genn/code_generator/initGroupMerged.cc
@@ -325,7 +325,7 @@ void NeuronInitGroupMerged::InSynPSM::generate(const BackendBase &backend, Envir
         });
 
     // If dendritic delays are required
-    if(getArchetype().isDendriticDelayRequired()) {
+    if(getArchetype().isDendriticOutputDelayRequired()) {
         // Add field for dendritic delay buffer and zero
         groupEnv.addField(getScalarType().createPointer(), "_den_delay", "denDelay" + fieldSuffix,
                           [](const auto &runtime, const auto &g, size_t) { return runtime.getArray(g, "denDelay"); });

--- a/src/genn/genn/code_generator/modelSpecMerged.cc
+++ b/src/genn/genn/code_generator/modelSpecMerged.cc
@@ -98,7 +98,7 @@ using namespace GeNN::CodeGenerator;
     std::vector<std::reference_wrapper<const SynapseGroupInternal>> synapseGroupsWithDendriticDelay;
     for(const auto &n : getModel().getNeuronGroups()) {
         for(const auto *sg : n.second.getFusedPSMInSyn()) {
-            if(sg->isDendriticDelayRequired()) {
+            if(sg->isDendriticOutputDelayRequired()) {
                 synapseGroupsWithDendriticDelay.push_back(std::cref(*sg));
             }
         }

--- a/src/genn/genn/code_generator/neuronUpdateGroupMerged.cc
+++ b/src/genn/genn/code_generator/neuronUpdateGroupMerged.cc
@@ -100,7 +100,8 @@ void NeuronUpdateGroupMerged::InSynPSM::generate(const BackendBase &backend, Env
                         [](const auto &runtime, const auto &g, size_t) { return runtime.getArray(g, "denDelayPtr");});
 
         // Get reference to dendritic delay buffer input for this timestep
-        psmEnv.printLine(backend.getPointerPrefix() + getScalarType().getName() + " *denDelayFront = &$(_den_delay)[(*$(_den_delay_ptr) * $(num_neurons)) + " + idx + "];");
+        const std::string denOffset = (batchSize > 1) ? "($(_batch_offset) * " + std::to_string(getArchetype().getMaxDendriticDelayTimesteps()) + ") + $(id)" : "$(id)";
+        psmEnv.printLine(backend.getPointerPrefix() + getScalarType().getName() + " *denDelayFront = &$(_den_delay)[(*$(_den_delay_ptr) * $(num_neurons)) + " + denOffset + "];");
 
         // Add delayed input from buffer into inSyn
         psmEnv.getStream() << "linSyn += *denDelayFront;" << std::endl;

--- a/src/genn/genn/code_generator/neuronUpdateGroupMerged.cc
+++ b/src/genn/genn/code_generator/neuronUpdateGroupMerged.cc
@@ -92,7 +92,7 @@ void NeuronUpdateGroupMerged::InSynPSM::generate(const BackendBase &backend, Env
     psmEnv.printLine(getScalarType().getName() + " linSyn = $(_out_post)[" + idx + "];");
 
     // If dendritic delay is required
-    if (getArchetype().isDendriticDelayRequired()) {
+    if (getArchetype().isDendriticOutputDelayRequired()) {
         // Add dendritic delay buffer and pointer into it
         psmEnv.addField(getScalarType().createPointer(), "_den_delay", "denDelay" + fieldSuffix,
                         [](const auto &runtime, const auto &g, size_t) { return runtime.getArray(g, "denDelay");});

--- a/src/genn/genn/code_generator/neuronUpdateGroupMerged.cc
+++ b/src/genn/genn/code_generator/neuronUpdateGroupMerged.cc
@@ -44,7 +44,7 @@ void NeuronUpdateGroupMerged::CurrentSource::generate(EnvironmentExternalBase &e
     // Create an environment which caches variables in local variables if they are accessed
     EnvironmentLocalVarCache<CurrentSourceVarAdapter, CurrentSource, NeuronUpdateGroupMerged> varEnv(
         *this, ng, getTypeContext(), csEnv, fieldSuffix, "l", false,
-        [batchSize, &ng](const std::string&, VarAccess d)
+        [batchSize, &ng](const std::string&, VarAccess d, bool)
         {
             return ng.getVarIndex(batchSize, getVarAccessDim(d), "$(id)");
         });
@@ -129,7 +129,7 @@ void NeuronUpdateGroupMerged::InSynPSM::generate(const BackendBase &backend, Env
     // Create an environment which caches variables in local variables if they are accessed
     EnvironmentLocalVarCache<SynapsePSMVarAdapter, InSynPSM, NeuronUpdateGroupMerged> varEnv(
         *this, ng, getTypeContext(), psmEnv, fieldSuffix, "l", false,
-        [batchSize, &ng](const std::string&, VarAccess d)
+        [batchSize, &ng](const std::string&, VarAccess d, bool)
         {
             return ng.getVarIndex(batchSize, getVarAccessDim(d), "$(id)");
         });
@@ -267,21 +267,15 @@ void NeuronUpdateGroupMerged::SynSpikeEvent::generateEventCondition(EnvironmentE
         synEnv.addLocalVarRefs<SynapseWUPreNeuronVarRefAdapter>(true);
 
         // Create an environment which caches variables in local variables if they are accessed
-        // **NOTE** always copy variables if synapse group is delayed
-        const bool delayed = (getArchetype().getAxonalDelaySteps() != 0);
         EnvironmentLocalVarCache<SynapseWUPreVarAdapter, SynSpikeEvent, NeuronUpdateGroupMerged> varEnv(
             *this, ng, getTypeContext(), synEnv, fieldSuffix, "l", false,
-            [batchSize, delayed, &ng](const std::string&, VarAccess d)
+            [batchSize, &ng](const std::string&, VarAccess d, bool delayed)
             {
                 return ng.getReadVarIndex(delayed, batchSize, getVarAccessDim(d), "$(id)");
             },
-            [batchSize, delayed, &ng](const std::string&, VarAccess d)
+            [batchSize, &ng](const std::string&, VarAccess d, bool delayed)
             {
                 return ng.getWriteVarIndex(delayed, batchSize, getVarAccessDim(d), "$(id)");
-            },
-            [delayed](const std::string&, VarAccess)
-            {
-                return delayed;
             });
 
         generateEventConditionInternal(varEnv, ng, batchSize, genEmitSpikeLikeEvent,
@@ -294,21 +288,15 @@ void NeuronUpdateGroupMerged::SynSpikeEvent::generateEventCondition(EnvironmentE
         synEnv.addLocalVarRefs<SynapseWUPostNeuronVarRefAdapter>(true);
 
         // Create an environment which caches variables in local variables if they are accessed
-        // **NOTE** always copy variables if synapse group is delayed
-        const bool delayed = (getArchetype().getBackPropDelaySteps() != 0);
         EnvironmentLocalVarCache<SynapseWUPostVarAdapter, SynSpikeEvent, NeuronUpdateGroupMerged> varEnv(
             *this, ng, getTypeContext(), synEnv, fieldSuffix, "l", false,
-            [batchSize, delayed, &ng](const std::string&, VarAccess d)
+            [batchSize, &ng](const std::string&, VarAccess d, bool delayed)
             {
                 return ng.getReadVarIndex(delayed, batchSize, getVarAccessDim(d), "$(id)");
             },
-            [batchSize, delayed, &ng](const std::string&, VarAccess d)
+            [batchSize, &ng](const std::string&, VarAccess d, bool delayed)
             {
                 return ng.getWriteVarIndex(delayed, batchSize, getVarAccessDim(d), "$(id)");
-            },
-            [delayed](const std::string&, VarAccess)
-            {
-                return delayed;
             }); 
 
         generateEventConditionInternal(varEnv, ng, batchSize, genEmitSpikeLikeEvent,
@@ -399,21 +387,15 @@ void NeuronUpdateGroupMerged::InSynWUMPostCode::generate(EnvironmentExternalBase
                    {synEnv.addInitialiser("const " + getTimeType().getName() + " lsTPost = $(_st)[" + spikeTimeReadIndex + "];")});
 
         // Create an environment which caches variables in local variables if they are accessed
-        // **NOTE** always copy variables if synapse group is delayed
-        const bool delayed = (getArchetype().getBackPropDelaySteps() != 0);
         EnvironmentLocalVarCache<SynapseWUPostVarAdapter, InSynWUMPostCode, NeuronUpdateGroupMerged> varEnv(
             *this, ng, getTypeContext(), synEnv, fieldSuffix, "l", false,
-            [batchSize, delayed, &ng](const std::string&, VarAccess d)
+            [batchSize, &ng](const std::string&, VarAccess d, bool delayed)
             {
                 return ng.getReadVarIndex(delayed, batchSize, getVarAccessDim(d), "$(id)");
             },
-            [batchSize, delayed, &ng](const std::string&, VarAccess d)
+            [batchSize, &ng](const std::string&, VarAccess d, bool delayed)
             {
                 return ng.getWriteVarIndex(delayed, batchSize, getVarAccessDim(d), "$(id)");
-            },
-            [delayed](const std::string&, VarAccess)
-            {
-                return delayed;
             });
 
         const std::string context = dynamicsNotSpike ? "dynamics" : "spike";
@@ -492,21 +474,15 @@ void NeuronUpdateGroupMerged::OutSynWUMPreCode::generate(EnvironmentExternalBase
                    {synEnv.addInitialiser("const " + getTimeType().getName() + " lsTPre = $(_st)[" + spikeTimeReadIndex + "];")});
 
         // Create an environment which caches variables in local variables if they are accessed
-        // **NOTE** always copy variables if synapse group is delayed
-        const bool delayed = (getArchetype().getAxonalDelaySteps() != 0);
         EnvironmentLocalVarCache<SynapseWUPreVarAdapter, OutSynWUMPreCode, NeuronUpdateGroupMerged> varEnv(
             *this, ng, getTypeContext(), synEnv, fieldSuffix, "l", false,
-            [batchSize, delayed, &ng](const std::string&, VarAccess d)
+            [batchSize, &ng](const std::string&, VarAccess d, bool delayed)
             {
                 return ng.getReadVarIndex(delayed, batchSize, getVarAccessDim(d), "$(id)");
             },
-            [batchSize, delayed, &ng](const std::string&, VarAccess d)
+            [batchSize, &ng](const std::string&, VarAccess d, bool delayed)
             {
                 return ng.getWriteVarIndex(delayed, batchSize, getVarAccessDim(d), "$(id)");
-            },
-            [delayed](const std::string&, VarAccess)
-            {
-                return delayed;
             });     
 
         const std::string context = dynamicsNotSpike ? "dynamics" : "spike";
@@ -638,22 +614,15 @@ void NeuronUpdateGroupMerged::generateNeuronUpdate(const BackendBase &backend, E
 
     // Create an environment which caches neuron variable fields in local variables if they are accessed
     // **NOTE** we do this right at the top so that local copies can be used by child groups
-    // **NOTE** always copy variables if variable is delayed
     EnvironmentLocalVarCache<NeuronVarAdapter, NeuronUpdateGroupMerged> neuronChildVarEnv(
         *this, *this, getTypeContext(), neuronChildEnv, "", "l", true,
-        [batchSize, this](const std::string &varName, VarAccess d)
+        [batchSize, this](const std::string &varName, VarAccess d, bool delayed)
         {
-            const bool delayed = (getArchetype().isVarQueueRequired(varName) && getArchetype().isDelayRequired());
             return getReadVarIndex(delayed, batchSize, getVarAccessDim(d), "$(id)") ;
         },
-        [batchSize, this](const std::string &varName, VarAccess d)
+        [batchSize, this](const std::string &varName, VarAccess d, bool delayed)
         {
-            const bool delayed = (getArchetype().isVarQueueRequired(varName) && getArchetype().isDelayRequired());
             return getWriteVarIndex(delayed, batchSize, getVarAccessDim(d), "$(id)") ;
-        },
-        [this](const std::string &varName, VarAccess)
-        {
-            return (getArchetype().isVarQueueRequired(varName) && getArchetype().isDelayRequired());
         });
 
     // Loop through incoming synapse groups

--- a/src/genn/genn/code_generator/neuronUpdateGroupMerged.cc
+++ b/src/genn/genn/code_generator/neuronUpdateGroupMerged.cc
@@ -246,7 +246,7 @@ void NeuronUpdateGroupMerged::SynSpikeEvent::generateEventCondition(EnvironmentE
      
     // Expose spike event times to neuron code
     const std::string timePrecision = getTimeType().getName();
-    const std::string spikeTimeReadIndex = ng.getReadVarIndex(ng.getArchetype().isSpikeDelayRequired(), batchSize,
+    const std::string spikeTimeReadIndex = ng.getReadVarIndex(ng.getArchetype().isSpikeEventDelayRequired(), batchSize,
                                                               VarAccessDim::BATCH | VarAccessDim::ELEMENT, "$(id)");
     synEnv.add(getTimeType().addConst(), "set", "lseT", 
                {synEnv.addInitialiser("const " + timePrecision + " lseT = $(_set)[" + spikeTimeReadIndex + "];")});

--- a/src/genn/genn/code_generator/presynapticUpdateStrategySIMT.cc
+++ b/src/genn/genn/code_generator/presynapticUpdateStrategySIMT.cc
@@ -28,7 +28,7 @@ bool isSmallSharedMemoryPop(const PresynapticUpdateGroupMerged &sg,
         return false;
     }
     // Otherwise, if dendritic delays are required, shared memory approach cannot be used so return false
-    else if(sg.getArchetype().isDendriticDelayRequired()) {
+    else if(sg.getArchetype().isDendriticOutputDelayRequired()) {
         return false;
     }
     // Otherwise, we should accumulate each postsynaptic neuron's input in shared menory if all neuron groups targetted
@@ -383,7 +383,7 @@ bool PostSpan::shouldAccumulateInRegister(const PresynapticUpdateGroupMerged &sg
 {
     // If no dendritic delays are required and data structure is dense, we can accumulate output directly into register
     const auto matrixType = sg.getArchetype().getMatrixType();
-    return (!sg.getArchetype().isDendriticDelayRequired()
+    return (!sg.getArchetype().isDendriticOutputDelayRequired()
             && ((matrixType & SynapseMatrixConnectivity::DENSE) || (matrixType & SynapseMatrixConnectivity::BITMASK)));
 }
 
@@ -583,7 +583,7 @@ bool PostSpanBitmask::isCompatible(const SynapseGroupInternal &sg, const Prefere
     // if synapse groups with bitmask connectivity and no dendritic delays request postsynaptic parallelism
     return ((sg.getParallelismHint() == SynapseGroup::ParallelismHint::WORD_PACKED_BITMASK)
             && (sg.getMatrixType() & SynapseMatrixConnectivity::BITMASK)
-            && !sg.isDendriticDelayRequired());
+            && !sg.isDendriticOutputDelayRequired());
 }
 //----------------------------------------------------------------------------
 void PostSpanBitmask::genPreamble(EnvironmentExternalBase &env, PresynapticUpdateGroupMerged &sg, 

--- a/src/genn/genn/code_generator/standardLibrary.cc
+++ b/src/genn/genn/code_generator/standardLibrary.cc
@@ -123,7 +123,7 @@ const auto libraryTypes = initLibraryTypes(
     std::make_pair("abs", std::make_pair(Type::ResolvedType::createFunction(Type::Int64, {Type::Int64}), "abs($(0))")),
 
     // Printf
-    std::make_pair("printf", std::make_pair(Type::ResolvedType::createFunction(Type::Int32, {Type::Int8.addConst().createPointer()}, true), "printf($(0), $(@))")));
+    std::make_pair("printf", std::make_pair(Type::ResolvedType::createFunction(Type::Int32, {Type::Int8.addConst().createPointer()}, Type::FunctionFlags::VARIADIC), "printf($(0), $(@))")));
 }
 
 const EnvironmentLibrary::Library floatRandomFunctions = {

--- a/src/genn/genn/code_generator/standardLibrary.cc
+++ b/src/genn/genn/code_generator/standardLibrary.cc
@@ -123,7 +123,7 @@ const auto libraryTypes = initLibraryTypes(
     std::make_pair("abs", std::make_pair(Type::ResolvedType::createFunction(Type::Int64, {Type::Int64}), "abs($(0))")),
 
     // Printf
-    std::make_pair("printf", std::make_pair(Type::ResolvedType::createFunction(Type::Int32, {Type::Int8.addQualifier(Type::Qualifier::CONSTANT).createPointer()}, true), "printf($(0), $(@))")));
+    std::make_pair("printf", std::make_pair(Type::ResolvedType::createFunction(Type::Int32, {Type::Int8.addConst().createPointer()}, true), "printf($(0), $(@))")));
 }
 
 const EnvironmentLibrary::Library floatRandomFunctions = {

--- a/src/genn/genn/code_generator/synapseUpdateGroupMerged.cc
+++ b/src/genn/genn/code_generator/synapseUpdateGroupMerged.cc
@@ -38,6 +38,7 @@ void applySynapseSubstitutions(EnvironmentExternalBase &env, const std::vector<T
         "", true);
 
     // **TODO** handle dendritic delay
+    // **NOTE** getDelayNeuronGroup should work fine in this context
     synEnv.template addVarRefs<SynapseWUPostNeuronVarRefAdapter>(
         [&sg, batchSize](VarAccessMode, const Models::VarReference &v)
         {
@@ -53,7 +54,8 @@ void applySynapseSubstitutions(EnvironmentExternalBase &env, const std::vector<T
             return sg.getPreWUVarIndex(batchSize, getVarAccessDim(a), "$(id_pre)");
         }, "", true);
 
-     // **TODO** handle dendritic delay
+    // **TODO** handle dendritic delay
+    // **NOTE** getPostWUVarIndex only checks backpropdelay steps
     synEnv.template addVars<SynapseWUPostVarAdapter>(
         [&sg, batchSize](VarAccess a, const std::string&) 
         { 

--- a/src/genn/genn/code_generator/synapseUpdateGroupMerged.cc
+++ b/src/genn/genn/code_generator/synapseUpdateGroupMerged.cc
@@ -36,6 +36,8 @@ void applySynapseSubstitutions(EnvironmentExternalBase &env, const std::vector<T
                                      v.getVarDims(), "$(id_pre)");
         }, 
         "", true);
+
+    // **TODO** handle dendritic delay
     synEnv.template addVarRefs<SynapseWUPostNeuronVarRefAdapter>(
         [&sg, batchSize](VarAccessMode, const Models::VarReference &v)
         {
@@ -50,6 +52,8 @@ void applySynapseSubstitutions(EnvironmentExternalBase &env, const std::vector<T
         { 
             return sg.getPreWUVarIndex(batchSize, getVarAccessDim(a), "$(id_pre)");
         }, "", true);
+
+     // **TODO** handle dendritic delay
     synEnv.template addVars<SynapseWUPostVarAdapter>(
         [&sg, batchSize](VarAccess a, const std::string&) 
         { 

--- a/src/genn/genn/code_generator/synapseUpdateGroupMerged.cc
+++ b/src/genn/genn/code_generator/synapseUpdateGroupMerged.cc
@@ -218,14 +218,10 @@ std::string SynapseGroupMergedBase::getPostSlot(unsigned int batchSize) const
 //----------------------------------------------------------------------------
 std::string SynapseGroupMergedBase::getPostDenDelayIndex(unsigned int batchSize, const std::string &index, const std::string &offset) const
 {
-    const std::string batchID = ((batchSize == 1) ? "" : "$(_post_batch_offset) + ") + index;
+    assert(!offset.empty());
+    const std::string batchID = ((batchSize == 1) ? "" : "$(_post_batch_den_delay_offset) + ") + index;
 
-    if(offset.empty()) {
-        return "(*$(_den_delay_ptr) * $(num_post) + " + batchID;
-    }
-    else {
-        return "(((*$(_den_delay_ptr) + " + offset + ") % " + std::to_string(getArchetype().getMaxDendriticDelayTimesteps()) + ") * $(num_post)) + " + batchID;
-    }
+    return "(((*$(_den_delay_ptr) + " + offset + ") % " + std::to_string(getArchetype().getMaxDendriticDelayTimesteps()) + ") * $(num_post)) + " + batchID;
 }
 //--------------------------------------------------------------------------
 std::string SynapseGroupMergedBase::getPrePrevSpikeTimeIndex(bool delay, unsigned int batchSize, VarAccessDim varDims, const std::string &index) const

--- a/src/genn/genn/code_generator/synapseUpdateGroupMerged.cc
+++ b/src/genn/genn/code_generator/synapseUpdateGroupMerged.cc
@@ -305,7 +305,7 @@ std::string SynapseGroupMergedBase::getPostVarHetDelayIndex(unsigned int batchSi
     else {
         const std::string delayOffset = "(" + delaySlot + " * $(num_post))";
         if(batched) {
-            return delayOffset + "($(_post_batch_offset) * " + std::to_string(numTrgDelaySlots) + ") + " + index;
+            return delayOffset + " + ($(_post_batch_offset) * " + std::to_string(numTrgDelaySlots) + ") + " + index;
         }
         else {
             return delayOffset + " + " + index;

--- a/src/genn/genn/code_generator/synapseUpdateGroupMerged.cc
+++ b/src/genn/genn/code_generator/synapseUpdateGroupMerged.cc
@@ -84,14 +84,15 @@ void applySynapseSubstitutions(EnvironmentExternalBase &env, const std::vector<T
                             sg.getPostVarHetDelayIndex(batchSize, getVarAccessDim(v.access), "$(id_post)"));
         }
         else {
+            const bool delayed = (sg.getArchetype().getBackPropDelaySteps() != 0
+                                  || sg.getArchetype().isWUPostVarHeterogeneouslyDelayed(v.name));
             synEnv.addField(resolvedType.addConst(), v.name,
                             resolvedType.createPointer(), v.name,
                             [v](auto &runtime, const auto &g, size_t) 
                             { 
                                 return runtime.getArray(g.getFusedWUPostTarget(), v.name);
                             },
-                            sg.getPostVarIndex(sg.getArchetype().getBackPropDelaySteps() != 0, batchSize,
-                                               getVarAccessDim(v.access), "$(id_post)"));
+                            sg.getPostVarIndex(delayed, batchSize, getVarAccessDim(v.access), "$(id_post)"));
         }
     }
     

--- a/src/genn/genn/code_generator/synapseUpdateGroupMerged.cc
+++ b/src/genn/genn/code_generator/synapseUpdateGroupMerged.cc
@@ -37,7 +37,6 @@ void applySynapseSubstitutions(EnvironmentExternalBase &env, const std::vector<T
         }, 
         "", true);
 
-
     // Add referenced postsynaptic neuron variables which may have heterogeneous delays
     synEnv.template addVarRefsHet<SynapseWUPostNeuronVarRefAdapter>(
         [&sg, batchSize](VarAccessMode, const Models::VarReference &v)
@@ -51,22 +50,24 @@ void applySynapseSubstitutions(EnvironmentExternalBase &env, const std::vector<T
         },
         "", true);
 
-    // Substitute names of pre and postsynaptic weight update variable
+    // Substitute names of preynaptic weight update variables
     synEnv.template addVars<SynapseWUPreVarAdapter>(
         [&sg, batchSize](VarAccess a, const std::string&) 
         { 
             return sg.getPreVarIndex(sg.getArchetype().getAxonalDelaySteps() != 0, batchSize, getVarAccessDim(a), "$(id_pre)");
         }, "", true);
 
-    // **TODO** handle dendritic delay
-    // **NOTE** getPostWUVarIndex only checks backpropdelay steps
-    synEnv.template addVars<SynapseWUPostVarAdapter>(
+   // Substitute names of postsynaptic weight update variables which may have heterogeneous delays
+    synEnv.template addVarsHet<SynapseWUPostVarAdapter>(
         [&sg, batchSize](VarAccess a, const std::string&) 
         { 
             return sg.getPostVarIndex(sg.getArchetype().getBackPropDelaySteps() != 0, batchSize, getVarAccessDim(a), "$(id_post)");
+        },
+        [&sg, batchSize](VarAccess a, const std::string&)
+        {
+            return sg.getPostVarHetDelayIndex(batchSize, getVarAccessDim(a), "$(id_post)");
         }, "", true);
 
-    
     // If this synapse group has a kernel
     if (!sg.getArchetype().getKernelSize().empty()) {
         // Add substitution

--- a/src/genn/genn/code_generator/synapseUpdateGroupMerged.cc
+++ b/src/genn/genn/code_generator/synapseUpdateGroupMerged.cc
@@ -28,7 +28,7 @@ void applySynapseSubstitutions(EnvironmentExternalBase &env, const std::vector<T
     synEnv.addInitialiserDerivedParams("", &SynapseGroupInternal::getWUInitialiser, &G::isWUDerivedParamHeterogeneous);
     synEnv.addExtraGlobalParams(wu->getExtraGlobalParams());
 
-    // Add referenced pre and postsynaptic neuron variables
+    // Add referenced presynaptic neuron variables
     synEnv.template addVarRefs<SynapseWUPreNeuronVarRefAdapter>(
         [&sg, batchSize](VarAccessMode, const Models::VarReference &v)
         {
@@ -37,8 +37,8 @@ void applySynapseSubstitutions(EnvironmentExternalBase &env, const std::vector<T
         }, 
         "", true);
 
-    // **TODO** handle dendritic delay
-    // **NOTE** getDelayNeuronGroup should work fine in this context
+
+    // Add referenced postsynaptic neuron variables which may have heterogeneous delays
     synEnv.template addVarRefsHet<SynapseWUPostNeuronVarRefAdapter>(
         [&sg, batchSize](VarAccessMode, const Models::VarReference &v)
         {
@@ -55,7 +55,7 @@ void applySynapseSubstitutions(EnvironmentExternalBase &env, const std::vector<T
     synEnv.template addVars<SynapseWUPreVarAdapter>(
         [&sg, batchSize](VarAccess a, const std::string&) 
         { 
-            return sg.getPreWUVarIndex(batchSize, getVarAccessDim(a), "$(id_pre)");
+            return sg.getPreVarIndex(sg.getArchetype().getAxonalDelaySteps() != 0, batchSize, getVarAccessDim(a), "$(id_pre)");
         }, "", true);
 
     // **TODO** handle dendritic delay
@@ -63,7 +63,7 @@ void applySynapseSubstitutions(EnvironmentExternalBase &env, const std::vector<T
     synEnv.template addVars<SynapseWUPostVarAdapter>(
         [&sg, batchSize](VarAccess a, const std::string&) 
         { 
-            return sg.getPostWUVarIndex(batchSize, getVarAccessDim(a), "$(id_post)");
+            return sg.getPostVarIndex(sg.getArchetype().getBackPropDelaySteps() != 0, batchSize, getVarAccessDim(a), "$(id_post)");
         }, "", true);
 
     

--- a/src/genn/genn/models.cc
+++ b/src/genn/genn/models.cc
@@ -103,8 +103,8 @@ NeuronGroup *VarReference::getDelayNeuronGroup() const
                 return (ref.group->getAxonalDelaySteps() > 0) ? ref.group->getSrcNeuronGroup() : nullptr;
             },
             [](const WUPostRef &ref)->NeuronGroup* {
-                // **TODO** also check if variable is dendritcally delayed
-                return (ref.group->getBackPropDelaySteps() > 0) ? ref.group->getTrgNeuronGroup() : nullptr;
+                return (ref.group->getBackPropDelaySteps() > 0 
+                        || ref.group->getWUInitialiser().isVarHeterogeneouslyDelayedInSynCode(ref.var.name)) ? ref.group->getTrgNeuronGroup() : nullptr;
             },
             [](const auto&)->NeuronGroup* { return nullptr; }},
         m_Detail);

--- a/src/genn/genn/models.cc
+++ b/src/genn/genn/models.cc
@@ -96,12 +96,14 @@ NeuronGroup *VarReference::getDelayNeuronGroup() const
     return std::visit(
         Utils::Overload{
             [](const NGRef &ref)->NeuronGroup* {
+                // **NOTE** this will also work fine with dendritic delay
                 return (ref.group->isDelayRequired() && ref.group->isVarQueueRequired(ref.var.name)) ? ref.group : nullptr;
             },
             [](const WUPreRef &ref)->NeuronGroup* {
                 return (ref.group->getAxonalDelaySteps() > 0) ? ref.group->getSrcNeuronGroup() : nullptr;
             },
             [](const WUPostRef &ref)->NeuronGroup* {
+                // **TODO** also check if variable is dendritcally delayed
                 return (ref.group->getBackPropDelaySteps() > 0) ? ref.group->getTrgNeuronGroup() : nullptr;
             },
             [](const auto&)->NeuronGroup* { return nullptr; }},

--- a/src/genn/genn/neuronGroup.cc
+++ b/src/genn/genn/neuronGroup.cc
@@ -379,10 +379,10 @@ NeuronGroup::NeuronGroup(const std::string &name, int numNeurons, const NeuronMo
                          const std::map<std::string, Type::NumericValue> &params, const std::map<std::string, InitVarSnippet::Init> &varInitialisers,
                          VarLocation defaultVarLocation, VarLocation defaultExtraGlobalParamLocation)
 :   m_Name(name), m_NumNeurons(numNeurons), m_Model(neuronModel), m_Params(params), m_VarInitialisers(varInitialisers),
-    m_NumDelaySlots(1), m_RecordingZeroCopyEnabled(false), m_SpikeLocation(defaultVarLocation), m_SpikeEventLocation(defaultVarLocation),
-    m_SpikeTimeLocation(defaultVarLocation), m_PrevSpikeTimeLocation(defaultVarLocation), m_SpikeEventTimeLocation(defaultVarLocation), 
-    m_PrevSpikeEventTimeLocation(defaultVarLocation), m_VarLocation(defaultVarLocation), m_ExtraGlobalParamLocation(defaultExtraGlobalParamLocation),
-    m_SpikeRecordingEnabled(false), m_SpikeEventRecordingEnabled(false)
+    m_NumDelaySlots(1), m_RecordingZeroCopyEnabled(false), m_SpikeQueueRequired(false), m_SpikeEventQueueRequired(false), 
+    m_SpikeLocation(defaultVarLocation), m_SpikeEventLocation(defaultVarLocation), m_SpikeTimeLocation(defaultVarLocation), 
+    m_PrevSpikeTimeLocation(defaultVarLocation), m_SpikeEventTimeLocation(defaultVarLocation), m_PrevSpikeEventTimeLocation(defaultVarLocation), 
+    m_VarLocation(defaultVarLocation), m_ExtraGlobalParamLocation(defaultExtraGlobalParamLocation), m_SpikeRecordingEnabled(false), m_SpikeEventRecordingEnabled(false)
 {
     // Validate names
     Utils::validatePopName(name, "Neuron group");
@@ -568,6 +568,8 @@ boost::uuids::detail::sha1::digest_type NeuronGroup::getHashDigest() const
     Utils::updateHash(isSpikeEventRecordingEnabled(), hash);
     Utils::updateHash(getNumDelaySlots(), hash);
     Utils::updateHash(m_VarQueueRequired, hash);
+    Utils::updateHash(isSpikeQueueRequired(), hash);
+    Utils::updateHash(isSpikeEventQueueRequired(), hash);
     m_DynamicParams.updateHash(hash);
 
     // Update hash with number of fused spike conditions
@@ -607,6 +609,8 @@ boost::uuids::detail::sha1::digest_type NeuronGroup::getInitHashDigest() const
     Utils::updateHash(isSimRNGRequired(), hash);
     Utils::updateHash(getNumDelaySlots(), hash);
     Utils::updateHash(m_VarQueueRequired, hash);
+    Utils::updateHash(isSpikeQueueRequired(), hash);
+    Utils::updateHash(isSpikeEventQueueRequired(), hash);
     Utils::updateHash(getModel()->getVars(), hash);
 
     // Include variable initialiser hashes

--- a/src/genn/genn/neuronGroup.cc
+++ b/src/genn/genn/neuronGroup.cc
@@ -379,7 +379,7 @@ NeuronGroup::NeuronGroup(const std::string &name, int numNeurons, const NeuronMo
                          const std::map<std::string, Type::NumericValue> &params, const std::map<std::string, InitVarSnippet::Init> &varInitialisers,
                          VarLocation defaultVarLocation, VarLocation defaultExtraGlobalParamLocation)
 :   m_Name(name), m_NumNeurons(numNeurons), m_Model(neuronModel), m_Params(params), m_VarInitialisers(varInitialisers),
-    m_NumDelaySlots(1), m_RecordingZeroCopyEnabled(false), m_SpikeQueueRequired(false), m_SpikeEventQueueRequired(false), 
+    m_NumDelaySlots(1), m_SpikeQueueRequired(false), m_SpikeEventQueueRequired(false), m_RecordingZeroCopyEnabled(false), 
     m_SpikeLocation(defaultVarLocation), m_SpikeEventLocation(defaultVarLocation), m_SpikeTimeLocation(defaultVarLocation), 
     m_PrevSpikeTimeLocation(defaultVarLocation), m_SpikeEventTimeLocation(defaultVarLocation), m_PrevSpikeEventTimeLocation(defaultVarLocation), 
     m_VarLocation(defaultVarLocation), m_ExtraGlobalParamLocation(defaultExtraGlobalParamLocation), m_SpikeRecordingEnabled(false), m_SpikeEventRecordingEnabled(false)

--- a/src/genn/genn/neuronGroup.cc
+++ b/src/genn/genn/neuronGroup.cc
@@ -379,7 +379,7 @@ NeuronGroup::NeuronGroup(const std::string &name, int numNeurons, const NeuronMo
                          const std::map<std::string, Type::NumericValue> &params, const std::map<std::string, InitVarSnippet::Init> &varInitialisers,
                          VarLocation defaultVarLocation, VarLocation defaultExtraGlobalParamLocation)
 :   m_Name(name), m_NumNeurons(numNeurons), m_Model(neuronModel), m_Params(params), m_VarInitialisers(varInitialisers),
-    m_NumDelaySlots(1), m_SpikeQueueRequired(false), m_SpikeEventQueueRequired(false), m_RecordingZeroCopyEnabled(false), 
+    m_NumDelaySlots(1), m_SpikeQueueRequired(false), m_SpikeEventQueueRequired(false), m_RecordingZeroCopyEnabled(false),
     m_SpikeLocation(defaultVarLocation), m_SpikeEventLocation(defaultVarLocation), m_SpikeTimeLocation(defaultVarLocation), 
     m_PrevSpikeTimeLocation(defaultVarLocation), m_SpikeEventTimeLocation(defaultVarLocation), m_PrevSpikeEventTimeLocation(defaultVarLocation), 
     m_VarLocation(defaultVarLocation), m_ExtraGlobalParamLocation(defaultExtraGlobalParamLocation), m_SpikeRecordingEnabled(false), m_SpikeEventRecordingEnabled(false)

--- a/src/genn/genn/runtime/runtime.cc
+++ b/src/genn/genn/runtime/runtime.cc
@@ -158,7 +158,8 @@ void Runtime::allocate(std::optional<size_t> numRecordingTimesteps)
     const size_t batchSize = getModel().getBatchSize();
     for(const auto &n : getModel().getNeuronGroups()) {
         LOGD_RUNTIME << "Allocating memory for neuron group '" << n.first << "'";
-        const size_t numNeuronDelaySlots = batchSize * n.second.getNumNeurons() * n.second.getNumDelaySlots();
+        const size_t nonDelayedNeuronVarSize = batchSize * n.second.getNumNeurons();
+        const size_t delayedNeuronVarSize = nonDelayedNeuronVarSize * n.second.getNumDelaySlots();
 
         // If spike or spike-like event recording is enabled
         if(n.second.isSpikeRecordingEnabled() || n.second.isSpikeEventRecordingEnabled()) {
@@ -193,13 +194,15 @@ void Runtime::allocate(std::optional<size_t> numRecordingTimesteps)
 
         // If neuron group needs to record its spike times
         if (n.second.isSpikeTimeRequired()) {
-            createArray(&n.second, "sT", getModel().getTimePrecision(), numNeuronDelaySlots, 
+            createArray(&n.second, "sT", getModel().getTimePrecision(), 
+                        n.second.isSpikeQueueRequired() ? delayedNeuronVarSize : nonDelayedNeuronVarSize, 
                         n.second.getSpikeTimeLocation());
         }
 
         // If neuron group needs to record its previous spike times
         if (n.second.isPrevSpikeTimeRequired()) {
-            createArray(&n.second, "prevST", getModel().getTimePrecision(), numNeuronDelaySlots, 
+            createArray(&n.second, "prevST", getModel().getTimePrecision(),
+                        n.second.isSpikeQueueRequired() ? delayedNeuronVarSize : nonDelayedNeuronVarSize, 
                         n.second.getPrevSpikeTimeLocation());
         }
 
@@ -269,9 +272,11 @@ void Runtime::allocate(std::optional<size_t> numRecordingTimesteps)
 
             // Prefix array names depending on whether neuron group is source or target of merged synapse group
             const std::string prefix = (&n.second == sg->getSrcNeuronGroup()) ? "src" : "trg";
-            createArray(sg, prefix + "SpkCnt", Type::Uint32, batchSize * n.second.getNumDelaySlots(), 
+            createArray(sg, prefix + "SpkCnt", Type::Uint32,
+                        n.second.isSpikeQueueRequired() ? batchSize * n.second.getNumDelaySlots() : batchSize,
                         n.second.getSpikeLocation(), false, 2);
-            createArray(sg, prefix + "Spk", Type::Uint32, numNeuronDelaySlots, 
+            createArray(sg, prefix + "Spk", Type::Uint32, 
+                        n.second.isSpikeQueueRequired() ? delayedNeuronVarSize : nonDelayedNeuronVarSize,
                         n.second.getSpikeLocation(), false, 2);
         }
 
@@ -281,20 +286,24 @@ void Runtime::allocate(std::optional<size_t> numRecordingTimesteps)
 
             // Prefix array names depending on whether neuron group is source or target of merged synapse group
             const std::string prefix = (&n.second == sg->getSrcNeuronGroup()) ? "src" : "trg";
-            createArray(sg, prefix + "SpkCntEvent", Type::Uint32, batchSize * n.second.getNumDelaySlots(), 
+            createArray(sg, prefix + "SpkCntEvent", Type::Uint32, 
+                        n.second.isSpikeEventQueueRequired() ? batchSize * n.second.getNumDelaySlots() : batchSize,
                         n.second.getSpikeEventLocation(), false, 2);
-            createArray(sg, prefix + "SpkEvent", Type::Uint32, numNeuronDelaySlots, 
+            createArray(sg, prefix + "SpkEvent", Type::Uint32, 
+                        n.second.isSpikeEventQueueRequired() ? delayedNeuronVarSize : nonDelayedNeuronVarSize,
                         n.second.getSpikeEventLocation(), false, 2);
 
             // If neuron group needs to record its spike-like-event times
             if (n.second.isSpikeEventTimeRequired()) {
-                createArray(sg, prefix + "SET", getModel().getTimePrecision(), numNeuronDelaySlots, 
+                createArray(sg, prefix + "SET", getModel().getTimePrecision(),
+                            n.second.isSpikeEventQueueRequired() ? delayedNeuronVarSize : nonDelayedNeuronVarSize,
                             n.second.getSpikeEventTimeLocation(), false, 2);
             }
 
             // If neuron group needs to record its previous spike-like-event times
             if (n.second.isPrevSpikeEventTimeRequired()) {
-                createArray(sg, prefix + "PrevSET", getModel().getTimePrecision(), numNeuronDelaySlots, 
+                createArray(sg, prefix + "PrevSET", getModel().getTimePrecision(),
+                            n.second.isSpikeEventQueueRequired() ? delayedNeuronVarSize : nonDelayedNeuronVarSize,
                             n.second.getPrevSpikeEventTimeLocation(), false, 2);
             }
 

--- a/src/genn/genn/runtime/runtime.cc
+++ b/src/genn/genn/runtime/runtime.cc
@@ -230,7 +230,7 @@ void Runtime::allocate(std::optional<size_t> numRecordingTimesteps)
                         sg->getTrgNeuronGroup()->getNumNeurons() * batchSize,
                         sg->getOutputLocation(), false, 2);
             
-            if (sg->isDendriticDelayRequired()) {
+            if (sg->isDendriticOutputDelayRequired()) {
                 createArray(sg, "denDelay", getModel().getPrecision(), 
                             (size_t)sg->getMaxDendriticDelayTimesteps() * (size_t)sg->getTrgNeuronGroup()->getNumNeurons() * batchSize,
                             sg->getDendriticDelayLocation(), false, 2);

--- a/src/genn/genn/runtime/runtime.cc
+++ b/src/genn/genn/runtime/runtime.cc
@@ -252,17 +252,15 @@ void Runtime::allocate(std::optional<size_t> numRecordingTimesteps)
         // Create arrays for variables from fused incoming synaptic populations
         for(const auto *sg: n.second.getFusedWUPreOutSyn()) {
             LOGD_RUNTIME << "\tFused WU pre incoming synapse group '" << sg->getName() << "'";
-            const unsigned int preDelaySlots = (sg->getAxonalDelaySteps() == 0) ? 1 : sg->getSrcNeuronGroup()->getNumDelaySlots();
             createNeuronVarArrays<SynapseWUPreVarAdapter>(sg, sg->getSrcNeuronGroup()->getNumNeurons(), 
-                                                          batchSize, preDelaySlots, true, 2);
+                                                          batchSize, sg->getSrcNeuronGroup()->getNumDelaySlots(), true, 2);
         }
         
         // Create arrays for variables from fused outgoing synaptic populations
         for(const auto *sg: n.second.getFusedWUPostInSyn()) {
             LOGD_RUNTIME << "\tFused WU post outgoing synapse group '" << sg->getName() << "'";
-            const unsigned int postDelaySlots = (sg->getBackPropDelaySteps() == 0) ? 1 : sg->getTrgNeuronGroup()->getNumDelaySlots();
             createNeuronVarArrays<SynapseWUPostVarAdapter>(sg, sg->getTrgNeuronGroup()->getNumNeurons(), 
-                                                           batchSize, postDelaySlots, true, 2);
+                                                           batchSize, sg->getTrgNeuronGroup()->getNumDelaySlots(), true, 2);
         }
 
         // Create arrays for spikes

--- a/src/genn/genn/synapseGroup.cc
+++ b/src/genn/genn/synapseGroup.cc
@@ -547,6 +547,30 @@ void SynapseGroup::finalise(double dt)
             getTrgNeuronGroup()->setVarQueueRequired(v.second.getVarName());
         }
     }
+
+    // If synapse group has axonal delaysa
+    if(getAxonalDelaySteps() > 0) {
+        // If it has presynaptic spike triggered code, mark source neuron group as requiring a spike queue
+        if(isPreSpikeRequired()) {
+            getSrcNeuronGroup()->setSpikeQueueRequired();
+        }
+        // If it has presynaptic spike-like-event triggered code, mark source neuron group as requiring a spike event queue
+        if(isPreSpikeEventRequired()) {
+            getSrcNeuronGroup()->setSpikeEventQueueRequired();
+        }
+    }
+
+    // If synapse group has backpropagation delays
+    if(getBackPropDelaySteps() > 0) {
+        // If it has postsynaptic spike triggered code, mark target neuron group as requiring a spike queue
+        if(isPostSpikeRequired()) {
+            getTrgNeuronGroup()->setSpikeQueueRequired();
+        }
+        // If it has postsynaptic spike-like-event triggered code, mark target neuron group as requiring a spike queue
+        if(isPostSpikeEventRequired()) {
+            getTrgNeuronGroup()->setSpikeEventQueueRequired();
+        }
+    }
 }
 //----------------------------------------------------------------------------
 const SynapseGroup &SynapseGroup::getFusedSpikeTarget(const NeuronGroup *ng) const

--- a/src/genn/genn/synapseGroup.cc
+++ b/src/genn/genn/synapseGroup.cc
@@ -519,7 +519,7 @@ void SynapseGroup::finalise(double dt)
     }
 
      // If weight update uses dendritic delay but maximum number of delay timesteps hasn't been specified
-    if((dendriticVarDelay || isDendriticDelayRequired()) && !m_MaxDendriticDelayTimesteps.has_value()) {
+    if((dendriticVarDelay || isDendriticOutputDelayRequired()) && !m_MaxDendriticDelayTimesteps.has_value()) {
         throw std::runtime_error("Synapse group '" + getName() + "' uses a weight update model with dendritic delays but maximum dendritic delay timesteps has not been set");
     }
 
@@ -692,7 +692,7 @@ bool SynapseGroup::canWUMPrePostUpdateBeFused(const NeuronGroup *ng) const
     return true;
 }
 //----------------------------------------------------------------------------
-bool SynapseGroup::isDendriticDelayRequired() const
+bool SynapseGroup::isDendriticOutputDelayRequired() const
 {
     return (Utils::isIdentifierReferenced("addToPostDelay", getWUInitialiser().getPreSpikeSynCodeTokens())
             || Utils::isIdentifierReferenced("addToPostDelay", getWUInitialiser().getPreEventSynCodeTokens())
@@ -711,7 +711,7 @@ bool SynapseGroup::isPresynapticOutputRequired() const
 //----------------------------------------------------------------------------
 bool SynapseGroup::isPostsynapticOutputRequired() const
 {
-    if(isDendriticDelayRequired()) {
+    if(isDendriticOutputDelayRequired()) {
         return true;
     }
     else {

--- a/src/genn/genn/synapseGroup.cc
+++ b/src/genn/genn/synapseGroup.cc
@@ -500,9 +500,9 @@ void SynapseGroup::finalise(double dt)
     const auto postWUVars = getWUInitialiser().getSnippet()->getPostVars();
     const bool heterogeneousVarDelay = 
         (std::any_of(postNeuronVarRefs.cbegin(), postNeuronVarRefs.cend(),
-                     [](const auto &v){ return getWUInitialiser().isVarHeterogeneouslyDelayedInSynCode(v.first); })
+                     [this](const auto &v){ return getWUInitialiser().isVarHeterogeneouslyDelayedInSynCode(v.first); })
          || std::any_of(postWUVars.cbegin(), postWUVars.cend(),
-                        [](const auto &v){ return getWUInitialiser().isVarHeterogeneouslyDelayedInSynCode(v.name); }));
+                        [this](const auto &v){ return getWUInitialiser().isVarHeterogeneouslyDelayedInSynCode(v.name); }));
 
     // If there are any dendritically delayed variables, ensure postsynaptic 
     // neuron group has enough delay slots to encompass maximum dendritic delay timesteps

--- a/src/genn/genn/synapseGroup.cc
+++ b/src/genn/genn/synapseGroup.cc
@@ -494,11 +494,6 @@ void SynapseGroup::finalise(double dt)
     m_SparseConnectivityInitialiser.finalise(dt);
     m_ToeplitzConnectivityInitialiser.finalise(dt);
 
-    // If weight update uses dendritic delay but maximum number of delay timesteps hasn't been specified
-    if(isDendriticDelayRequired() && !m_MaxDendriticDelayTimesteps.has_value()) {
-        throw std::runtime_error("Synapse group '" + getName() + "' uses a weight update model with dendritic delays but maximum dendritic delay timesteps has not been set");
-    }
-
     // Determine whether any postsynaptic variable references are accessed with delay
     // **NOTE** this isn't done lazily because Utils::isIdentifierDelayed also checks for consistency
     bool dendriticVarDelay = false;
@@ -521,6 +516,11 @@ void SynapseGroup::finalise(double dt)
     // group has enough delay slots to encompass maximum dendritic delay timesteps
     if(dendriticVarDelay) {
         m_TrgNeuronGroup->checkNumDelaySlots(getMaxDendriticDelayTimesteps());
+    }
+
+     // If weight update uses dendritic delay but maximum number of delay timesteps hasn't been specified
+    if((dendriticVarDelay || isDendriticDelayRequired()) && !m_MaxDendriticDelayTimesteps.has_value()) {
+        throw std::runtime_error("Synapse group '" + getName() + "' uses a weight update model with dendritic delays but maximum dendritic delay timesteps has not been set");
     }
 
     // Loop through presynaptic variable references

--- a/src/genn/genn/transpiler/parser.cc
+++ b/src/genn/genn/transpiler/parser.cc
@@ -298,13 +298,13 @@ GeNN::Type::ResolvedType parseDeclarationSpecifiers(ParserState &parserState)
     // If there are any type qualifiers, add const
     // **THINK** this relies of const being only qualifier
     if(!typeQualifiers.empty()) {
-        type = type.addQualifier(Qualifier::CONSTANT);
+        type = type.addConst();
     }
     
     // Loop through levels of pointer indirection
     // **THINK** this relies of const being only qualifier
     for(const auto &p : pointerTypeQualifiers) {
-        type = type.createPointer(p.empty() ? Qualifier{0} : Qualifier::CONSTANT);
+        type = type.createPointer(!p.empty());
     }
     return type;
 }

--- a/src/genn/genn/transpiler/prettyPrinter.cc
+++ b/src/genn/genn/transpiler/prettyPrinter.cc
@@ -245,7 +245,7 @@ private:
             }
 
             // If function is variadic
-            if (type.getFunction().variadic) {
+            if (type.getFunction().hasFlag(Type::FunctionFlags::VARIADIC)) {
                 // If variadic placeholder is found
                 const std::string variadicPlaceholder = "$(@)";
                 const size_t found = name.find(variadicPlaceholder);
@@ -258,7 +258,7 @@ private:
                     // Replace variadic placeholder with all remaining arguments (after trimming trailing ", ")
                     std::string variadicArguments = variadicArgumentsStream.str();
                     name.replace(found, variadicPlaceholder.length(),
-                                    variadicArguments.substr(0, variadicArguments.length() - 2));
+                                 variadicArguments.substr(0, variadicArguments.length() - 2));
                 }
                 else {
                     throw std::runtime_error("Variadic function template for '" + variable.getName().lexeme + "' (" + name + ") has "

--- a/src/genn/genn/transpiler/prettyPrinter.cc
+++ b/src/genn/genn/transpiler/prettyPrinter.cc
@@ -102,25 +102,22 @@ private:
     {
         // Cache reference to current reference
         std::reference_wrapper<EnvironmentBase> oldEnvironment = m_Environment; 
+    
+        // Create new call argument environment and set to current
+        EnvironmentCallArgument environment(oldEnvironment.get());
+        m_Environment = environment;
 
-        // Push new vector of arguments onto call argument stack and 
-        // reserve memory to hold index argument
-        m_CallArguments.emplace();
-        m_CallArguments.top().reserve(1);
-        {
-            // Create new call argument environment and set to current
-            EnvironmentCallArgument environment(oldEnvironment.get());
-            m_Environment = environment;
-
-            // Pretty print array index
-            arraySubscript.getIndex()->accept(*this);
-
-            // Add pretty printed argument to vector on top of stack
-            m_CallArguments.top().push_back(environment.getString());
-        }
+        // Pretty print array index
+        arraySubscript.getIndex()->accept(*this);
 
         // Restore old environment
         m_Environment = oldEnvironment;
+
+        // Push arguments to top of stack
+        m_CallArguments.emplace(std::piecewise_construct,
+                                std::forward_as_tuple(true),
+                                std::forward_as_tuple());
+        m_CallArguments.top().second.push_back(environment.getString());
 
         // Pretty print array
         // **NOTE** like with Expression::Call, when this reaches an
@@ -150,12 +147,9 @@ private:
         // Cache reference to current reference
         std::reference_wrapper<EnvironmentBase> oldEnvironment = m_Environment; 
         
-        // Push new vector of arguments onto call argument stack and 
-        // reserve memory to hold all arguments
-        m_CallArguments.emplace();
-        m_CallArguments.top().reserve(call.getArguments().size());
-
         // Loop through call arguments
+        std::vector<std::string> arguments;
+        arguments.reserve(call.getArguments().size());
         for (const auto &a : call.getArguments()) {
             // Create new call argument environment and set to current
             EnvironmentCallArgument environment(oldEnvironment.get());
@@ -164,13 +158,18 @@ private:
             // Pretty print argument
             a->accept(*this);
             
-            // Add pretty printed argument to vector on top of stack
-            m_CallArguments.top().push_back(environment.getString());
+            // Add pretty printed argument to vector
+            arguments.push_back(environment.getString());
          }
 
         // Restore old environment
         m_Environment = oldEnvironment;
-         
+        
+        // Push arguments to top of stack
+        m_CallArguments.emplace(std::piecewise_construct,
+                                std::forward_as_tuple(false), 
+                                std::forward_as_tuple(arguments));
+        
         // Pretty print callee
         call.getCallee()->accept(*this);
 
@@ -252,7 +251,7 @@ private:
 
             // Loop through call arguments on top of stack
             size_t i = 0;
-            for (i = 0; i < m_CallArguments.top().size(); i++) {
+            for (i = 0; i < m_CallArguments.top().second.size(); i++) {
                 // If name contains a $(i) placeholder to replace with this argument, replace with pretty-printed argument
                 const std::string placeholder = "$(" + std::to_string(i) + ")";
 
@@ -264,7 +263,7 @@ private:
                 
                 // Keep replacing placeholders
                 do {
-                    name.replace(found, placeholder.length(), m_CallArguments.top().at(i));
+                    name.replace(found, placeholder.length(), m_CallArguments.top().second.at(i));
                     found = name.find(placeholder, found);
                 } while(found != std::string::npos);
             }
@@ -277,7 +276,7 @@ private:
                 if (found != std::string::npos) {
                     // Concatenate together all remaining arguments
                     std::ostringstream variadicArgumentsStream;
-                    std::copy(m_CallArguments.top().cbegin() + i, m_CallArguments.top().cend(),
+                    std::copy(m_CallArguments.top().second.cbegin() + i, m_CallArguments.top().second.cend(),
                                 std::ostream_iterator<std::string>(variadicArgumentsStream, ", "));
 
                     // Replace variadic placeholder with all remaining arguments (after trimming trailing ", ")
@@ -287,16 +286,16 @@ private:
                 }
                 else {
                     throw std::runtime_error("Variadic function template for '" + variable.getName().lexeme + "' (" + name + ") has "
-                                             "insufficient placeholders for " + std::to_string(m_CallArguments.top().size()) + " argument call and no variadic placeholder '$(@)'");
+                                             "insufficient placeholders for " + std::to_string(m_CallArguments.top().second.size()) + " argument call and no variadic placeholder '$(@)'");
                 }
             }
         }
-        // Otherwise, if there are argumetns, they are presumably for array indexing
-        else if(!m_CallArguments.empty() && !m_CallArguments.top().empty()){
-            assert(m_CallArguments.top().size() == 1);
+        // Otherwise, if there are array subscript arguments on top of stack
+        else if(!m_CallArguments.empty() && m_CallArguments.top().first){
+            assert(m_CallArguments.top().second.size() == 1);
 
             // Add standard indexing to name
-            name += "[" + m_CallArguments.top().front() + "]";
+            name += "[" + m_CallArguments.top().second.front() + "]";
         }
         
         // Print out name
@@ -476,7 +475,7 @@ private:
     const Type::TypeContext &m_Context;
     const TypeChecker::ResolvedTypeMap &m_ResolvedTypes;
     StatementHandler m_ForEachSynapseHandler;
-    std::stack<std::vector<std::string>> m_CallArguments;
+    std::stack<std::pair<bool, std::vector<std::string>>> m_CallArguments;
 };
 }   // Anonymous namespace
 

--- a/src/genn/genn/transpiler/typeChecker.cc
+++ b/src/genn/genn/transpiler/typeChecker.cc
@@ -486,7 +486,7 @@ private:
                 // If  function is non-variadic and number of arguments 
                 // match or variadic and enough arguments are provided
                 const auto &argumentTypes = type.getFunction().argTypes;
-                const bool variadic = type.getFunction().variadic;
+                const bool variadic = type.getFunction().hasFlag(Type::FunctionFlags::VARIADIC);
                 if((!variadic && m_CallArguments.top().size() == argumentTypes.size())
                    || (variadic && m_CallArguments.top().size() >= argumentTypes.size()))
                 {

--- a/src/genn/genn/type.cc
+++ b/src/genn/genn/type.cc
@@ -126,7 +126,7 @@ bool NumericValue::operator >= (const NumericValue &other) const
 //----------------------------------------------------------------------------
 std::string ResolvedType::getName() const
 {
-    const std::string qualifier = hasQualifier(Type::Qualifier::CONSTANT) ? "const " : "";
+    const std::string qualifier = isConst ? "const " : "";
     return std::visit(
         Utils::Overload{
             [&qualifier](const Type::ResolvedType::Value &value)
@@ -240,8 +240,8 @@ ResolvedType getCommonType(const ResolvedType &a, const ResolvedType &b)
     // If either type is double, common type is double
     assert(a.isNumeric());
     assert(b.isNumeric());
-    const auto unqualifiedA = a.removeQualifiers();
-    const auto unqualifiedB = b.removeQualifiers();
+    const auto unqualifiedA = a.removeConst();
+    const auto unqualifiedB = b.removeConst();
     if(unqualifiedA == Double || unqualifiedB == Double) {
         return Double;
     }
@@ -408,7 +408,7 @@ void updateHash(const ResolvedType::Function &v, boost::uuids::detail::sha1 &has
 //----------------------------------------------------------------------------
 void updateHash(const ResolvedType &v, boost::uuids::detail::sha1 &hash)
 {
-    Utils::updateHash(v.qualifiers, hash);
+    Utils::updateHash(v.isConst, hash);
     Utils::updateHash(v.detail, hash);
 }
 //----------------------------------------------------------------------------

--- a/src/genn/genn/weightUpdateModels.cc
+++ b/src/genn/genn/weightUpdateModels.cc
@@ -170,7 +170,7 @@ Init::Init(const Base *snippet, const std::map<std::string, Type::NumericValue> 
     m_PostDynamicsCodeTokens = Utils::scanCode(getSnippet()->getPostDynamicsCode(), "Weight update model postsynaptic dynamics code");
 }
 //----------------------------------------------------------------------------
-bool Init::isIdentifierDelayedInSynCode(const std::string &name) const
+bool Init::isVarHeterogeneouslyDelayedInSynCode(const std::string &name) const
 {
     return (Utils::isIdentifierDelayed(name, getPreSpikeSynCodeTokens()) 
             || Utils::isIdentifierDelayed(name, getPreEventSynCodeTokens())

--- a/src/genn/genn/weightUpdateModels.cc
+++ b/src/genn/genn/weightUpdateModels.cc
@@ -170,6 +170,15 @@ Init::Init(const Base *snippet, const std::map<std::string, Type::NumericValue> 
     m_PostDynamicsCodeTokens = Utils::scanCode(getSnippet()->getPostDynamicsCode(), "Weight update model postsynaptic dynamics code");
 }
 //----------------------------------------------------------------------------
+bool Init::isIdentifierDelayedInSynCode(const std::string &name) const
+{
+    return (Utils::isIdentifierDelayed(name, getPreSpikeSynCodeTokens()) 
+            || Utils::isIdentifierDelayed(name, getPreEventSynCodeTokens())
+            || Utils::isIdentifierDelayed(name, getPostEventSynCodeTokens())
+            || Utils::isIdentifierDelayed(name, getPostSpikeSynCodeTokens())
+            || Utils::isIdentifierDelayed(name, getSynapseDynamicsCodeTokens()));
+}
+//----------------------------------------------------------------------------
 void Init::finalise(double dt)
 {
     // Superclass

--- a/tests/features/test_continuous_propagation.py
+++ b/tests/features/test_continuous_propagation.py
@@ -401,3 +401,73 @@ def test_reverse(make_model, backend, precision):
 
         assert np.sum(pre_n_pop.vars["y"].view) == (model.timestep - 1)
         assert np.sum(pre_pre_n_pop.vars["y"].view) == (model.timestep - 1)
+
+@pytest.mark.parametrize("backend", ["single_threaded_cpu", "cuda"])
+@pytest.mark.parametrize("precision", [types.Double, types.Float])
+def test_reverse_den_delay(make_model, backend, precision):
+    continous_reverse_delay_model = create_weight_update_model(
+        "continous_reverse_delay",
+        vars=[("g", "scalar", VarAccess.READ_ONLY),
+              ("d", "uint8_t", VarAccess.READ_ONLY)],
+        post_neuron_var_refs=[("x", "scalar", VarAccessMode.READ_ONLY)],
+        synapse_dynamics_code=
+        """
+        addToPre(g * x[d]);
+        """)
+
+    model = make_model(precision, "test_reverse_den_delay", backend=backend)
+    model.dt = 1.0
+
+    # Add postsynptic population to connect to
+    post_n_pop = model.add_neuron_population(
+        "Post", 10, pre_neuron_model,
+        {}, {"x": 0.0})
+
+    delay = np.arange(9, -1, -1)
+    
+    # Create neuron model to read addToPre input
+    dense_n_pop = model.add_neuron_population(
+        "DensePre", 1, post_neuron_model,
+        {}, {"x": 0.0})
+    dense_s_pop = model.add_synapse_population(
+        "DenseSynapse", "DENSE",
+        dense_n_pop, post_n_pop,
+        init_weight_update(continous_reverse_delay_model, {}, 
+                           {"g": 1.0, "d": delay},
+                           post_var_refs={"x": create_var_ref(post_n_pop, "x")}),
+        init_postsynaptic("DeltaCurr"))
+    dense_s_pop.max_dendritic_delay_timesteps = 10
+    
+    # Create neuron model to read addToPre input
+    sparse_n_pop = model.add_neuron_population(
+        "SparsePre", 1, post_neuron_model,
+        {}, {"x": 0.0})
+    sparse_s_pop = model.add_synapse_population(
+        "SparseSynapse", "SPARSE",
+        sparse_n_pop, post_n_pop,
+        init_weight_update(continous_reverse_delay_model, {}, 
+                           {"g": 1.0, "d": delay},
+                           post_var_refs={"x": create_var_ref(post_n_pop, "x")}),
+        init_postsynaptic("DeltaCurr"))
+    sparse_s_pop.set_sparse_connections(np.zeros(10, dtype=int), np.arange(10))
+    sparse_s_pop.max_dendritic_delay_timesteps = 10
+
+    # Build model and load
+    model.build()
+    model.load()
+
+    # Simulate for 11 timesteps
+    output_populations = [dense_n_pop, sparse_n_pop]
+    while model.timestep < 11:
+        model.step_time()
+
+        # Loop through output populations
+        correct = 10.0 if model.timestep == 11 else 0.0
+        for pop in output_populations:
+            # Pull state variable
+            pop.vars["x"].pull_from_device()
+
+            # If not close to correct value, error
+            if not np.isclose(pop.vars["x"].view[0], correct):
+                assert False, f"{pop.name} decoding incorrect ({pop.vars['x'].view[0]} rather than {correct})"
+

--- a/tests/features/test_continuous_propagation.py
+++ b/tests/features/test_continuous_propagation.py
@@ -18,7 +18,7 @@ pre_neuron_model = create_neuron_model(
     """
     x = (id == (int)t) ? 1.0 : 0.0;
     """,
-    var_name_types=[("x", "scalar")])
+    vars=[("x", "scalar")])
 
 post_neuron_model = create_neuron_model(
     "post_neuron",
@@ -26,7 +26,7 @@ post_neuron_model = create_neuron_model(
     """
     x = Isyn;
     """,
-    var_name_types=[("x", "scalar")])
+    vars=[("x", "scalar")])
 
 decoder_model = create_sparse_connect_init_snippet(
     "decoder",
@@ -53,7 +53,7 @@ decoder_dense_model = create_var_init_snippet(
 def test_forward(make_model, backend, precision):
     continous_weight_update_model = create_weight_update_model(
         "continous_weight_update",
-        var_name_types=[("g", "scalar", VarAccess.READ_ONLY)],
+        vars=[("g", "scalar", VarAccess.READ_ONLY)],
         pre_neuron_var_refs=[("x", "scalar", VarAccessMode.READ_ONLY)],
         synapse_dynamics_code=
         """
@@ -241,7 +241,7 @@ def test_forward(make_model, backend, precision):
 def test_forward_den_delay(make_model, backend, precision):
     continous_den_delay_wum = create_weight_update_model(
         "continous_den_delay",
-        var_name_types=[("g", "scalar", VarAccess.READ_ONLY),
+        vars=[("g", "scalar", VarAccess.READ_ONLY),
                         ("d", "uint8_t", VarAccess.READ_ONLY)],
         pre_neuron_var_refs=[("x", "scalar", VarAccessMode.READ_ONLY)],
         synapse_dynamics_code=
@@ -326,11 +326,11 @@ def test_reverse(make_model, backend, precision):
         y = Isyn;
         x = (id == (int)t) ? 1.0 : 0.0;
         """,
-        var_name_types=[("x", "scalar"), ("y", "scalar")])
+        vars=[("x", "scalar"), ("y", "scalar")])
 
     continous_reverse_model = create_weight_update_model(
         "continous_reverse",
-        var_name_types=[("g", "scalar", VarAccess.READ_ONLY)],
+        vars=[("g", "scalar", VarAccess.READ_ONLY)],
         pre_neuron_var_refs=[("x", "scalar", VarAccessMode.READ_ONLY)],
         synapse_dynamics_code=
         """

--- a/tests/features/test_custom_connectivity_update.py
+++ b/tests/features/test_custom_connectivity_update.py
@@ -83,11 +83,11 @@ def _check_connectivity(sg, get_row_length_fn, get_connectivity_fn, var_checks=[
 def test_custom_connectivity_update(make_model, backend, precision, batch_size):
     neuron_model = create_neuron_model(
         "neuron",
-        var_name_types=[("V", "scalar")])
+        vars=[("V", "scalar")])
 
     weight_update_model = create_weight_update_model(
         "weight_update",
-        var_name_types=[("g", "scalar", VarAccess.READ_ONLY_DUPLICATE),
+        vars=[("g", "scalar", VarAccess.READ_ONLY_DUPLICATE),
                         ("d", "unsigned int", VarAccess.READ_ONLY)])
 
     # Snippet to initialise variable to hold its row-major index
@@ -286,7 +286,7 @@ def test_custom_connectivity_update_delay(make_model, backend, precision):
         """
         removeIdx = (id + (int)round(t / dt)) % 64;
         """,
-        var_name_types=[("removeIdx", "int")])
+        vars=[("removeIdx", "int")])
 
     post_neuron_model = create_neuron_model(
         "post_neuron",
@@ -294,14 +294,14 @@ def test_custom_connectivity_update_delay(make_model, backend, precision):
         """
         remove = ((id + (int)round(t / dt)) % 64) == 0;
         """,
-        var_name_types=[("remove", "bool")])
+        vars=[("remove", "bool")])
 
     # Weight update model that does something arbitrary stuff with 
     # presynaptic variable reference to make sure it gets delayed
     pre_weight_update_model = create_weight_update_model(
         "pre_weight_update",
         pre_neuron_var_refs=[("removeIdx", "int", VarAccessMode.READ_ONLY)],
-        var_name_types=[("g", "scalar", VarAccess.READ_ONLY)],
+        vars=[("g", "scalar", VarAccess.READ_ONLY)],
         pre_spike_syn_code=
         """
         addToPost(g * (float)removeIdx);
@@ -312,7 +312,7 @@ def test_custom_connectivity_update_delay(make_model, backend, precision):
     post_weight_update_model = create_weight_update_model(
         "post_weight_update",
         post_neuron_var_refs=[("remove", "bool", VarAccessMode.READ_ONLY)],
-        var_name_types=[("g", "scalar", VarAccess.READ_ONLY)],
+        vars=[("g", "scalar", VarAccess.READ_ONLY)],
         pre_spike_syn_code=
         """
         addToPost(g * (float)remove);
@@ -442,7 +442,7 @@ def test_custom_connectivity_update_remap(make_model, backend, precision):
         """)
     pre_reverse_model = create_neuron_model(
         "pre_reverse",
-        var_name_types=[("x", "scalar")],
+        vars=[("x", "scalar")],
         sim_code=
         """
         x = Isyn;
@@ -454,7 +454,7 @@ def test_custom_connectivity_update_remap(make_model, backend, precision):
         """
         addToPre(g);
         """,
-        var_name_types=[("g", "scalar", VarAccess.READ_ONLY)])
+        vars=[("g", "scalar", VarAccess.READ_ONLY)])
     
     remove_ones_model = create_custom_connectivity_update_model(
         "remove_synapse",

--- a/tests/features/test_custom_update.py
+++ b/tests/features/test_custom_update.py
@@ -29,30 +29,30 @@ empty_neuron_model = create_neuron_model("empty")
 def test_custom_update(make_model, backend, precision, batch_size):
     neuron_model = create_neuron_model(
         "neuron",
-        var_name_types=[("X", "scalar", VarAccess.READ_ONLY_DUPLICATE),
+        vars=[("X", "scalar", VarAccess.READ_ONLY_DUPLICATE),
                         ("XShared", "scalar", VarAccess.READ_ONLY_SHARED_NEURON)])
 
     current_source_model = create_current_source_model(
         "current_source",
-        var_name_types=[("X", "scalar", VarAccess.READ_ONLY_DUPLICATE),
+        vars=[("X", "scalar", VarAccess.READ_ONLY_DUPLICATE),
                         ("XShared", "scalar", VarAccess.READ_ONLY_SHARED_NEURON)])
 
     weight_update_model = create_weight_update_model(
         "weight_update",
-        var_name_types=[("X", "scalar", VarAccess.READ_ONLY_DUPLICATE)],
-        pre_var_name_types=[("preX", "scalar", VarAccess.READ_ONLY_DUPLICATE),
+        vars=[("X", "scalar", VarAccess.READ_ONLY_DUPLICATE)],
+        pre_vars=[("preX", "scalar", VarAccess.READ_ONLY_DUPLICATE),
                             ("preXShared", "scalar", VarAccess.READ_ONLY_SHARED_NEURON)],
-        post_var_name_types=[("postX", "scalar", VarAccess.READ_ONLY_DUPLICATE),
+        post_vars=[("postX", "scalar", VarAccess.READ_ONLY_DUPLICATE),
                              ("postXShared", "scalar", VarAccess.READ_ONLY_SHARED_NEURON)])
 
     postsynaptic_update_model = create_postsynaptic_model(
         "postsynaptic_update",
-        var_name_types=[("psmX", "scalar", VarAccess.READ_ONLY_DUPLICATE),
+        vars=[("psmX", "scalar", VarAccess.READ_ONLY_DUPLICATE),
                         ("psmXShared", "scalar", VarAccess.READ_ONLY_SHARED_NEURON)])
 
     custom_update_model = create_custom_update_model(
         "custom_update",
-        var_name_types=[("X", "scalar", CustomUpdateVarAccess.READ_ONLY)],
+        vars=[("X", "scalar", CustomUpdateVarAccess.READ_ONLY)],
         var_refs=[("R", "scalar")])
 
     set_time_custom_update_model = create_custom_update_model(
@@ -62,7 +62,7 @@ def test_custom_update(make_model, backend, precision, batch_size):
          V = (batch * 1000.0) + t;
          R = (batch * 1000.0) + t;
          """,
-         var_name_types=[("V", "scalar")],
+         vars=[("V", "scalar")],
          var_refs=[("R", "scalar", VarAccessMode.READ_WRITE)])
 
     set_time_shared_custom_update_model = create_custom_update_model(
@@ -220,12 +220,12 @@ def test_custom_update(make_model, backend, precision, batch_size):
 def test_custom_update_delay(make_model, backend, precision, batch_size):
     neuron_model = create_neuron_model(
         "neuron",
-        var_name_types=[("V", "scalar", VarAccess.READ_ONLY_DUPLICATE),
+        vars=[("V", "scalar", VarAccess.READ_ONLY_DUPLICATE),
                         ("U", "scalar", VarAccess.READ_ONLY_DUPLICATE)])
 
     weight_update_model = create_weight_update_model(
         "weight_update",
-        var_name_types=[("g", "scalar", VarAccess.READ_ONLY_DUPLICATE)],
+        vars=[("g", "scalar", VarAccess.READ_ONLY_DUPLICATE)],
         pre_neuron_var_refs=[("V", "scalar", VarAccessMode.READ_ONLY)],
         synapse_dynamics_code=
         """
@@ -233,8 +233,8 @@ def test_custom_update_delay(make_model, backend, precision, batch_size):
         """)
     pre_weight_update_model = create_weight_update_model(
         "pre_weight_update",
-        pre_var_name_types=[("pre", "scalar")],
-        var_name_types=[("g", "scalar", VarAccess.READ_ONLY_DUPLICATE)],
+        pre_vars=[("pre", "scalar")],
+        vars=[("g", "scalar", VarAccess.READ_ONLY_DUPLICATE)],
         pre_neuron_var_refs=[("V", "scalar", VarAccessMode.READ_ONLY)],
         synapse_dynamics_code=
         """
@@ -319,7 +319,7 @@ def test_custom_update_delay(make_model, backend, precision, batch_size):
 def test_custom_update_transpose(make_model, backend, precision, batch_size):
     static_pulse_duplicate_model = create_weight_update_model(
         "static_pulse_duplicate",
-        var_name_types=[("g", "scalar", VarAccess.READ_ONLY_DUPLICATE)],
+        vars=[("g", "scalar", VarAccess.READ_ONLY_DUPLICATE)],
         pre_spike_syn_code=
         """
         addToPost(g);
@@ -375,7 +375,7 @@ def test_custom_update_transpose(make_model, backend, precision, batch_size):
 def test_custom_update_neuron_reduce(make_model, backend, precision, batch_size):
     reduction_neuron_model = create_neuron_model(
         "reduction_neuron",
-        var_name_types=[("X", "scalar", VarAccess.READ_ONLY_DUPLICATE),
+        vars=[("X", "scalar", VarAccess.READ_ONLY_DUPLICATE),
                         ("Y", "scalar", VarAccess.READ_ONLY_DUPLICATE)])
 
     softmax_1_custom_update_model = create_custom_update_model(
@@ -384,7 +384,7 @@ def test_custom_update_neuron_reduce(make_model, backend, precision, batch_size)
         """
         MaxX = X;
         """,
-        var_name_types=[("MaxX", "scalar", CustomUpdateVarAccess.REDUCE_NEURON_MAX)],
+        vars=[("MaxX", "scalar", CustomUpdateVarAccess.REDUCE_NEURON_MAX)],
         var_refs=[("X", "scalar", VarAccessMode.READ_ONLY)])
 
     softmax_2_custom_update_model = create_custom_update_model(
@@ -393,7 +393,7 @@ def test_custom_update_neuron_reduce(make_model, backend, precision, batch_size)
         """
         SumExpX = exp(X - MaxX);
         """,
-        var_name_types=[("SumExpX", "scalar", CustomUpdateVarAccess.REDUCE_NEURON_SUM)],
+        vars=[("SumExpX", "scalar", CustomUpdateVarAccess.REDUCE_NEURON_SUM)],
         var_refs=[("X", "scalar", VarAccessMode.READ_ONLY),
                   ("MaxX", "scalar", VarAccessMode.READ_ONLY)])
 
@@ -456,12 +456,12 @@ def test_custom_update_batch_reduction(make_model, backend, precision, batch_siz
     # **TODO** once VarAccess is refactored, we should really be able to reduce neuron shared across batch dimension
     neuron_model = create_neuron_model(
         "neuron",
-        var_name_types=[("X", "scalar", VarAccess.READ_ONLY_DUPLICATE),
+        vars=[("X", "scalar", VarAccess.READ_ONLY_DUPLICATE),
                         ("SumX", "scalar", VarAccess.READ_ONLY)])
 
     weight_update_model = create_weight_update_model(
         "weight_update",
-        var_name_types=[("X", "scalar", VarAccess.READ_ONLY_DUPLICATE),
+        vars=[("X", "scalar", VarAccess.READ_ONLY_DUPLICATE),
                         ("SumX", "scalar", VarAccess.READ_ONLY)])
    
     reduction_custom_update_model = create_custom_update_model(
@@ -471,7 +471,7 @@ def test_custom_update_batch_reduction(make_model, backend, precision, batch_siz
         SumX = X;
         MaxX = X;
         """,
-        var_name_types=[("MaxX", "scalar", CustomUpdateVarAccess.REDUCE_BATCH_MAX)],
+        vars=[("MaxX", "scalar", CustomUpdateVarAccess.REDUCE_BATCH_MAX)],
         var_refs=[("X", "scalar", VarAccessMode.READ_ONLY),
                   ("SumX", "scalar", VarAccessMode.REDUCE_SUM)])
 

--- a/tests/features/test_dynamic_param.py
+++ b/tests/features/test_dynamic_param.py
@@ -24,7 +24,7 @@ def test_dynamic_param(make_model, backend, precision):
         x = t + shift + input;
         """,
         params=["input"],
-        var_name_types=[("x", "scalar"), ("shift", "scalar")])
+        vars=[("x", "scalar"), ("shift", "scalar")])
     
     postsynaptic_model = create_postsynaptic_model(
         "postsynaptic",
@@ -35,7 +35,7 @@ def test_dynamic_param(make_model, backend, precision):
         inSyn = 0;
         """,
         params=["psmInput"],
-        var_name_types=[("psmX", "scalar"), ("psmShift", "scalar")])
+        vars=[("psmX", "scalar"), ("psmShift", "scalar")])
 
     weight_update_model = create_weight_update_model(
         "weight_update",
@@ -44,7 +44,7 @@ def test_dynamic_param(make_model, backend, precision):
         x = t + shift + input;
         """,
         params=["input"],
-        var_name_types=[("x", "scalar"), ("shift", "scalar")])
+        vars=[("x", "scalar"), ("shift", "scalar")])
     
     
     current_source_model = create_current_source_model(
@@ -55,7 +55,7 @@ def test_dynamic_param(make_model, backend, precision):
         injectCurrent(0.0);
         """,
         params=["input"],
-        var_name_types=[("x", "scalar"), ("shift", "scalar")])
+        vars=[("x", "scalar"), ("shift", "scalar")])
     
     custom_update_model = create_custom_update_model(
         "custom_update",
@@ -65,7 +65,7 @@ def test_dynamic_param(make_model, backend, precision):
         """,
         params=["input"],
         var_refs=[("y", "scalar")],
-        var_name_types=[("x", "scalar"), ("shift", "scalar")])
+        vars=[("x", "scalar"), ("shift", "scalar")])
 
     custom_connectivity_update_model = create_custom_connectivity_update_model(
         "custom_connectivity_update",

--- a/tests/features/test_egp.py
+++ b/tests/features/test_egp.py
@@ -49,21 +49,21 @@ def test_egp_var_init(make_model, backend, precision):
     
     nop_neuron_model = create_neuron_model(
         "nop_neuron",
-        var_name_types=[("repeat", "scalar")])
+        vars=[("repeat", "scalar")])
 
     nop_current_source_model = create_current_source_model(
         "nop_current_source",
-        var_name_types=[("repeat", "scalar")])
+        vars=[("repeat", "scalar")])
 
     nop_postsynaptic_update_model = create_postsynaptic_model(
         "nop_postsynaptic_update",
-        var_name_types=[("psm_repeat", "scalar")])
+        vars=[("psm_repeat", "scalar")])
 
     nop_weight_update_model = create_weight_update_model(
         "nop_weight_update",
-        var_name_types=[("repeat", "scalar")],
-        pre_var_name_types=[("pre_repeat", "scalar")],
-        post_var_name_types=[("post_repeat", "scalar")])
+        vars=[("repeat", "scalar")],
+        pre_vars=[("pre_repeat", "scalar")],
+        post_vars=[("post_repeat", "scalar")])
     
     model = make_model(precision, "test_egp_var_init", backend=backend)
 
@@ -143,7 +143,7 @@ def test_egp_ref(make_model, backend, precision):
         """
         x = e[id];
         """,
-        var_name_types=[("x", "scalar")],
+        vars=[("x", "scalar")],
         extra_global_params=[("e", "scalar*")])
     
     custom_update_model = create_custom_update_model(

--- a/tests/features/test_event_propagation.py
+++ b/tests/features/test_event_propagation.py
@@ -18,7 +18,7 @@ post_neuron_model = create_neuron_model(
     """
     x = Isyn;
     """,
-    var_name_types=[("x", "scalar")])
+    vars=[("x", "scalar")])
 
 decoder_model = create_sparse_connect_init_snippet(
     "decoder",
@@ -42,7 +42,7 @@ decoder_dense_model = create_var_init_snippet(
 
 static_event_pulse_model = create_weight_update_model(
     "static_event_pulse",
-    var_name_types=[("g", "scalar")],
+    vars=[("g", "scalar")],
     pre_event_threshold_condition_code=
     """
     (unsigned int)round(t) == id
@@ -562,7 +562,7 @@ def test_reverse(make_model, backend, precision):
 
     pre_reverse_spike_source_model = create_neuron_model(
         "pre_reverse_spike_source",
-        var_name_types=[("startSpike", "unsigned int"), 
+        vars=[("startSpike", "unsigned int"), 
                         ("endSpike", "unsigned int", VarAccess.READ_ONLY_DUPLICATE),
                         ("x", "scalar")],
         extra_global_params=[("spikeTimes", "scalar*")],
@@ -581,7 +581,7 @@ def test_reverse(make_model, backend, precision):
     
     pre_model = create_neuron_model(
         "pre",
-        var_name_types=[("x", "scalar")],
+        vars=[("x", "scalar")],
         extra_global_params=[("spikeTimes", "scalar*")],
         sim_code=
         """
@@ -594,7 +594,7 @@ def test_reverse(make_model, backend, precision):
         """
         addToPre(g);
         """,
-        var_name_types=[("g", "scalar", VarAccess.READ_ONLY)])
+        vars=[("g", "scalar", VarAccess.READ_ONLY)])
     
     static_pulse_reverse_constant_weight_model = create_weight_update_model(
         "static_pulse_reverse_constant_weight",
@@ -605,7 +605,7 @@ def test_reverse(make_model, backend, precision):
 
     static_event_pulse_reverse_model = create_weight_update_model(
         "static_event_pulse_reverse",
-        var_name_types=[("g", "scalar")],
+        vars=[("g", "scalar")],
         pre_event_threshold_condition_code=
         """
         (unsigned int)round(t) == id
@@ -696,7 +696,7 @@ def test_reverse(make_model, backend, precision):
 def test_reverse_post(make_model, backend, precision):
     pre_reverse_model = create_neuron_model(
         "pre_reverse",
-        var_name_types=[("x", "scalar")],
+        vars=[("x", "scalar")],
         sim_code=
         """
         x = Isyn;
@@ -708,7 +708,7 @@ def test_reverse_post(make_model, backend, precision):
         """
         addToPre(g);
         """,
-        var_name_types=[("g", "scalar", VarAccess.READ_ONLY)])
+        vars=[("g", "scalar", VarAccess.READ_ONLY)])
     
     static_pulse_reverse_event_post_model = create_weight_update_model(
         "static_pulse_reverse_event_post",
@@ -720,7 +720,7 @@ def test_reverse_post(make_model, backend, precision):
         """
         (unsigned int)round(t) == id
         """,
-        var_name_types=[("g", "scalar", VarAccess.READ_ONLY)])
+        vars=[("g", "scalar", VarAccess.READ_ONLY)])
 
     model = make_model(precision, "test_reverse_post", backend=backend)
     model.dt = 1.0

--- a/tests/features/test_event_times.py
+++ b/tests/features/test_event_times.py
@@ -54,7 +54,7 @@ def test_spike_times(make_model, backend, precision):
     # Neuron model which fires at t = id ms and every 10 ms after that
     pattern_spike_neuron_model = create_neuron_model(
         "pattern_spike_neuron",
-        var_name_types=[("a", "scalar")],
+        vars=[("a", "scalar")],
         sim_code=
         """
         a = st;
@@ -66,8 +66,8 @@ def test_spike_times(make_model, backend, precision):
 
     pre_weight_update_model = create_weight_update_model(
         "pre_weight_update",
-        var_name_types=[("a", "scalar"), ("b", "scalar")],
-        pre_var_name_types=[("c", "scalar")],
+        vars=[("a", "scalar"), ("b", "scalar")],
+        pre_vars=[("c", "scalar")],
         sim_code=
         """
         a = prev_st_pre;
@@ -83,7 +83,7 @@ def test_spike_times(make_model, backend, precision):
 
     post_weight_update_model = create_weight_update_model(
         "post_weight_update",
-        var_name_types=[("a", "scalar"), ("b", "scalar")],
+        vars=[("a", "scalar"), ("b", "scalar")],
         pre_spike_syn_code=
         """
         a = st_post;
@@ -161,7 +161,7 @@ def test_spike_event_times(make_model, backend, precision):
 
     pre_weight_update_model = create_weight_update_model(
         "pre_weight_update",
-        var_name_types=[("a", "scalar"), ("b", "scalar")],
+        vars=[("a", "scalar"), ("b", "scalar")],
         pre_event_syn_code=
         """
         a = prev_set_pre;
@@ -177,7 +177,7 @@ def test_spike_event_times(make_model, backend, precision):
 
     post_weight_update_model = create_weight_update_model(
         "post_weight_update",
-        var_name_types=[("a", "scalar"), ("b", "scalar")],
+        vars=[("a", "scalar"), ("b", "scalar")],
         pre_spike_syn_code=
         """
         a = set_post;

--- a/tests/features/test_num.py
+++ b/tests/features/test_num.py
@@ -30,7 +30,7 @@ def test_num(make_model, backend, precision, batch_size):
     # Models which set state variables to double one of the num_XXX variables
     neuron_model = create_neuron_model(
         "neuron",
-        var_name_types=[("num_neurons_test", "unsigned int"),
+        vars=[("num_neurons_test", "unsigned int"),
                         ("num_batch_test", "unsigned int")],
         sim_code=
         """
@@ -40,7 +40,7 @@ def test_num(make_model, backend, precision, batch_size):
 
     current_source_model = create_current_source_model(
         "current_source",
-        var_name_types=[("num_neurons_test", "unsigned int"),
+        vars=[("num_neurons_test", "unsigned int"),
                         ("num_batch_test", "unsigned int")],
         injection_code=
         """
@@ -50,12 +50,12 @@ def test_num(make_model, backend, precision, batch_size):
 
     weight_update_model = create_weight_update_model(
         "weight_update",
-        var_name_types=[("num_pre_syn_test", "unsigned int"),
+        vars=[("num_pre_syn_test", "unsigned int"),
                         ("num_post_syn_test", "unsigned int"),
                         ("num_batch_syn_test", "unsigned int")],
-        pre_var_name_types=[("num_neurons_pre_test", "unsigned int"),
+        pre_vars=[("num_neurons_pre_test", "unsigned int"),
                             ("num_batch_pre_test", "unsigned int")],
-        post_var_name_types=[("num_neurons_post_test", "unsigned int"),
+        post_vars=[("num_neurons_post_test", "unsigned int"),
                              ("num_batch_post_test", "unsigned int")],
         
         synapse_dynamics_code=
@@ -77,7 +77,7 @@ def test_num(make_model, backend, precision, batch_size):
 
     postsynaptic_update_model = create_postsynaptic_model(
         "postsynaptic_update",
-        var_name_types=[("num_neurons_test", "unsigned int"),
+        vars=[("num_neurons_test", "unsigned int"),
                         ("num_batch_test", "unsigned int")],
         sim_code=
         """
@@ -87,7 +87,7 @@ def test_num(make_model, backend, precision, batch_size):
 
     custom_update_model = create_custom_update_model(
         "custom_update",
-        var_name_types=[("num_neurons_test", "unsigned int"),
+        vars=[("num_neurons_test", "unsigned int"),
                         ("num_batch_test", "unsigned int")],
         var_refs=[("ref", "unsigned int", VarAccessMode.READ_ONLY)],
         update_code=
@@ -98,7 +98,7 @@ def test_num(make_model, backend, precision, batch_size):
 
     custom_update_wu_model = create_custom_update_model(
         "custom_update_wu",
-        var_name_types=[("num_pre_syn_test", "unsigned int"),
+        vars=[("num_pre_syn_test", "unsigned int"),
                         ("num_post_syn_test", "unsigned int"),
                         ("num_batch_syn_test", "unsigned int")],
         var_refs=[("ref", "unsigned int", VarAccessMode.READ_ONLY)],

--- a/tests/features/test_pre_post_neuron_vars.py
+++ b/tests/features/test_pre_post_neuron_vars.py
@@ -14,7 +14,7 @@ from pygenn import (create_neuron_model, create_var_ref,
 # into synapse during various kinds of synaptic event
 pre_learn_post_weight_update_model = create_weight_update_model(
     "pre_learn_post_weight_update",
-    var_name_types=[("w", "scalar")],
+    vars=[("w", "scalar")],
     pre_neuron_var_refs=[("s", "scalar", VarAccessMode.READ_ONLY)],
     
     post_spike_syn_code=
@@ -24,7 +24,7 @@ pre_learn_post_weight_update_model = create_weight_update_model(
 
 pre_sim_weight_update_model = create_weight_update_model(
     "pre_sim_weight_update",
-    var_name_types=[("w", "scalar")],
+    vars=[("w", "scalar")],
     pre_neuron_var_refs=[("s", "scalar", VarAccessMode.READ_ONLY)],
 
     pre_spike_syn_code=
@@ -34,7 +34,7 @@ pre_sim_weight_update_model = create_weight_update_model(
 
 pre_event_weight_update_model = create_weight_update_model(
     "pre_sim_weight_update",
-    var_name_types=[("w", "scalar")],
+    vars=[("w", "scalar")],
     pre_neuron_var_refs=[("s", "scalar", VarAccessMode.READ_ONLY)],
 
     pre_event_syn_code=
@@ -50,7 +50,7 @@ pre_event_weight_update_model = create_weight_update_model(
 # into synapse during various kinds of synaptic event
 post_sim_weight_update_model = create_weight_update_model(
     "post_sim_weight_update",
-    var_name_types=[("w", "scalar")],
+    vars=[("w", "scalar")],
     post_neuron_var_refs=[("s", "scalar", VarAccessMode.READ_ONLY)],
 
     pre_spike_syn_code=
@@ -60,7 +60,7 @@ post_sim_weight_update_model = create_weight_update_model(
 
 post_learn_post_weight_update_model = create_weight_update_model(
     "post_learn_post_weight_update",
-    var_name_types=[("w", "scalar")],
+    vars=[("w", "scalar")],
     post_neuron_var_refs=[("s", "scalar", VarAccessMode.READ_ONLY)],
 
     post_spike_syn_code=
@@ -70,7 +70,7 @@ post_learn_post_weight_update_model = create_weight_update_model(
 
 post_event_weight_update_model = create_weight_update_model(
     "pre_sim_weight_update",
-    var_name_types=[("w", "scalar")],
+    vars=[("w", "scalar")],
     post_neuron_var_refs=[("s", "scalar", VarAccessMode.READ_ONLY)],
 
     pre_event_syn_code=
@@ -97,7 +97,7 @@ def test_pre_post_neuron_var(make_model, backend, precision, delay):
         """
         t >= (scalar)id && fmod(t - (scalar)id, 10.0) < 1e-4
         """,
-        var_name_types=[("s", "scalar"), ("shift", "scalar", VarAccess.READ_ONLY)])
+        vars=[("s", "scalar"), ("shift", "scalar", VarAccess.READ_ONLY)])
 
     # Neuron model which updates a state variable with time + per-neuron shift
     shift_pattern_neuron_model = create_neuron_model(
@@ -106,7 +106,7 @@ def test_pre_post_neuron_var(make_model, backend, precision, delay):
         """
         s = t + shift;
         """,
-        var_name_types=[("s", "scalar"), ("shift", "scalar", VarAccess.READ_ONLY)])
+        vars=[("s", "scalar"), ("shift", "scalar", VarAccess.READ_ONLY)])
 
 
     model = make_model(precision, "test_pre_post_neuron_var", backend=backend)

--- a/tests/features/test_recording.py
+++ b/tests/features/test_recording.py
@@ -23,7 +23,7 @@ spike_event_source_array_model = create_neuron_model(
         output = false;
     }
     """,
-    var_name_types=[("startSpike", "unsigned int"), ("endSpike", "unsigned int", VarAccess.READ_ONLY_DUPLICATE),
+    vars=[("startSpike", "unsigned int"), ("endSpike", "unsigned int", VarAccess.READ_ONLY_DUPLICATE),
                     ("output", "bool")],
     extra_global_params=[("spikeTimes", "scalar*")])
 

--- a/tests/features/test_rng.py
+++ b/tests/features/test_rng.py
@@ -29,7 +29,7 @@ def test_sim(make_model, backend, precision, batch_size):
         uniform = gennrand_uniform();
         normal = gennrand_normal();
         """,
-        var_name_types=[("uniform", "scalar"), ("normal", "scalar")])
+        vars=[("uniform", "scalar"), ("normal", "scalar")])
 
     current_source_model = create_current_source_model(
         "current_source",
@@ -39,7 +39,7 @@ def test_sim(make_model, backend, precision, batch_size):
         normal = gennrand_normal();
         injectCurrent(0.0);
         """,
-        var_name_types=[("uniform", "scalar"), ("normal", "scalar")])
+        vars=[("uniform", "scalar"), ("normal", "scalar")])
 
     custom_connectivity_update_model = create_custom_connectivity_update_model(
         "custom_connectivity_update",
@@ -149,21 +149,21 @@ def test_init(make_model, backend, precision):
 
     nop_neuron_model = create_neuron_model(
         "nop_neuron",
-        var_name_types=create_vars())
+        vars=create_vars())
 
     nop_current_source_model = create_current_source_model(
         "nop_current_source",
-        var_name_types=create_vars())
+        vars=create_vars())
 
     nop_postsynaptic_update_model = create_postsynaptic_model(
         "nop_postsynaptic_update",
-        var_name_types=create_vars("psm_"))
+        vars=create_vars("psm_"))
 
     nop_weight_update_model = create_weight_update_model(
         "nop_weight_update",
-        var_name_types=create_vars(),
-        pre_var_name_types=create_vars("pre_"),
-        post_var_name_types=create_vars("post_"))
+        vars=create_vars(),
+        pre_vars=create_vars("pre_"),
+        post_vars=create_vars("post_"))
         
     model = make_model(precision, "test_init", backend=backend)
 

--- a/tests/features/test_wu_vars.py
+++ b/tests/features/test_wu_vars.py
@@ -37,8 +37,8 @@ def test_wu_var(make_model, backend, precision, fuse, delay):
     # during various kinds of synaptic event
     pre_learn_post_weight_update_model = create_weight_update_model(
         "pre_learn_post_weight_update",
-        var_name_types=[("w", "scalar")],
-        pre_var_name_types=[("s", "scalar")],
+        vars=[("w", "scalar")],
+        pre_vars=[("s", "scalar")],
         
         post_spike_syn_code=
         """
@@ -51,8 +51,8 @@ def test_wu_var(make_model, backend, precision, fuse, delay):
     
     pre_sim_weight_update_model = create_weight_update_model(
         "pre_sim_weight_update",
-        var_name_types=[("w", "scalar")],
-        pre_var_name_types=[("s", "scalar")],
+        vars=[("w", "scalar")],
+        pre_vars=[("s", "scalar")],
 
         pre_spike_syn_code=
         """
@@ -65,8 +65,8 @@ def test_wu_var(make_model, backend, precision, fuse, delay):
     
     pre_synapse_dynamics_weight_update_model = create_weight_update_model(
         "pre_synapse_dynamics_weight_update",
-        var_name_types=[("w", "scalar")],
-        pre_var_name_types=[("s", "scalar")],
+        vars=[("w", "scalar")],
+        pre_vars=[("s", "scalar")],
 
         synapse_dynamics_code=
         """
@@ -82,8 +82,8 @@ def test_wu_var(make_model, backend, precision, fuse, delay):
     # during various kinds of synaptic event
     post_learn_post_weight_update_model = create_weight_update_model(
         "post_learn_post_weight_update",
-        var_name_types=[("w", "scalar")],
-        post_var_name_types=[("s", "scalar")],
+        vars=[("w", "scalar")],
+        post_vars=[("s", "scalar")],
         
         post_spike_syn_code=
         """
@@ -96,8 +96,8 @@ def test_wu_var(make_model, backend, precision, fuse, delay):
     
     post_sim_weight_update_model = create_weight_update_model(
         "post_sim_weight_update",
-        var_name_types=[("w", "scalar")],
-        post_var_name_types=[("s", "scalar")],
+        vars=[("w", "scalar")],
+        post_vars=[("s", "scalar")],
 
         pre_spike_syn_code=
         """
@@ -110,8 +110,8 @@ def test_wu_var(make_model, backend, precision, fuse, delay):
     
     post_synapse_dynamics_weight_update_model = create_weight_update_model(
         "post_synapse_dynamics_weight_update",
-        var_name_types=[("w", "scalar")],
-        post_var_name_types=[("s", "scalar")],
+        vars=[("w", "scalar")],
+        post_vars=[("s", "scalar")],
         
         synapse_dynamics_code=
         """
@@ -225,8 +225,8 @@ def test_wu_var_cont(make_model, backend, precision, fuse, delay):
     # during various kinds of synaptic event
     pre_learn_post_weight_update_model = create_weight_update_model(
         "pre_learn_post_weight_update",
-        var_name_types=[("w", "scalar")],
-        pre_var_name_types=[("s", "scalar"), ("shift", "scalar", VarAccess.READ_ONLY)],
+        vars=[("w", "scalar")],
+        pre_vars=[("s", "scalar"), ("shift", "scalar", VarAccess.READ_ONLY)],
         
         post_spike_syn_code=
         """
@@ -239,8 +239,8 @@ def test_wu_var_cont(make_model, backend, precision, fuse, delay):
 
     pre_sim_weight_update_model = create_weight_update_model(
         "pre_sim_weight_update",
-        var_name_types=[("w", "scalar")],
-        pre_var_name_types=[("s", "scalar"), ("shift", "scalar", VarAccess.READ_ONLY)],
+        vars=[("w", "scalar")],
+        pre_vars=[("s", "scalar"), ("shift", "scalar", VarAccess.READ_ONLY)],
 
         pre_spike_syn_code=
         """
@@ -256,8 +256,8 @@ def test_wu_var_cont(make_model, backend, precision, fuse, delay):
     # during various kinds of synaptic event
     post_learn_post_weight_update_model = create_weight_update_model(
         "post_learn_post_weight_update",
-        var_name_types=[("w", "scalar")],
-        post_var_name_types=[("s", "scalar"), ("shift", "scalar", VarAccess.READ_ONLY)],
+        vars=[("w", "scalar")],
+        post_vars=[("s", "scalar"), ("shift", "scalar", VarAccess.READ_ONLY)],
         
         post_spike_syn_code=
         """
@@ -270,8 +270,8 @@ def test_wu_var_cont(make_model, backend, precision, fuse, delay):
     
     post_sim_weight_update_model = create_weight_update_model(
         "post_sim_weight_update",
-        var_name_types=[("w", "scalar")],
-        post_var_name_types=[("s", "scalar"), ("shift", "scalar", VarAccess.READ_ONLY)],
+        vars=[("w", "scalar")],
+        post_vars=[("s", "scalar"), ("shift", "scalar", VarAccess.READ_ONLY)],
 
         pre_spike_syn_code=
         """

--- a/tests/unit/customConnectivityUpdate.cc
+++ b/tests/unit/customConnectivityUpdate.cc
@@ -374,13 +374,15 @@ TEST(CustomConnectivityUpdate, CompareDifferentDependentVars)
         pre, post,
         initWeightUpdate<WeightUpdateModels::StaticPulseDendriticDelay>({}, {{"g", 1.0}, {"d", 1.0}}),
         initPostsynaptic<PostsynapticModels::DeltaCurr>());
-    
+    sg1->setMaxDendriticDelayTimesteps(1);
+
     auto *sg2 = model.addSynapsePopulation(
         "Synapses2", SynapseMatrixType::SPARSE,
         pre, post,
         initWeightUpdate<StaticPulseDendriticDelayReverse>({}, {{"g", 1.0}, {"d", 1.0}}),
         initPostsynaptic<PostsynapticModels::DeltaCurr>());
-    
+    sg2->setMaxDendriticDelayTimesteps(1);
+
     auto *sg3 = model.addSynapsePopulation(
         "Synapses3", SynapseMatrixType::SPARSE,
         pre, post,
@@ -462,34 +464,34 @@ TEST(CustomConnectivityUpdate, CompareRemap)
     stdpSG3->setNarrowSparseIndEnabled(true);
     
     // Create  custom updates to passively count synapse in static and STDP - neither should result in remap
-    auto *staticCountCCU = model.addCustomConnectivityUpdate<CountPositive>("StaticCountCCU", "Count", staticSG,
-                                                                            {}, {}, countPreVarValues, {},
-                                                                            {{"g", createWUVarRef(staticSG, "g")}});
-    auto *stdp1CountCCU = model.addCustomConnectivityUpdate<CountPositive>("STDP1CountCCU", "Count", stdpSG1,
-                                                                           {}, {}, countPreVarValues, {},
-                                                                           {{"g", createWUVarRef(stdpSG1, "g")}});
+    model.addCustomConnectivityUpdate<CountPositive>("StaticCountCCU", "Count", staticSG,
+                                                     {}, {}, countPreVarValues, {},
+                                                     {{"g", createWUVarRef(staticSG, "g")}});
+    model.addCustomConnectivityUpdate<CountPositive>("STDP1CountCCU", "Count", stdpSG1,
+                                                     {}, {}, countPreVarValues, {},
+                                                     {{"g", createWUVarRef(stdpSG1, "g")}});
 
     // Create custom update to remove connections from static synapse - no need for remap
-    auto *staticRemove1CCU = model.addCustomConnectivityUpdate<RemoveSynapse>("StaticRemove1CCU", "Remove1", staticSG,
-                                                                             {}, {{"a", 1.0}});
+    model.addCustomConnectivityUpdate<RemoveSynapse>("StaticRemove1CCU", "Remove1", staticSG,
+                                                     {}, {{"a", 1.0}});
 
     // Create two custom updates to remove connections from STDP sg 1 - needs one remap
-    auto *stdp1Remove1CCU1 = model.addCustomConnectivityUpdate<RemoveSynapse>("STDP1Remove1CCU1", "Remove1", stdpSG1,
-                                                                             {}, {{"a", 1.0}});
-    auto *stdp1Remove1CCU2 = model.addCustomConnectivityUpdate<RemoveSynapse>("STDP1Remove1CCU2", "Remove1", stdpSG1,
-                                                                            {}, {{"a", 1.0}});
+    model.addCustomConnectivityUpdate<RemoveSynapse>("STDP1Remove1CCU1", "Remove1", stdpSG1,
+                                                     {}, {{"a", 1.0}});
+    model.addCustomConnectivityUpdate<RemoveSynapse>("STDP1Remove1CCU2", "Remove1", stdpSG1,
+                                                     {}, {{"a", 1.0}});
 
     // Create custom update to remove connections from STDP sg 1 in different group - needs one remap
-    auto *stdp1Remove2CCU = model.addCustomConnectivityUpdate<RemoveSynapse>("STDP1Remove2CCU", "Remove2", stdpSG1,
-                                                                             {}, {{"a", 1.0}});
+    model.addCustomConnectivityUpdate<RemoveSynapse>("STDP1Remove2CCU", "Remove2", stdpSG1,
+                                                     {}, {{"a", 1.0}});
     
     // Create custom update to remove connections from STDP sg 3 which has narrowed indices - needs one remap
-    auto *stdp3Remove1CCU = model.addCustomConnectivityUpdate<RemoveSynapse>("STDP3Remove1CCU", "Remove1", stdpSG3,
-                                                                             {}, { {"a", 1.0} });
+    model.addCustomConnectivityUpdate<RemoveSynapse>("STDP3Remove1CCU", "Remove1", stdpSG3,
+                                                     {}, { {"a", 1.0} });
 
     // Create custom update to remove connections from STDP sg 2 in different group - needs one remap
-    auto *stdp2Remove1CCU = model.addCustomConnectivityUpdate<RemoveSynapse>("STDP2Remove1CCU", "Remove1", stdpSG2,
-                                                                             {}, {{"a", 1.0}});
+    model.addCustomConnectivityUpdate<RemoveSynapse>("STDP2Remove1CCU", "Remove1", stdpSG2,
+                                                     {}, {{"a", 1.0}});
 
     model.finalise();
 

--- a/tests/unit/customUpdate.cc
+++ b/tests/unit/customUpdate.cc
@@ -298,6 +298,7 @@ TEST(CustomUpdates, VarReferenceTypeChecks)
         pre, post,
         initWeightUpdate<WeightUpdateModels::StaticPulseDendriticDelay>({}, {{"g", 1.0}, {"d", 4}}),
         initPostsynaptic<PostsynapticModels::DeltaCurr>());
+    sg1->setMaxDendriticDelayTimesteps(1);
 
     VarValues sumVarValues{{"sum", 0.0}};
     WUVarReferences sumVarReferences1{{"a", createWUVarRef(sg1, "g")}, {"b", createWUVarRef(sg1, "g")}};
@@ -465,12 +466,14 @@ TEST(CustomUpdates, WUVarSynapseGroupChecks)
         pre, post,
         initWeightUpdate<WeightUpdateModels::StaticPulseDendriticDelay>({}, {{"g", 1.0}, {"d", 4}}),
         initPostsynaptic<PostsynapticModels::DeltaCurr>());
+    sg1->setMaxDendriticDelayTimesteps(1);
+
     auto *sg2 = model.addSynapsePopulation(
         "Synapses2", SynapseMatrixType::DENSE,
         pre, post,
         initWeightUpdate<WeightUpdateModels::StaticPulseDendriticDelay>({}, {{"g", 1.0}, {"d", 4}}),
         initPostsynaptic<PostsynapticModels::DeltaCurr>());
-
+    sg2->setMaxDendriticDelayTimesteps(1);
 
     VarValues sumVarValues{{"sum", 0.0}};
     WUVarReferences sumVarReferences1{{"a", createWUVarRef(sg1, "g")}, {"b", createWUVarRef(sg1, "g")}};
@@ -1111,6 +1114,7 @@ TEST(CustomUpdates, CompareDifferentWUBatched)
         pre, post,
         initWeightUpdate<StaticPulseDendriticDelaySplit>({}, synVarInit),
         initPostsynaptic<PostsynapticModels::DeltaCurr>());
+    sg1->setMaxDendriticDelayTimesteps(1);
 
     // Add one custom update which sums duplicated variables (g and d), another which sums shared variables (gCommon and dCommon) and another which sums one of each
     WUVarReferences sumVarReferences1{{"a", createWUVarRef(sg1, "g")}, {"b", createWUVarRef(sg1, "d")}};

--- a/tests/unit/neuronGroup.cc
+++ b/tests/unit/neuronGroup.cc
@@ -469,21 +469,24 @@ TEST(NeuronGroup, FusePSM)
         pre, post,
         initWeightUpdate<WeightUpdateModels::StaticPulseDendriticDelay>({}, wumVarVals),
         initPostsynaptic<PostsynapticModels::ExpCurr>(psmParamVals, {}));
-    
+    syn->setMaxDendriticDelayTimesteps(1);
+
     // Create second synapse group
     auto *syn2 = model.addSynapsePopulation(
         "Syn2", SynapseMatrixType::DENSE,
         pre, post,
         initWeightUpdate<WeightUpdateModels::StaticPulseDendriticDelay>({}, wumVarVals),
         initPostsynaptic<PostsynapticModels::ExpCurr>(psmParamVals, {}));
-    
+    syn2->setMaxDendriticDelayTimesteps(1);
+
     // Create synapse group with different value for PSM parameter
     auto *synParam = model.addSynapsePopulation(
         "SynParam", SynapseMatrixType::DENSE,
         pre, post,
         initWeightUpdate<WeightUpdateModels::StaticPulseDendriticDelay>({}, wumVarVals),
         initPostsynaptic<PostsynapticModels::ExpCurr>(psmParamVals2, {}));
-    
+    synParam->setMaxDendriticDelayTimesteps(1);
+
     // Create synapse group with different target variable
     auto *synTarget = model.addSynapsePopulation(
         "SynTarget", SynapseMatrixType::DENSE,
@@ -491,7 +494,8 @@ TEST(NeuronGroup, FusePSM)
         initWeightUpdate<WeightUpdateModels::StaticPulseDendriticDelay>({}, wumVarVals),
         initPostsynaptic<PostsynapticModels::ExpCurr>(psmParamVals, {}));
     synTarget->setPostTargetVar("Isyn2");
-    
+    synTarget->setMaxDendriticDelayTimesteps(1);
+
     // Create synapse group with different max dendritic delay
     auto *synDelay = model.addSynapsePopulation(
         "SynDelay", SynapseMatrixType::DENSE,
@@ -499,7 +503,7 @@ TEST(NeuronGroup, FusePSM)
         initWeightUpdate<WeightUpdateModels::StaticPulseDendriticDelay>({}, wumVarVals),
         initPostsynaptic<PostsynapticModels::ExpCurr>(psmParamVals, {}));
     synDelay->setMaxDendriticDelayTimesteps(20);
-    
+
     model.finalise();
     
     // Cast synapse groups to internal types
@@ -552,13 +556,15 @@ TEST(NeuronGroup, FuseVarPSM)
         pre, post,
         initWeightUpdate<WeightUpdateModels::StaticPulseDendriticDelay>({}, wumVarVals),
         initPostsynaptic<AlphaCurr>(psmParamVals, psmVarValsConst1));
-    
+    syn1->setMaxDendriticDelayTimesteps(1);
+
     // Create second synapse group with same model and constant initialisers
     auto *syn2 = model.addSynapsePopulation(
         "Syn2", SynapseMatrixType::DENSE,
         pre, post,
         initWeightUpdate<WeightUpdateModels::StaticPulseDendriticDelay>({}, wumVarVals),
         initPostsynaptic<AlphaCurr>(psmParamVals, psmVarValsConst1));
+    syn2->setMaxDendriticDelayTimesteps(1);
 
     // Create third synapse group with same model and different constant initialisers
     auto *syn3 = model.addSynapsePopulation(
@@ -566,14 +572,15 @@ TEST(NeuronGroup, FuseVarPSM)
         pre, post,
         initWeightUpdate<WeightUpdateModels::StaticPulseDendriticDelay>({}, wumVarVals),
         initPostsynaptic<AlphaCurr>(psmParamVals, psmVarValsConst2));
-    
+    syn3->setMaxDendriticDelayTimesteps(1);
+
      // Create fourth synapse group with same model and random variable initialisers
     auto *syn4 = model.addSynapsePopulation(
         "Syn4", SynapseMatrixType::DENSE,
         pre, post,
         initWeightUpdate<WeightUpdateModels::StaticPulseDendriticDelay>({}, wumVarVals),
         initPostsynaptic<AlphaCurr>(psmParamVals, psmVarValsRand));
-    
+    syn4->setMaxDendriticDelayTimesteps(1);
     
     // **TODO** third safe group with different variable initialisers
     model.finalise();

--- a/tests/unit/scanner.cc
+++ b/tests/unit/scanner.cc
@@ -150,7 +150,7 @@ TEST(Scanner, String)
 TEST(Scanner, IsIdentifierDelayed)
 {
     TestErrorHandler errorHandler;
-    const auto tokens = Scanner::scanSource("X[10] Z Y[3] Y[0] X Z", errorHandler);
+    const auto tokens = Scanner::scanSource("X[10] W Z Y[3] Y[0] X Z W[10]", errorHandler);
     ASSERT_FALSE(errorHandler.hasError());
 
     // Check delayed tokens
@@ -160,9 +160,11 @@ TEST(Scanner, IsIdentifierDelayed)
     ASSERT_FALSE(Utils::isIdentifierDelayed("Z", tokens));
 
     // Check non-existent tokens aren't delayed
-    ASSERT_FALSE(Utils::isIdentifierDelayed("W", tokens));
+    ASSERT_FALSE(Utils::isIdentifierDelayed("T", tokens));
 
     // Check error is thrown if identifier is referenced with and without delay
     EXPECT_THROW({ Utils::isIdentifierDelayed("X", tokens); }, 
+        std::runtime_error);
+    EXPECT_THROW({ Utils::isIdentifierDelayed("W", tokens); }, 
         std::runtime_error);
 }

--- a/tests/unit/scanner.cc
+++ b/tests/unit/scanner.cc
@@ -2,6 +2,7 @@
 #include "gtest/gtest.h"
 
 // GeNN includes
+#include "gennUtils.h"
 #include "type.h"
 
 // GeNN transpiler includes
@@ -144,4 +145,24 @@ TEST(Scanner, String)
 
     ASSERT_EQ(tokens[0].lexeme, "\"hello world\"");
     ASSERT_EQ(tokens[1].lexeme, "\"pre-processor\"");
+}
+//--------------------------------------------------------------------------
+TEST(Scanner, IsIdentifierDelayed)
+{
+    TestErrorHandler errorHandler;
+    const auto tokens = Scanner::scanSource("X[10] Z Y[3] Y[0] X Z", errorHandler);
+    ASSERT_FALSE(errorHandler.hasError());
+
+    // Check delayed tokens
+    ASSERT_TRUE(Utils::isIdentifierDelayed("Y", tokens));
+
+    // Check non-delayed tokens
+    ASSERT_FALSE(Utils::isIdentifierDelayed("Z", tokens));
+
+    // Check non-existent tokens aren't delayed
+    ASSERT_FALSE(Utils::isIdentifierDelayed("W", tokens));
+
+    // Check error is thrown if identifier is referenced with and without delay
+    EXPECT_THROW({ Utils::isIdentifierDelayed("X", tokens); }, 
+        std::runtime_error);
 }

--- a/tests/unit/synapseGroup.cc
+++ b/tests/unit/synapseGroup.cc
@@ -989,6 +989,31 @@ TEST(SynapseGroup, IsDendriticDelayRequired)
     ASSERT_TRUE(static_cast<SynapseGroupInternal*>(synContinuous)->isDendriticDelayRequired());
 }
 
+TEST(SynapseGroup, SetMaxDendriticDelayTimesteps)
+{
+    ParamValues paramVals{{"a", 0.02}, {"b", 0.2}, {"c", -65.0}, {"d", 8.0}};
+    VarValues varVals{{"V", 0.0}, {"U", 0.0}};
+
+    ModelSpecInternal model;
+    auto *pre = model.addNeuronPopulation<NeuronModels::Izhikevich>("Pre", 10, paramVals, varVals);
+    auto *post = model.addNeuronPopulation<NeuronModels::Izhikevich>("Post", 10, paramVals, varVals);
+
+    ParamValues staticPulseDendriticParamVals{{"g", 0.1}, {"d", 1}};
+
+    auto *syn = model.addSynapsePopulation(
+        "Syn", SynapseMatrixType::DENSE,
+        pre, post,
+        initWeightUpdate<StaticPulseDendriticDelayConstantWeight>(staticPulseDendriticParamVals, {}),
+        initPostsynaptic<PostsynapticModels::DeltaCurr>());
+
+    try {
+        model.finalise();
+        FAIL();
+    }
+    catch(const std::runtime_error &) {
+    }
+}
+
 TEST(SynapseGroup, InvalidName)
 {
     ParamValues paramVals{{"a", 0.02}, {"b", 0.2}, {"c", -65.0}, {"d", 8.0}};

--- a/tests/unit/synapseGroup.cc
+++ b/tests/unit/synapseGroup.cc
@@ -986,9 +986,9 @@ TEST(SynapseGroup, IsDendriticDelayRequired)
         initWeightUpdate<ContinuousDenDelay>(contDenDelayParamVars, {}),
         initPostsynaptic<PostsynapticModels::DeltaCurr>());
 
-    ASSERT_TRUE(static_cast<SynapseGroupInternal*>(syn)->isDendriticDelayRequired());
-    ASSERT_TRUE(static_cast<SynapseGroupInternal*>(synGraded)->isDendriticDelayRequired());
-    ASSERT_TRUE(static_cast<SynapseGroupInternal*>(synContinuous)->isDendriticDelayRequired());
+    ASSERT_TRUE(static_cast<SynapseGroupInternal*>(syn)->isDendriticOutputDelayRequired());
+    ASSERT_TRUE(static_cast<SynapseGroupInternal*>(synGraded)->isDendriticOutputDelayRequired());
+    ASSERT_TRUE(static_cast<SynapseGroupInternal*>(synContinuous)->isDendriticOutputDelayRequired());
 }
 
 TEST(SynapseGroup, SetMaxDendriticDelayTimesteps)

--- a/tests/unit/synapseGroup.cc
+++ b/tests/unit/synapseGroup.cc
@@ -335,6 +335,8 @@ TEST(SynapseGroup, CompareWUDifferentModel)
         ng0, ng1,
         initWeightUpdate<WeightUpdateModels::StaticPulseDendriticDelay>({}, staticPulseDendriticVarVals),
         initPostsynaptic<PostsynapticModels::DeltaCurr>());
+    sg1->setMaxDendriticDelayTimesteps(1);
+
     // Finalize model
     model.finalise();
 
@@ -1000,7 +1002,7 @@ TEST(SynapseGroup, SetMaxDendriticDelayTimesteps)
 
     ParamValues staticPulseDendriticParamVals{{"g", 0.1}, {"d", 1}};
 
-    auto *syn = model.addSynapsePopulation(
+    model.addSynapsePopulation(
         "Syn", SynapseMatrixType::DENSE,
         pre, post,
         initWeightUpdate<StaticPulseDendriticDelayConstantWeight>(staticPulseDendriticParamVals, {}),

--- a/tests/unit/typeChecker.cc
+++ b/tests/unit/typeChecker.cc
@@ -179,6 +179,17 @@ TEST(TypeChecker, ArraySubscript)
 
     // Pointer to pointer, double indexing
 
+    // Array-subscript overload indexing
+    {
+        TestEnvironment typeEnvironment;
+        typeEnvironment.define(Type::ResolvedType::createFunction(Type::Int32, {Type::Uint32},
+                                                                  Type::FunctionFlags::ARRAY_SUBSCRIPT_OVERRIDE),
+                               "overrideIntArray");
+        const auto type = typeCheckExpression("overrideIntArray[4]", typeEnvironment);
+        EXPECT_EQ(type, Type::Int32);
+        EXPECT_FALSE(type.isConst);
+    }
+
     // Float array indexing
     EXPECT_THROW({
         TestEnvironment typeEnvironment;


### PR DESCRIPTION
This PR enables you to access postsynaptic neuron variable references and postsynaptic weight update model variables in synapse code (pre, post spike/spike-like event triggered or synapse dynamics) using an array subscript expression to specify a potentially heterogeneous delay slot e.g. ``x_post[d]``. This interacts with the existing delay system as follows:

* If any postsynaptic _neuron_ variable references are made with new ``[]`` syntax
    - Number of postsynaptic neuron group delay slots needs to be made at least as large as max dendritic delay
    - Target neuron variables need to be marked as queued using the existing mechanism so they are allocated + initialised with delay slots
* If any postsynaptic _weight update model_ variables are accessed with new ``[]`` syntax
    - Again, the number of postsynaptic neuron group delay slots needs to be made at least as large as max dendritic delay 
    - With the old homogeneous delays, if synapse group was delayed, all weight update model pre and postsynaptic variables were delayed. However, now, some postsynaptic weight update model variables might be delayed and some not. To address this I've added a very similar mechanism to the neuron variable queuing to synapse group which has repercussions for fusing etc etc

One side effect of this change is that neuron groups might now have some variables which require queueing but no axonal/backpropagation delays applied to their spikes. This resulted in unnecessarily complex code being generated for spike handling so I have extended the existing tracking of which variables are queued to also track whether spikes or spike events are queued.

The handling of the actual ``[d]`` syntax is implemented by adding ``x_post`` to the type system as a special sort of function (with signature ``scalar x_post(int index)`` (assuming the type of ``x_post`` is ``scalar``). These functions are tagged with the ``Type::FunctionFlags::ARRAY_SUBSCRIPT_OVERRIDE`` flag. The type checker and pretty printer then treat, ``[]`` as a special sort of function call which enables all the existing substitution magic used to stick code behind functions to be used.

In the process of making this change, I tidied up a few things:

- Added an error if ``addToPostDelay`` is called or the new ``[]`` syntax is used in synapse code but no maximum number of dendritic delay steps has been specified.
- Types in the type system don't really need an enum of qualifiers - the only qualifier that's ever going to be supported is ``const`` so I have simplified a bunch of code by replacing this with a simple bool. Conversely, function types *do* need some more flags so replaced ``variadic`` boolean with some flags (now including ``Type::FunctionFlags::ARRAY_SUBSCRIPT_OVERRIDE`` )
- Because of type promotion, it doesn't _really_ matter but the types of ``addToPre`` functions etc actually vary depending on what type ``scalar`` is so constants like ``Type::AddToPre`` have been replaced by functions like ``Type::getAddToPre(Type::Float)`` which generate the right function type.
- The syntax for ``EnvironmentLocalVarCache`` was unnecessarily complex - the adaptor type being passed in already provides the required information about delay an 99% of the time this is what determines whether variables should be copied between delay slots every timestep.
- Finally got annoyed enough to update some warnings about deprecated kwargs in the tests
