### PR TITLE
Ability to add to kernel weights

### DIFF
--- a/include/genn/backends/single_threaded_cpu/backend.h
+++ b/include/genn/backends/single_threaded_cpu/backend.h
@@ -118,6 +118,10 @@ public:
     virtual void genKernelSynapseVariableInit(EnvironmentExternalBase &env, SynapseInitGroupMerged &sg, HandlerEnv handler) const final;
     virtual void genKernelCustomUpdateVariableInit(EnvironmentExternalBase &env, CustomWUUpdateInitGroupMerged &cu, HandlerEnv handler) const final;
 
+    //! Get suitable atomic *lhsPointer += rhsValue or *lhsPointer |= rhsValue style operation
+    virtual std::string getAtomicOperation(const std::string &lhsPointer, const std::string &rhsValue,
+                                           const Type::ResolvedType &type, AtomicOperation op = AtomicOperation::ADD) const final;
+
     virtual void genGlobalDeviceRNG(CodeStream &definitions, CodeStream &runner, CodeStream &allocations, CodeStream &free) const final;
     virtual void genTimer(CodeStream &definitions, CodeStream &runner, CodeStream &allocations, CodeStream &free, CodeStream &stepTimeFinalise, 
                           const std::string &name, bool updateInStepTime) const final;

