### PR TITLE
Stop Windows CUDA compilation relying on correct order of CUDA + Visual Studio installation

### DIFF
--- a/src/genn/backends/cuda/backend.cc
+++ b/src/genn/backends/cuda/backend.cc
@@ -1945,7 +1945,7 @@ void Backend::genMSBuildImportProps(std::ostream &os) const
 {
     // Import CUDA props file
     os << "\t<ImportGroup Label=\"ExtensionSettings\">" << std::endl;
-    os << "\t\t<Import Project=\"$(VCTargetsPath)\\BuildCustomizations\\CUDA $(CudaVersion).props\" />" << std::endl;
+    os << "\t\t<Import Project=\"$(CUDA_PATH)\\extras\\visual_studio_integration\\MSBuildExtensions\\CUDA $(CudaVersion).props\" />" << std::endl;
     os << "\t</ImportGroup>" << std::endl;
 }
 //--------------------------------------------------------------------------
@@ -1999,7 +1999,7 @@ void Backend::genMSBuildCompileModule(const std::string &moduleName, std::ostrea
 void Backend::genMSBuildImportTarget(std::ostream &os) const
 {
     os << "\t<ImportGroup Label=\"ExtensionTargets\">" << std::endl;
-    os << "\t\t<Import Project=\"$(VCTargetsPath)\\BuildCustomizations\\CUDA $(CudaVersion).targets\" />" << std::endl;
+    os << "\t\t<Import Project=\"$(CUDA_PATH)\\extras\\visual_studio_integration\\MSBuildExtensions\\CUDA $(CudaVersion).targets\" />" << std::endl;
     os << "\t</ImportGroup>" << std::endl;
 }
 //--------------------------------------------------------------------------


### PR DESCRIPTION
Visual C++ uses a build extension to build CUDA code. If you install CUDA properly (after your desired version of Visual Studio and ticking correct box), this gets copied somewhere into the ``BuildCustomizations`` folder of Visual Studio where GeNN has previous found it. However, seems like it works fine to pull the build customization stuff straight out of the CUDA install, allowing GeNN to work on e.g. Sussex Lab machines where the CUDA build extension isn't properly installed.

Tested on:
* Lab machine (Windows 10, Visual Studio Community 2022, CUDA 12.2)
* Laptop (Windows 11, Visual Studio Enterprise 2022, CUDA 12.3)
* Home machine (Windows 10, Visual Studio Enterprise 2019, CUDA 11.4)

I also checked the old version of CUDA 10 lurking on my home machine and the build customization files were in the same place