### PR TITLE
Fixed merging/fusing issue with multiple spike-like event conditions

### DIFF
--- a/src/genn/genn/neuronGroup.cc
+++ b/src/genn/genn/neuronGroup.cc
@@ -631,6 +631,10 @@ boost::uuids::detail::sha1::digest_type NeuronGroup::getInitHashDigest() const
     // **NOTE** nothing else is required as logic of initialisation only depends on number of delay slots
     Utils::updateHash(getFusedSpike().size(), hash);
 
+    // Update hash with number of fused spike event conditions
+    // **NOTE** nothing else is required as logic of initialisation only depends on number of delay slots
+    Utils::updateHash(getFusedSpikeEvent().size(), hash);
+
     // Update hash with hash list built from current sources
     updateHashList(this, getCurrentSources(), hash, &CurrentSourceInternal::getInitHashDigest);
 


### PR DESCRIPTION
Initialisation doesn't care much about what happens in a merged neuron group's outgoing spike-like events but it needs to know how many different conditions there are so it can zero out the correct number of datastructures. This was missing.