--- a/include/genn/genn/code_generator/backendBase.h
+++ b/include/genn/genn/code_generator/backendBase.h
@@ -124,6 +124,16 @@ struct PreferencesBase
 class GENN_EXPORT BackendBase
 {
 public:
+    //------------------------------------------------------------------------
+    // Enumerations
+    //------------------------------------------------------------------------
+    //! What atomic operation is required
+    enum class AtomicOperation
+    {
+        ADD,
+        OR,
+    };
+
     //--------------------------------------------------------------------------
     // Typedefines
     //--------------------------------------------------------------------------
@@ -235,6 +245,10 @@ public:
     virtual void genDenseSynapseVariableRowInit(EnvironmentExternalBase &env, HandlerEnv handler) const = 0;
     virtual void genKernelSynapseVariableInit(EnvironmentExternalBase &env, SynapseInitGroupMerged &sg, HandlerEnv handler) const = 0;
     virtual void genKernelCustomUpdateVariableInit(EnvironmentExternalBase &env, CustomWUUpdateInitGroupMerged &cu, HandlerEnv handler) const = 0;
+
+    //! Get suitable atomic *lhsPointer += rhsValue or *lhsPointer |= rhsValue style operation
+    virtual std::string getAtomicOperation(const std::string &lhsPointer, const std::string &rhsValue,
+                                           const Type::ResolvedType &type, AtomicOperation op = AtomicOperation::ADD) const = 0;
 
     //! Generate a single RNG instance
     /*! On single-threaded platforms this can be a standard RNG like M.T. but, on parallel platforms, it is likely to be a counter-based RNG */

--- a/include/genn/genn/code_generator/backendSIMT.h
+++ b/include/genn/genn/code_generator/backendSIMT.h
@@ -59,13 +59,6 @@ public:
     //------------------------------------------------------------------------
     // Enumerations
     //------------------------------------------------------------------------
-    //! What atomic operation is required
-    enum class AtomicOperation
-    {
-        ADD,
-        OR,
-    };
-
     //! What memory space atomic operation is required
     enum class AtomicMemSpace
     {
@@ -143,6 +136,10 @@ public:
     
     virtual void genKernelSynapseVariableInit(EnvironmentExternalBase &env, SynapseInitGroupMerged &sg, HandlerEnv handler) const final;
     virtual void genKernelCustomUpdateVariableInit(EnvironmentExternalBase &env, CustomWUUpdateInitGroupMerged &cu, HandlerEnv handler) const final;
+
+    //! Get suitable atomic *lhsPointer += rhsValue or *lhsPointer |= rhsValue style operation
+    virtual std::string getAtomicOperation(const std::string &lhsPointer, const std::string &rhsValue,
+                                           const Type::ResolvedType &type, AtomicOperation op = AtomicOperation::ADD) const final;
 
     //! Should 'scalar' variables be implemented on device or can host variables be used directly?
     virtual bool isDeviceScalarRequired() const final { return true; }

--- a/include/genn/genn/code_generator/synapseUpdateGroupMerged.h
+++ b/include/genn/genn/code_generator/synapseUpdateGroupMerged.h
@@ -102,9 +102,9 @@ public:
         generateRunnerBase(backend, definitions, name);
     }
 
-    void generateSpikeEventUpdate(EnvironmentExternalBase &env, 
+    void generateSpikeEventUpdate(const BackendBase &backend, EnvironmentExternalBase &env, 
                                   unsigned int batchSize, double dt);
-    void generateSpikeUpdate(EnvironmentExternalBase &env, 
+    void generateSpikeUpdate(const BackendBase &backend, EnvironmentExternalBase &env, 
                              unsigned int batchSize, double dt);
     void generateProceduralConnectivity(EnvironmentExternalBase &env);
     void generateToeplitzConnectivity(EnvironmentExternalBase &env,
@@ -130,9 +130,9 @@ public:
         generateRunnerBase(backend, definitions, name);
     }
 
-    void generateSpikeEventUpdate(EnvironmentExternalBase &env, 
+    void generateSpikeEventUpdate(const BackendBase &backend, EnvironmentExternalBase &env, 
                                   unsigned int batchSize, double dt);
-    void generateSpikeUpdate(EnvironmentExternalBase &env, 
+    void generateSpikeUpdate(const BackendBase &backend, EnvironmentExternalBase &env, 
                              unsigned int batchSize, double dt);
     
     //----------------------------------------------------------------------------
@@ -154,7 +154,7 @@ public:
         generateRunnerBase(backend, definitions, name);
     }
 
-    void generateSynapseUpdate(EnvironmentExternalBase &env, 
+    void generateSynapseUpdate(const BackendBase &backend, EnvironmentExternalBase &env, 
                                unsigned int batchSize, double dt);
 
     //----------------------------------------------------------------------------

--- a/src/genn/backends/single_threaded_cpu/backend.cc
+++ b/src/genn/backends/single_threaded_cpu/backend.cc
@@ -1607,11 +1607,11 @@ std::string Backend::getAtomicOperation(const std::string &lhsPointer, const std
                                         const Type::ResolvedType &type, AtomicOperation op) const
 {
     if(op == AtomicOperation::ADD) {
-        return "(*" + lhsPointer + " += " + rhsValue + ")";
+        return "(*(" + lhsPointer + ") += (" + rhsValue + "))";
     }
     else if(op == AtomicOperation::OR) {
         assert(type == Type::Uint32 || type == Type::Int32);
-        return "(" + lhsPointer + " |= " + rhsValue + ")";
+        return "(*(" + lhsPointer + ") |= (" + rhsValue + "))";
     }
     else {
         assert(false);

--- a/src/genn/genn/code_generator/presynapticUpdateStrategySIMT.cc
+++ b/src/genn/genn/code_generator/presynapticUpdateStrategySIMT.cc
@@ -141,10 +141,10 @@ void PreSpan::genUpdate(EnvironmentExternalBase &env, PresynapticUpdateGroupMerg
             synEnv.add(Type::getAddToPrePost(sg.getScalarType()), "addToPre", "lOutPre += ($(0))");
             
             if(trueSpike) {
-                sg.generateSpikeUpdate(synEnv, batchSize, dt);
+                sg.generateSpikeUpdate(backend, synEnv, batchSize, dt);
             }
             else {
-                sg.generateSpikeEventUpdate(synEnv, batchSize, dt);
+                sg.generateSpikeEventUpdate(backend, synEnv, batchSize, dt);
             }
             
         }
@@ -319,10 +319,10 @@ void PostSpan::genUpdate(EnvironmentExternalBase &env, PresynapticUpdateGroupMer
                 synEnv.add(Type::getAddToPrePost(sg.getScalarType()), "addToPre", "lOutPre += ($(0))");
 
                 if(trueSpike) {
-                    sg.generateSpikeUpdate(synEnv, batchSize, dt);
+                    sg.generateSpikeUpdate(backend, synEnv, batchSize, dt);
                 }
                 else {
-                    sg.generateSpikeEventUpdate(synEnv, batchSize, dt);
+                    sg.generateSpikeEventUpdate(backend, synEnv, batchSize, dt);
                 }
 
                 if(sg.getArchetype().getMatrixType() & SynapseMatrixConnectivity::SPARSE) {
@@ -509,10 +509,10 @@ void PreSpanProcedural::genUpdate(EnvironmentExternalBase &env, PresynapticUpdat
 
             // Generate spike update
             if(trueSpike) {
-                sg.generateSpikeUpdate(preUpdateEnv, batchSize, dt);
+                sg.generateSpikeUpdate(backend, preUpdateEnv, batchSize, dt);
             }
             else {
-                sg.generateSpikeEventUpdate(preUpdateEnv, batchSize, dt);
+                sg.generateSpikeEventUpdate(backend, preUpdateEnv, batchSize, dt);
             }
         }
 
@@ -689,10 +689,10 @@ void PostSpanBitmask::genUpdate(EnvironmentExternalBase &env, PresynapticUpdateG
                     postEnv.add(Type::getAddToPrePost(sg.getScalarType()), "addToPre", "lOutPre += ($(0))");
 
                     if(trueSpike) {
-                        sg.generateSpikeUpdate(postEnv, batchSize, dt);
+                        sg.generateSpikeUpdate(backend, postEnv, batchSize, dt);
                     }
                     else {
-                        sg.generateSpikeEventUpdate(postEnv, batchSize, dt);
+                        sg.generateSpikeEventUpdate(backend, postEnv, batchSize, dt);
                     }
 
                     postEnv.getStream() << "ibit++;" << std::endl;
@@ -827,10 +827,10 @@ void PostSpanToeplitz::genUpdate(EnvironmentExternalBase &env, PresynapticUpdate
 
         // Generate spike update
         if(trueSpike) {
-            sg.generateSpikeUpdate(preUpdateEnv, 1, dt);
+            sg.generateSpikeUpdate(backend, preUpdateEnv, 1, dt);
         }
         else {
-            sg.generateSpikeEventUpdate(preUpdateEnv, 1, dt);
+            sg.generateSpikeEventUpdate(backend, preUpdateEnv, 1, dt);
         }
     }
 


### PR DESCRIPTION
This PR adds:

1. A backend-agnostic way of generating simple (i.e. not returning previous value or selecting memory spaces) atomic functions (on SIMT backends, this just wraps subset of existing atomic-function generation functionality and, on single-threaded CPU backend, it inserts a += style operator).
2. When making synapse substitutions, create pointer fields for kernel weights and, from these, create read-only variable accessors AND atomic functions to allow modification of READ-WRITE variables.

I am not going to document this as it's more of a quick fix than how I want to implement this in the longer term.