### PR TITLE
Fix deprecation

### DIFF
--- a/pygenn/genn_model.py
+++ b/pygenn/genn_model.py
@@ -27,12 +27,12 @@ from .genn_groups import (CurrentSourceMixin, CustomConnectivityUpdateMixin,
                           CustomUpdateMixin, CustomUpdateWUMixin,
                           NeuronGroupMixin, SynapseGroupMixin)
 
-from distutils.spawn import find_executable
 from importlib import import_module
 from os import path, environ
 from platform import system
 from psutil import cpu_count
 from setuptools import msvc
+from shutil import which
 from subprocess import check_call  # to call make
 from textwrap import dedent
 from warnings import warn
@@ -83,8 +83,7 @@ if system() == "Windows":
     # Find MSBuild in path
     # **NOTE** we need to do this because setting the path via 
     # check_call's env kwarg does not effect finding the executable
-    # **NOTE** shutil.which would be nicer, but isn't in Python < 3.3
-    _msbuild = find_executable("msbuild",  _msvc_env["PATH"])
+    _msbuild = which("msbuild",  path=_msvc_env["PATH"])
 
     # If Python version is newer than 3.8 and CUDA path is in environment
     if sys.version_info >= (3, 8) and "CUDA_PATH" in environ:

--- a/setup.py
+++ b/setup.py
@@ -289,7 +289,8 @@ setup(
     zip_safe=False,
     python_requires=">=3.6",
     install_requires=["numpy>=1.17", "psutil",
-                      "importlib-metadata>=1.0;python_version<'3.8'"],
+                      "importlib-metadata>=1.0;python_version<'3.8'",
+                      "setuptools<74.0"],
     extras_require={
         "doc": ["sphinx", "sphinx-gallery", "sphinx-argparse"],
         "userproject": ["mnist", "tqdm", "scipy", "matplotlib"],


### PR DESCRIPTION
Fixed a couple of minor issues:
* ``distutils`` and hence ``distutils.spawn.find_executable`` is deprecated, replace with ``shutil.which``. Only reason we didn't do this before was because GeNN 4.X tried to maintain Python 2.7 compatibility.
* ``setuptools`` 74 gets rid of the module of Visual Studio magic helpers which we use to find the compiler on Windows. For now have just restricted setuptools to < 74 (This also affects Brian https://github.com/brian-team/brian2/issues/1557)