### PR TITLE
Automate detection of homogeneous parameters and remove integer division

### DIFF
--- a/include/genn/genn/code_generator/codeGenUtils.h
+++ b/include/genn/genn/code_generator/codeGenUtils.h
@@ -57,6 +57,8 @@ inline auto padSize(A size, B blockSize)
 
 GENN_EXPORT void genTypeRange(CodeStream &os, const Type::ResolvedType &type, const std::string &prefix);
 
+GENN_EXPORT std::string getFastDivide(const std::string &numerator, const std::string &divisorVar);
+
 //! Parse, type check and pretty print previously scanned vector of tokens representing an expression
 GENN_EXPORT void prettyPrintExpression(const std::vector<Transpiler::Token> &tokens, const Type::TypeContext &typeContext, 
                                        Transpiler::TypeChecker::EnvironmentInternal &typeCheckEnv, Transpiler::PrettyPrinter::EnvironmentInternal &prettyPrintEnv,

--- a/include/genn/genn/code_generator/customConnectivityUpdateGroupMerged.h
+++ b/include/genn/genn/code_generator/customConnectivityUpdateGroupMerged.h
@@ -47,9 +47,6 @@ private:
     //----------------------------------------------------------------------------
     // Private methods
     //----------------------------------------------------------------------------
-    bool isParamHeterogeneous(const std::string &name) const;
-    bool isDerivedParamHeterogeneous(const std::string &name) const;
-
     template<typename A>
     void addPrivateVarRefAccess(EnvironmentGroupMergedField<CustomConnectivityUpdateGroupMerged> &env, unsigned int batchSize, 
                                 std::function<std::string(VarAccessMode, const typename A::RefType&)> getIndexFn)
@@ -143,9 +140,6 @@ private:
     //----------------------------------------------------------------------------
     // Private methods
     //----------------------------------------------------------------------------
-    bool isParamHeterogeneous(const std::string &name) const;
-    bool isDerivedParamHeterogeneous(const std::string &name) const;
-
     template<typename A>
     void addVars(EnvironmentGroupMergedField<CustomConnectivityHostUpdateGroupMerged> &env, const std::string &count, const BackendBase &backend)
     {

--- a/include/genn/genn/code_generator/customUpdateGroupMerged.h
+++ b/include/genn/genn/code_generator/customUpdateGroupMerged.h
@@ -37,13 +37,6 @@ public:
     // Static constants
     //----------------------------------------------------------------------------
     static const std::string name;
-
-private:
-    //----------------------------------------------------------------------------
-    // Private methods
-    //----------------------------------------------------------------------------
-    bool isParamHeterogeneous(const std::string &paramName) const;
-    bool isDerivedParamHeterogeneous(const std::string &paramName) const;
 };
 
 // ----------------------------------------------------------------------------
@@ -57,9 +50,6 @@ public:
     //----------------------------------------------------------------------------
     // Public API
     //----------------------------------------------------------------------------
-    bool isParamHeterogeneous(const std::string &paramName) const;
-    bool isDerivedParamHeterogeneous(const std::string &paramName) const;
-
     boost::uuids::detail::sha1::digest_type getHashDigest() const;
 
     void generateCustomUpdate(EnvironmentExternalBase &env, unsigned int batchSize,

--- a/include/genn/genn/code_generator/environment.h
+++ b/include/genn/genn/code_generator/environment.h
@@ -478,8 +478,7 @@ public:
                                 [getFieldValue](Runtime::Runtime &r, const GroupInternal &g, size_t i)
                                 {
                                     return std::visit(
-                                        Utils::Overload{
-                                            [](const auto &res)->typename G::FieldValue { return res; }},
+                                        [](const auto &res)->typename G::FieldValue { return res; },
                                         getFieldValue(r, g, i));
                                 }};
         this->addInternal(type, name, std::make_tuple(false, LazyString{indexSuffix, *this}, std::make_optional(field)),

--- a/include/genn/genn/code_generator/environment.h
+++ b/include/genn/genn/code_generator/environment.h
@@ -536,8 +536,8 @@ public:
                  });
 
         // Add B field
-        addField(GeNN::Type::Uint32, name + "_b",
-                 GeNN::Type::Uint32.addConst(), fieldName + "B",
+        addField(GeNN::Type::Uint32.addConst(), name + "_b",
+                 GeNN::Type::Uint32, fieldName + "B",
                  [getFieldValue](const GroupInternal &g, size_t i) -> uint32_t
                  {
                      const uint32_t uintMax = std::numeric_limits<uint32_t>::max();

--- a/include/genn/genn/code_generator/environment.h
+++ b/include/genn/genn/code_generator/environment.h
@@ -509,12 +509,12 @@ public:
                  GeNN::Type::Uint32, fieldName,
                  getFieldValue);
 
-        // Add M field
+        // Add M field (actually m + 32)
         addField(GeNN::Type::Uint32.addConst(), name + "_m",
                  GeNN::Type::Uint32, fieldName + "M",
                  [getFieldValue](const GroupInternal &g, size_t i)
                  {
-                     return (uint32_t)std::floor(std::log2(getFieldValue(g, i)));
+                     return 32 + (uint32_t)std::floor(std::log2(getFieldValue(g, i)));
                  });
         
         // Add A field
@@ -529,7 +529,7 @@ public:
                          return uintMax;
                      }
                      else {
-                         const uint32_t t = (1ul << (m + 32)) / d;
+                         const uint32_t t = (1ull << (m + 32)) / d;
                          const uint32_t r = ((t * d) + d) & uintMax;
                          return (r <= (1ul << m)) ? (t + 1ul) : t;
                      }
@@ -547,7 +547,7 @@ public:
                          return uintMax;
                      }
                      else {
-                         const uint32_t t = (1ul << (m + 32ul)) / d;
+                         const uint32_t t = (1ull << (m + 32)) / d;
                          const uint32_t r = ((t * d) + d) & uintMax;
                          return (r <= (1ul << m)) ? 0 : t;
                      }

--- a/include/genn/genn/code_generator/groupMerged.h
+++ b/include/genn/genn/code_generator/groupMerged.h
@@ -276,18 +276,19 @@ public:
     {
         // Implement merged group
         os << "static Merged" << name << "Group" << this->getIndex() << " merged" << name << "Group" << this->getIndex() << "[" << this->getGroups().size() << "];" << std::endl;
+        if(!getFields().empty()) {
+            // Write function to update
+            os << "void pushMerged" << name << "Group" << this->getIndex() << "ToDevice(unsigned int idx, ";
+            generateStructFieldArgumentDefinitions(os, backend);
+            os << ")";
+            {
+                CodeStream::Scope b(os);
 
-        // Write function to update
-        os << "void pushMerged" << name << "Group" << this->getIndex() << "ToDevice(unsigned int idx, ";
-        generateStructFieldArgumentDefinitions(os, backend);
-        os << ")";
-        {
-            CodeStream::Scope b(os);
-
-            // Loop through sorted fields and set array entry
-            const auto sortedFields = getSortedFields(backend);
-            for(const auto &f : sortedFields) {
-                os << "merged" << name << "Group" << this->getIndex() << "[idx]." << f.name << " = " << f.name << ";" << std::endl;
+                // Loop through sorted fields and set array entry
+                const auto sortedFields = getSortedFields(backend);
+                for(const auto &f : sortedFields) {
+                    os << "merged" << name << "Group" << this->getIndex() << "[idx]." << f.name << " = " << f.name << ";" << std::endl;
+                }
             }
         }
     }
@@ -365,9 +366,11 @@ protected:
     void generateRunnerBase(const BackendBase &backend, CodeStream &definitions, const std::string &name, bool host = false) const
     {
         // Generate definition for function to push group
-        definitions << "EXPORT_FUNC void pushMerged" << name << "Group" << this->getIndex() << "ToDevice(unsigned int idx, ";
-        generateStructFieldArgumentDefinitions(definitions, backend);
-        definitions << ");" << std::endl;
+        if(!getFields().empty()) {
+            definitions << "EXPORT_FUNC void pushMerged" << name << "Group" << this->getIndex() << "ToDevice(unsigned int idx, ";
+            generateStructFieldArgumentDefinitions(definitions, backend);
+            definitions << ");" << std::endl;
+        }
 
         // Loop through fields again to generate any dynamic field pushing functions that are required
         for(const auto &f : m_Fields) {

--- a/include/genn/genn/code_generator/groupMerged.h
+++ b/include/genn/genn/code_generator/groupMerged.h
@@ -116,21 +116,6 @@ protected:
     //------------------------------------------------------------------------
     // Protected API
     //------------------------------------------------------------------------
-    //! Helper to test whether parameter values are heterogeneous within merged group
-    template<typename P>
-    bool isParamValueHeterogeneous(const std::string &name, P getParamValuesFn) const
-    {
-        // Get value of parameter in archetype group
-        const auto archetypeValue = getParamValuesFn(getArchetype()).at(name);
-
-        // Return true if any parameter values differ from the archetype value
-        return std::any_of(getGroups().cbegin(), getGroups().cend(),
-                           [&name, archetypeValue, getParamValuesFn](const GroupInternal &g)
-                           {
-                               return (getParamValuesFn(g).at(name) != archetypeValue);
-                           });
-    }
-
     //! Helper to update hash with the hash of calling getHashableFn on each group
     template<typename H>
     void updateHash(H getHashableFn, boost::uuids::detail::sha1 &hash) const

--- a/include/genn/genn/code_generator/initGroupMerged.h
+++ b/include/genn/genn/code_generator/initGroupMerged.h
@@ -20,28 +20,6 @@ class InitGroupMergedBase : public B
 public:
     using B::B;
 
-    //----------------------------------------------------------------------------
-    // Public API
-    //----------------------------------------------------------------------------
-    //! Should the var init parameter be implemented heterogeneously?
-    bool isVarInitParamHeterogeneous(const std::string &varName, const std::string &paramName) const
-    {
-        return this->isParamValueHeterogeneous(paramName, 
-                                               [&varName](const auto &g)
-                                               { 
-                                                   return A(g).getInitialisers().at(varName).getParams(); 
-                                               });
-    }
-
-    //! Should the var init derived parameter be implemented heterogeneously?
-    bool isVarInitDerivedParamHeterogeneous(const std::string &varName, const std::string &paramName) const
-    {
-        return this->isParamValueHeterogeneous(paramName, 
-                                               [&varName](const auto &g) 
-                                               { 
-                                                   return A(g).getInitialisers().at(varName).getDerivedParams();
-                                               });
-    }
 protected:
     //----------------------------------------------------------------------------
     // Protected methods
@@ -307,18 +285,6 @@ public:
     void generateSparseColumnInit(EnvironmentExternalBase &env);
     void generateKernelInit(EnvironmentExternalBase &env, unsigned int batchSize);
 
-    //! Should the var init parameter be implemented heterogeneously?
-    bool isVarInitParamHeterogeneous(const std::string &varName, const std::string &paramName) const;
-
-    //! Should the var init derived parameter be implemented heterogeneously?
-    bool isVarInitDerivedParamHeterogeneous(const std::string &varName, const std::string &paramName) const;
-    
-    //! Should the sparse connectivity initialization parameter be implemented heterogeneously?
-    bool isSparseConnectivityInitParamHeterogeneous(const std::string &paramName) const;
-
-    //! Should the sparse connectivity initialization parameter be implemented heterogeneously?
-    bool isSparseConnectivityInitDerivedParamHeterogeneous(const std::string &paramName) const;
-
     //----------------------------------------------------------------------------
     // Static constants
     //----------------------------------------------------------------------------
@@ -355,16 +321,6 @@ public:
     // Static constants
     //----------------------------------------------------------------------------
     static const std::string name;
-
-private:
-    //------------------------------------------------------------------------
-    // Private methods
-    //------------------------------------------------------------------------
-    //! Should the connectivity initialization parameter be implemented heterogeneously for EGP init?
-    bool isConnectivityInitParamHeterogeneous(const std::string &paramName) const;
-
-    //! Should the connectivity initialization derived parameter be implemented heterogeneously for EGP init?
-    bool isConnectivityInitDerivedParamHeterogeneous(const std::string &paramName) const;
 };
 
 // ----------------------------------------------------------------------------

--- a/include/genn/genn/code_generator/neuronUpdateGroupMerged.h
+++ b/include/genn/genn/code_generator/neuronUpdateGroupMerged.h
@@ -28,12 +28,6 @@ public:
 
         //! Update hash with child groups
         void updateHash(boost::uuids::detail::sha1 &hash) const;
-
-        //! Should the current source parameter be implemented heterogeneously?
-        bool isParamHeterogeneous(const std::string &paramName) const;
-
-        //! Should the current source derived parameter be implemented heterogeneously?
-        bool isDerivedParamHeterogeneous(const std::string &paramName) const;
     };
 
     //----------------------------------------------------------------------------
@@ -53,12 +47,6 @@ public:
 
         //! Update hash with child groups
         void updateHash(boost::uuids::detail::sha1 &hash) const;
-
-        //! Should the current source parameter be implemented heterogeneously?
-        bool isParamHeterogeneous(const std::string &paramName) const;
-
-        //! Should the current source derived parameter be implemented heterogeneously?
-        bool isDerivedParamHeterogeneous(const std::string &paramName) const;
     };
 
     //----------------------------------------------------------------------------
@@ -115,12 +103,7 @@ public:
 
         //! Update hash with child groups
         void updateHash(boost::uuids::detail::sha1 &hash) const;
-    
-        //! Should the current source parameter be implemented heterogeneously?
-        bool isParamHeterogeneous(const std::string &paramName) const;
 
-        //! Should the current source derived parameter be implemented heterogeneously?
-        bool isDerivedParamHeterogeneous(const std::string &paramName) const;
     private:
         void generateEventConditionInternal(EnvironmentExternalBase &env, NeuronUpdateGroupMerged &ng,
                                             unsigned int batchSize, BackendBase::GroupHandlerEnv<SynSpikeEvent> genEmitSpikeLikeEvent,
@@ -149,12 +132,6 @@ public:
 
         //! Update hash with child groups
         void updateHash(boost::uuids::detail::sha1 &hash) const;
-
-        //! Should the current source parameter be implemented heterogeneously?
-        bool isParamHeterogeneous(const std::string &paramName) const;
-
-        //! Should the current source derived parameter be implemented heterogeneously?
-        bool isDerivedParamHeterogeneous(const std::string &paramName) const;
     };
 
     //----------------------------------------------------------------------------
@@ -177,12 +154,6 @@ public:
 
         //! Update hash with child groups
         void updateHash(boost::uuids::detail::sha1 &hash) const;
-
-        //! Should the current source parameter be implemented heterogeneously?
-        bool isParamHeterogeneous(const std::string &paramName) const;
-
-        //! Should the current source derived parameter be implemented heterogeneously?
-        bool isDerivedParamHeterogeneous(const std::string &paramName) const;
     };
 
     NeuronUpdateGroupMerged(size_t index, const Type::TypeContext &typeContext,
@@ -219,12 +190,6 @@ public:
     const std::vector<SynSpikeEvent> &getMergedSpikeEventGroups() const{ return m_MergedSpikeEventGroups; }
     const std::vector<InSynWUMPostCode> &getMergedInSynWUMPostCodeGroups() const { return m_MergedInSynWUMPostCodeGroups; }
     const std::vector<OutSynWUMPreCode> &getMergedOutSynWUMPreCodeGroups() const { return m_MergedOutSynWUMPreCodeGroups; }
-    
-    //! Should the parameter be implemented heterogeneously?
-    bool isParamHeterogeneous(const std::string &paramName) const;
-
-    //! Should the derived parameter be implemented heterogeneously?
-    bool isDerivedParamHeterogeneous(const std::string &paramName) const;
 
     //----------------------------------------------------------------------------
     // Static constants

--- a/include/genn/genn/code_generator/synapseUpdateGroupMerged.h
+++ b/include/genn/genn/code_generator/synapseUpdateGroupMerged.h
@@ -17,30 +17,6 @@ public:
     //------------------------------------------------------------------------
     // Public API
     //------------------------------------------------------------------------
-    //! Should the weight update model parameter be implemented heterogeneously?
-    bool isWUParamHeterogeneous(const std::string &paramName) const;
-
-    //! Should the weight update model derived parameter be implemented heterogeneously?
-    bool isWUDerivedParamHeterogeneous(const std::string &paramName) const;
-
-    //! Should the weight update model variable initialization parameter be implemented heterogeneously?
-    bool isVarInitParamHeterogeneous(const std::string &varName, const std::string &paramName) const;
-    
-    //! Should the weight update model variable initialization derived parameter be implemented heterogeneously?
-    bool isVarInitDerivedParamHeterogeneous(const std::string &varName, const std::string &paramName) const;
-
-    //! Should the sparse connectivity initialization parameter be implemented heterogeneously?
-    bool isSparseConnectivityInitParamHeterogeneous(const std::string &paramName) const;
-
-    //! Should the sparse connectivity initialization parameter be implemented heterogeneously?
-    bool isSparseConnectivityInitDerivedParamHeterogeneous(const std::string &paramName) const;
-
-    //! Should the Toeplitz connectivity initialization parameter be implemented heterogeneously?
-    bool isToeplitzConnectivityInitParamHeterogeneous(const std::string &paramName) const;
-
-    //! Should the Toeplitz connectivity initialization parameter be implemented heterogeneously?
-    bool isToeplitzConnectivityInitDerivedParamHeterogeneous(const std::string &paramName) const;
-
     std::string getPreSlot(bool delay, unsigned int batchSize) const;
     std::string getPostSlot(bool delay, unsigned int batchSize) const;
 

--- a/include/genn/genn/runtime/runtime.h
+++ b/include/genn/genn/runtime/runtime.h
@@ -572,6 +572,10 @@ private:
     template<typename G>
     void pushMergedGroup(const G &g)
     {
+        if(g.getFields().empty()) {
+            LOGD_RUNTIME << "Skipping empty merged group '" << G::name << "' index: " << g.getIndex();
+            return;
+        }
         LOGD_RUNTIME << "Pushing merged group '" << G::name << "' index: " << g.getIndex();
 
         // Loop through groups

--- a/src/genn/genn/code_generator/backendBase.cc
+++ b/src/genn/genn/code_generator/backendBase.cc
@@ -278,7 +278,7 @@ void buildStandardSynapseEnvironment(const BackendBase &backend, EnvironmentGrou
     env.add(Uint32.addConst(), "num_batch", std::to_string(batchSize));
     if(batchSize > 1) {
         // Calculate batch offsets into pre and postsynaptic populations
-        env.add(Uint32.addConst(), "_prema_batch_offset", "preBatchOffset",
+        env.add(Uint32.addConst(), "_pre_batch_offset", "preBatchOffset",
                 {env.addInitialiser("const unsigned int preBatchOffset = $(num_pre) * $(batch);")});
         env.add(Uint32.addConst(), "_post_batch_offset", "postBatchOffset",
                 {env.addInitialiser("const unsigned int postBatchOffset = $(num_post) * $(batch);")});

--- a/src/genn/genn/code_generator/backendBase.cc
+++ b/src/genn/genn/code_generator/backendBase.cc
@@ -47,11 +47,11 @@ void buildCustomUpdateWUSizeEnvironment(const BackendBase &backend, EnvironmentG
     env.addField(Type::Uint32.addConst(), "num_post",
                  Type::Uint32, "numTrgNeurons", 
                  [](const auto  &cg, size_t) { return cg.getSynapseGroup()->getTrgNeuronGroup()->getNumNeurons(); });
-    env.addField(Type::Uint32, "_row_stride", "rowStride", 
-                 [&backend](const auto &cg, size_t) -> uint64_t
-                 {
-                     return backend.getSynapticMatrixRowStride(*cg.getSynapseGroup());
-                 });
+    env.addFastDivideField("_row_stride", "rowStride", 
+                           [&backend](const auto &g, size_t) -> uint32_t
+                           {
+                               return backend.getSynapticMatrixRowStride(*g.getSynapseGroup());
+                           });
 
     // If underlying synapse group has kernel connectivity
     const auto *sg = env.getGroup().getArchetype().getSynapseGroup();

--- a/src/genn/genn/code_generator/backendBase.cc
+++ b/src/genn/genn/code_generator/backendBase.cc
@@ -173,11 +173,11 @@ void buildStandardSynapseEnvironment(const BackendBase &backend, EnvironmentGrou
     env.addField(Uint32.addConst(), "num_post",
                  Uint32, "numTrgNeurons", 
                  [](const SynapseGroupInternal &sg, size_t) { return sg.getTrgNeuronGroup()->getNumNeurons(); });
-    env.addField(Uint32, "_row_stride", "rowStride", 
-                 [&backend](const SynapseGroupInternal &sg, size_t) -> uint64_t
-                 {
-                     return backend.getSynapticMatrixRowStride(sg);
-                 });
+    env.addFastDivideField("_row_stride", "rowStride", 
+                           [&backend](const SynapseGroupInternal &sg, size_t) -> uint32_t
+                           {
+                               return backend.getSynapticMatrixRowStride(sg);
+                           });
     env.addField(Uint32, "_col_stride", "colStride", 
                  [](const SynapseGroupInternal &sg, size_t) { return sg.getMaxSourceConnections(); });
 

--- a/src/genn/genn/code_generator/backendSIMT.cc
+++ b/src/genn/genn/code_generator/backendSIMT.cc
@@ -832,7 +832,7 @@ void BackendSIMT::genSynapseDynamicsKernel(EnvironmentExternalBase &env, ModelSp
 
                 if(sg.getArchetype().getMatrixType() & SynapseMatrixConnectivity::SPARSE) {
                     // **OPTIMIZE * *we can do a fast constant divide optimization here and use the result to calculate the remainder
-                    synEnv.printLine("const unsigned int row = $(id) / $(_row_stride);");
+                    synEnv.printLine("const unsigned int row = " + getFastDivide("$(id)", "_row_stride") + ";");
                     synEnv.printLine("const unsigned int col = $(id) % $(_row_stride);");
 
                     synEnv.add(Type::Uint32.addConst(), "id_pre", "row");
@@ -844,7 +844,7 @@ void BackendSIMT::genSynapseDynamicsKernel(EnvironmentExternalBase &env, ModelSp
                 else {
                     // **OPTIMIZE** we can do a fast constant divide optimization here and use the result to calculate the remainder
                     synEnv.add(Type::Uint32.addConst(), "id_pre", "idPre",
-                               {synEnv.addInitialiser("const unsigned int idPre = ($(id) / $(_row_stride));")});
+                               {synEnv.addInitialiser("const unsigned int idPre = " + getFastDivide("$(id)", "_row_stride") + ";")});
                     synEnv.add(Type::Uint32.addConst(), "id_post", "idPost",
                                {synEnv.addInitialiser("const unsigned int idPost = ($(id) % $(_row_stride));")});    
                 }
@@ -1083,7 +1083,7 @@ void BackendSIMT::genCustomUpdateWUKernel(EnvironmentExternal &env, ModelSpecMer
                 else {
                     if (sg->getMatrixType() & SynapseMatrixConnectivity::SPARSE) {
                         // **OPTIMIZE * *we can do a fast constant divide optimization here and use the result to calculate the remainder
-                        synEnv.printLine("const unsigned int row = $(id) / $(_row_stride);");
+                        synEnv.printLine("const unsigned int row = " + getFastDivide("$(id)", "_row_stride") + ";");
                         synEnv.printLine("const unsigned int col = $(id) % $(_row_stride);");
 
                         synEnv.add(Type::Uint32.addConst(), "id_pre", "row");
@@ -1095,9 +1095,9 @@ void BackendSIMT::genCustomUpdateWUKernel(EnvironmentExternal &env, ModelSpecMer
                     else {
                         // **OPTIMIZE** we can do a fast constant divide optimization here and use the result to calculate the remainder
                         synEnv.add(Type::Uint32.addConst(), "id_pre", "idPre",
-                                   {synEnv.addInitialiser("const unsigned int idPre = $(id) / $(_row_stride)")});
+                                   {synEnv.addInitialiser("const unsigned int idPre = " + getFastDivide("$(id)", "_row_stride") + ";")});
                         synEnv.add(Type::Uint32.addConst(), "id_post", "idPost",
-                                   {synEnv.addInitialiser("const unsigned int idPost = $(id) % $(_row_stride)")});
+                                   {synEnv.addInitialiser("const unsigned int idPost = $(id) % $(_row_stride);")});
                     }
                 }
 
@@ -1872,7 +1872,7 @@ void BackendSIMT::genPostsynapticUpdate(EnvironmentExternalBase &env, Postsynapt
 
                     // **OPTIMIZE** we can do a fast constant divide optimization here
                     synEnv.add(Type::Uint32.addConst(), "id_pre", "idPre",
-                                {synEnv.addInitialiser("const unsigned int idPre = $(id_syn) / $(_row_stride);")});
+                                {synEnv.addInitialiser("const unsigned int idPre = " + getFastDivide("$(id_syn)", "_row_stride") + ";")});
                 }
                 else {
                     synEnv.add(Type::Uint32.addConst(), "id_syn", "synAddress",

--- a/src/genn/genn/code_generator/codeGenUtils.cc
+++ b/src/genn/genn/code_generator/codeGenUtils.cc
@@ -33,7 +33,7 @@ void genTypeRange(CodeStream &os, const Type::ResolvedType &type, const std::str
 //----------------------------------------------------------------------------
 GENN_EXPORT std::string getFastDivide(const std::string &numerator, const std::string &divisorVar)
 {
-    return "((((uint64_t)(" + numerator + ") * $(" + divisorVar + "_a)) + $(" + divisorVar + "_b)) >> (32 + $(" + divisorVar + "_m)))";
+    return "((((uint64_t)(" + numerator + ") * $(" + divisorVar + "_a)) + $(" + divisorVar + "_b)) >> $(" + divisorVar + "_m))";
 }
 //----------------------------------------------------------------------------
 void prettyPrintExpression(const std::vector<Transpiler::Token> &tokens, const Type::TypeContext &typeContext, 

--- a/src/genn/genn/code_generator/codeGenUtils.cc
+++ b/src/genn/genn/code_generator/codeGenUtils.cc
@@ -31,6 +31,11 @@ void genTypeRange(CodeStream &os, const Type::ResolvedType &type, const std::str
     os << "#define " << prefix << "_MAX " << Type::writeNumeric(numeric.max, type) << std::endl;
 }
 //----------------------------------------------------------------------------
+GENN_EXPORT std::string getFastDivide(const std::string &numerator, const std::string &divisorVar)
+{
+    return "((((uint64_t)(" + numerator + ") * $(" + divisorVar + "_a)) + $(" + divisorVar + "_b)) >> (32 + $(" + divisorVar + "_m)))";
+}
+//----------------------------------------------------------------------------
 void prettyPrintExpression(const std::vector<Transpiler::Token> &tokens, const Type::TypeContext &typeContext, 
                                        Transpiler::TypeChecker::EnvironmentInternal &typeCheckEnv, Transpiler::PrettyPrinter::EnvironmentInternal &prettyPrintEnv,
                                        Transpiler::ErrorHandler &errorHandler)

--- a/src/genn/genn/code_generator/customConnectivityUpdateGroupMerged.cc
+++ b/src/genn/genn/code_generator/customConnectivityUpdateGroupMerged.cc
@@ -394,14 +394,14 @@ void CustomConnectivityHostUpdateGroupMerged::generateUpdate(const BackendBase &
         // Add fields for number of pre and postsynaptic neurons
         groupEnv.addField(Type::Uint32.addConst(), "num_pre",
                           Type::Uint32, "numSrcNeurons", 
-                          [](const auto&, const auto &cg, size_t) 
+                          [](const auto &cg, size_t) 
                           { 
                               const SynapseGroupInternal *sgInternal = static_cast<const SynapseGroupInternal*>(cg.getSynapseGroup());
                               return sgInternal->getSrcNeuronGroup()->getNumNeurons();
                           });
         groupEnv.addField(Type::Uint32.addConst(), "num_post",
                           Type::Uint32, "numTrgNeurons", 
-                          [](const auto&, const auto &cg, size_t) 
+                          [](const auto &cg, size_t) 
                           { 
                               const SynapseGroupInternal *sgInternal = static_cast<const SynapseGroupInternal*>(cg.getSynapseGroup());
                               return sgInternal->getSrcNeuronGroup()->getNumNeurons();
@@ -410,7 +410,7 @@ void CustomConnectivityHostUpdateGroupMerged::generateUpdate(const BackendBase &
         // Expose row stride        
         groupEnv.addField(Type::Uint32.addConst(), "row_stride",
                           Type::Uint32, "rowStride", 
-                          [&backend](const auto&, const auto &cg, size_t) -> uint64_t 
+                          [&backend](const auto &cg, size_t) -> uint64_t 
                           {
                               return backend.getSynapticMatrixRowStride(*cg.getSynapseGroup()); 
                           });

--- a/src/genn/genn/code_generator/customConnectivityUpdateGroupMerged.cc
+++ b/src/genn/genn/code_generator/customConnectivityUpdateGroupMerged.cc
@@ -108,10 +108,8 @@ void CustomConnectivityUpdateGroupMerged::generateUpdate(const BackendBase &back
     // Substitute parameter and derived parameter names
     const auto *cm = getArchetype().getModel();
     updateEnv.addParams(cm->getParams(), "", &CustomConnectivityUpdateInternal::getParams, 
-                        &CustomConnectivityUpdateGroupMerged::isParamHeterogeneous,
                         &CustomConnectivityUpdateInternal::isParamDynamic);
-    updateEnv.addDerivedParams(cm->getDerivedParams(), "", &CustomConnectivityUpdateInternal::getDerivedParams, 
-                               &CustomConnectivityUpdateGroupMerged::isDerivedParamHeterogeneous);
+    updateEnv.addDerivedParams(cm->getDerivedParams(), "", &CustomConnectivityUpdateInternal::getDerivedParams);
     updateEnv.addExtraGlobalParams(cm->getExtraGlobalParams());
     updateEnv.addExtraGlobalParamRefs(cm->getExtraGlobalParamRefs());
     
@@ -454,10 +452,8 @@ void CustomConnectivityHostUpdateGroupMerged::generateUpdate(const BackendBase &
         // Substitute parameter and derived parameter names
         const auto *cm = getArchetype().getModel();
         groupEnv.addParams(cm->getParams(), "", &CustomConnectivityUpdateInternal::getParams, 
-                           &CustomConnectivityHostUpdateGroupMerged::isParamHeterogeneous,
                            &CustomConnectivityUpdateInternal::isParamDynamic);
-        groupEnv.addDerivedParams(cm->getDerivedParams(), "", &CustomConnectivityUpdateInternal::getDerivedParams, 
-                                  &CustomConnectivityHostUpdateGroupMerged::isDerivedParamHeterogeneous);
+        groupEnv.addDerivedParams(cm->getDerivedParams(), "", &CustomConnectivityUpdateInternal::getDerivedParams);
 
         // Loop through EGPs
         for(const auto &egp : cm->getExtraGlobalParams()) {

--- a/src/genn/genn/code_generator/customConnectivityUpdateGroupMerged.cc
+++ b/src/genn/genn/code_generator/customConnectivityUpdateGroupMerged.cc
@@ -351,16 +351,6 @@ void CustomConnectivityUpdateGroupMerged::generateUpdate(const BackendBase &back
                               }
                           });
 }
-//----------------------------------------------------------------------------
-bool CustomConnectivityUpdateGroupMerged::isParamHeterogeneous(const std::string &name) const
-{
-    return isParamValueHeterogeneous(name, [](const CustomConnectivityUpdateInternal &cg) { return cg.getParams(); });
-}
-//----------------------------------------------------------------------------
-bool CustomConnectivityUpdateGroupMerged::isDerivedParamHeterogeneous(const std::string &name) const
-{
-    return isParamValueHeterogeneous(name, [](const CustomConnectivityUpdateInternal &cg) { return cg.getDerivedParams(); });
-}
 
 // ----------------------------------------------------------------------------
 // CustomConnectivityRemapUpdateGroupMerged
@@ -509,14 +499,4 @@ void CustomConnectivityHostUpdateGroupMerged::generateUpdate(const BackendBase &
         Transpiler::ErrorHandler errorHandler("Custom connectivity '" + getArchetype().getName() + "' host update code");
         prettyPrintStatements(getArchetype().getHostUpdateCodeTokens(), getTypeContext(), groupEnv, errorHandler);
     }
-}
-//----------------------------------------------------------------------------
-bool CustomConnectivityHostUpdateGroupMerged::isParamHeterogeneous(const std::string &name) const
-{
-    return isParamValueHeterogeneous(name, [](const CustomConnectivityUpdateInternal &cg) { return cg.getParams(); });
-}
-//----------------------------------------------------------------------------
-bool CustomConnectivityHostUpdateGroupMerged::isDerivedParamHeterogeneous(const std::string &name) const
-{
-    return isParamValueHeterogeneous(name, [](const CustomConnectivityUpdateInternal &cg) { return cg.getDerivedParams(); });
 }

--- a/src/genn/genn/code_generator/customUpdateGroupMerged.cc
+++ b/src/genn/genn/code_generator/customUpdateGroupMerged.cc
@@ -164,29 +164,9 @@ std::string CustomUpdateGroupMerged::getVarRefIndex(const NeuronGroup *delayNeur
         return getVarIndex(batchSize, varDims, index);
     }    
 }
-//----------------------------------------------------------------------------
-bool CustomUpdateGroupMerged::isParamHeterogeneous(const std::string &paramName) const
-{
-    return isParamValueHeterogeneous(paramName, [](const auto &cg) { return cg.getParams(); });
-}
-//----------------------------------------------------------------------------    
-bool CustomUpdateGroupMerged::isDerivedParamHeterogeneous(const std::string &paramName) const
-{
-    return isParamValueHeterogeneous(paramName, [](const auto &cg) { return cg.getDerivedParams(); });
-}
 
 // ----------------------------------------------------------------------------
 // GeNN::CodeGenerator::CustomUpdateWUGroupMergedBase
-//----------------------------------------------------------------------------
-bool CustomUpdateWUGroupMergedBase::isParamHeterogeneous(const std::string &paramName) const
-{
-    return isParamValueHeterogeneous(paramName, [](const CustomUpdateWUInternal &cg) { return cg.getParams(); });
-}
-//----------------------------------------------------------------------------
-bool CustomUpdateWUGroupMergedBase::isDerivedParamHeterogeneous(const std::string &paramName) const
-{
-    return isParamValueHeterogeneous(paramName, [](const CustomUpdateWUInternal &cg) { return cg.getDerivedParams(); });
-}
 //----------------------------------------------------------------------------
 boost::uuids::detail::sha1::digest_type CustomUpdateWUGroupMergedBase::getHashDigest() const
 {

--- a/src/genn/genn/code_generator/customUpdateGroupMerged.cc
+++ b/src/genn/genn/code_generator/customUpdateGroupMerged.cc
@@ -311,7 +311,7 @@ const std::string CustomUpdateHostReductionGroupMerged::name = "CustomUpdateHost
 void CustomUpdateHostReductionGroupMerged::generateCustomUpdate(EnvironmentGroupMergedField<CustomUpdateHostReductionGroupMerged> &env)
 {
     env.addField(Type::Uint32, "_size", "size",
-                 [](const auto &, const auto &c, size_t) { return c.getNumNeurons(); });
+                 [](const auto &c, size_t) { return c.getNumNeurons(); });
     
     // If some variables are delayed, add delay pointer
     if(getArchetype().getDelayNeuronGroup() != nullptr) {
@@ -329,7 +329,7 @@ const std::string CustomWUUpdateHostReductionGroupMerged::name = "CustomWUUpdate
 void CustomWUUpdateHostReductionGroupMerged::generateCustomUpdate(EnvironmentGroupMergedField<CustomWUUpdateHostReductionGroupMerged> &env)
 {
     env.addField(Type::Uint32, "_size", "size",
-                 [](const auto &, const auto &c, size_t) -> uint64_t 
+                 [](const auto &c, size_t) -> uint64_t 
                  { 
                      return c.getSynapseGroup()->getMaxConnections() * (size_t)c.getSynapseGroup()->getSrcNeuronGroup()->getNumNeurons(); 
                  });

--- a/src/genn/genn/code_generator/customUpdateGroupMerged.cc
+++ b/src/genn/genn/code_generator/customUpdateGroupMerged.cc
@@ -53,9 +53,8 @@ void CustomUpdateGroupMerged::generateCustomUpdate(EnvironmentExternalBase &env,
     // Substitute parameter and derived parameter names
     const CustomUpdateModels::Base *cm = getArchetype().getModel();
     cuEnv.addParams(cm->getParams(), "", &CustomUpdateInternal::getParams, 
-                    &CustomUpdateGroupMerged::isParamHeterogeneous,
                     &CustomUpdateInternal::isParamDynamic);
-    cuEnv.addDerivedParams(cm->getDerivedParams(), "", &CustomUpdateInternal::getDerivedParams, &CustomUpdateGroupMerged::isDerivedParamHeterogeneous);
+    cuEnv.addDerivedParams(cm->getDerivedParams(), "", &CustomUpdateInternal::getDerivedParams);
     cuEnv.addExtraGlobalParams(cm->getExtraGlobalParams());
     cuEnv.addExtraGlobalParamRefs(cm->getExtraGlobalParamRefs());
     
@@ -225,9 +224,8 @@ void CustomUpdateWUGroupMergedBase::generateCustomUpdate(EnvironmentExternalBase
     // Substitute parameter and derived parameter names
     const CustomUpdateModels::Base *cm = getArchetype().getModel();
     cuEnv.addParams(cm->getParams(), "", &CustomUpdateWUInternal::getParams, 
-                    &CustomUpdateWUGroupMergedBase::isParamHeterogeneous,
                     &CustomUpdateWUInternal::isParamDynamic);
-    cuEnv.addDerivedParams(cm->getDerivedParams(), "", &CustomUpdateWUInternal::getDerivedParams, &CustomUpdateWUGroupMergedBase::isDerivedParamHeterogeneous);
+    cuEnv.addDerivedParams(cm->getDerivedParams(), "", &CustomUpdateWUInternal::getDerivedParams);
     cuEnv.addExtraGlobalParams(cm->getExtraGlobalParams());
     cuEnv.addExtraGlobalParamRefs(cm->getExtraGlobalParamRefs());
 

--- a/src/genn/genn/code_generator/initGroupMerged.cc
+++ b/src/genn/genn/code_generator/initGroupMerged.cc
@@ -773,10 +773,10 @@ void SynapseConnectivityHostInitGroupMerged::generateInit(const BackendBase &bac
         // Create substitutions
         groupEnv.addField(Type::Uint32.addConst(), "num_pre",
                           Type::Uint32, "numSrcNeurons", 
-                          [](const auto &, const SynapseGroupInternal &sg, size_t) { return sg.getSrcNeuronGroup()->getNumNeurons(); });
+                          [](const SynapseGroupInternal &sg, size_t) { return sg.getSrcNeuronGroup()->getNumNeurons(); });
         groupEnv.addField(Type::Uint32.addConst(), "num_post",
                           Type::Uint32, "numTrgNeurons", 
-                          [](const auto &, const SynapseGroupInternal &sg, size_t) { return sg.getTrgNeuronGroup()->getNumNeurons(); });
+                          [](const SynapseGroupInternal &sg, size_t) { return sg.getTrgNeuronGroup()->getNumNeurons(); });
         groupEnv.add(Type::Uint32.addConst(), "num_threads", std::to_string(numThreads));
 
         groupEnv.addInitialiserParams("", &SynapseGroupInternal::getSparseConnectivityInitialiser,

--- a/src/genn/genn/code_generator/initGroupMerged.cc
+++ b/src/genn/genn/code_generator/initGroupMerged.cc
@@ -137,8 +137,8 @@ void genInitNeuronVarCode(const BackendBase &backend, EnvironmentExternalBase &e
 
             // Substitute in parameters and derived parameters for initialising variables
             EnvironmentGroupMergedField<G, F> varEnv(env, group, fieldGroup);
-            varEnv.template addVarInitParams<A>(&G::isVarInitParamHeterogeneous, var.name, fieldSuffix);
-            varEnv.template addVarInitDerivedParams<A>(&G::isVarInitDerivedParamHeterogeneous, var.name, fieldSuffix);
+            varEnv.template addVarInitParams<A>(var.name, fieldSuffix);
+            varEnv.template addVarInitDerivedParams<A>(var.name, fieldSuffix);
             varEnv.addExtraGlobalParams(varInit.getSnippet()->getExtraGlobalParams(), var.name, fieldSuffix);
 
             // Add field for variable itself
@@ -220,8 +220,8 @@ void genInitWUVarCode(EnvironmentExternalBase &env, G &group,
 
             // Substitute in parameters and derived parameters for initialising variables
             EnvironmentGroupMergedField<G> varEnv(env, group);
-            varEnv.template addVarInitParams<A>(&G::isVarInitParamHeterogeneous, var.name);
-            varEnv.template addVarInitDerivedParams<A>(&G::isVarInitDerivedParamHeterogeneous, var.name);
+            varEnv.template addVarInitParams<A>(var.name);
+            varEnv.template addVarInitDerivedParams<A>(var.name);
             varEnv.addExtraGlobalParams(varInit.getSnippet()->getExtraGlobalParams(), var.name);
 
             // Add field for variable itself
@@ -688,34 +688,6 @@ void SynapseConnectivityInitGroupMerged::generateKernelInit(EnvironmentExternalB
         });
 }
 //----------------------------------------------------------------------------
-bool SynapseConnectivityInitGroupMerged::isVarInitParamHeterogeneous(const std::string &varName, const std::string &paramName) const
-{
-    return isParamValueHeterogeneous(paramName, 
-                                     [&varName](const auto &g)
-                                     { 
-                                         return SynapseWUVarAdapter(g).getInitialisers().at(varName).getParams(); 
-                                     });
-}
-//----------------------------------------------------------------------------
-bool SynapseConnectivityInitGroupMerged::isVarInitDerivedParamHeterogeneous(const std::string &varName, const std::string &paramName) const
-{
-    return isParamValueHeterogeneous(paramName, 
-                                    [&varName](const auto &g) 
-                                    { 
-                                        return SynapseWUVarAdapter(g).getInitialisers().at(varName).getDerivedParams();
-                                    });
-}
-//----------------------------------------------------------------------------
-bool SynapseConnectivityInitGroupMerged::isSparseConnectivityInitParamHeterogeneous(const std::string &paramName) const
-{
-    return isParamValueHeterogeneous(paramName, [](const SynapseGroupInternal &sg) { return sg.getSparseConnectivityInitialiser().getParams(); });
-}
-//----------------------------------------------------------------------------
-bool SynapseConnectivityInitGroupMerged::isSparseConnectivityInitDerivedParamHeterogeneous(const std::string &paramName) const
-{
-    return isParamValueHeterogeneous(paramName, [](const SynapseGroupInternal &sg) { return sg.getSparseConnectivityInitialiser().getDerivedParams(); });
-}
-//----------------------------------------------------------------------------
 void SynapseConnectivityInitGroupMerged::genInitConnectivity(EnvironmentExternalBase &env, bool rowNotColumns)
 {
     // Create environment for group
@@ -723,10 +695,8 @@ void SynapseConnectivityInitGroupMerged::genInitConnectivity(EnvironmentExternal
 
     // Substitute in parameters and derived parameters for initialising connectivity
     const auto &connectInit = getArchetype().getSparseConnectivityInitialiser();
-    groupEnv.addInitialiserParams("", &SynapseGroupInternal::getSparseConnectivityInitialiser,
-                                  &SynapseConnectivityInitGroupMerged::isSparseConnectivityInitParamHeterogeneous);
-    groupEnv.addInitialiserDerivedParams("", &SynapseGroupInternal::getSparseConnectivityInitialiser,
-                                         &SynapseConnectivityInitGroupMerged::isSparseConnectivityInitDerivedParamHeterogeneous);
+    groupEnv.addInitialiserParams("", &SynapseGroupInternal::getSparseConnectivityInitialiser);
+    groupEnv.addInitialiserDerivedParams("", &SynapseGroupInternal::getSparseConnectivityInitialiser);
     groupEnv.addExtraGlobalParams(connectInit.getSnippet()->getExtraGlobalParams(), "SparseConnect", "");
 
     const std::string context = rowNotColumns ? "row" : "column";
@@ -779,10 +749,8 @@ void SynapseConnectivityHostInitGroupMerged::generateInit(const BackendBase &bac
                           [](const SynapseGroupInternal &sg, size_t) { return sg.getTrgNeuronGroup()->getNumNeurons(); });
         groupEnv.add(Type::Uint32.addConst(), "num_threads", std::to_string(numThreads));
 
-        groupEnv.addInitialiserParams("", &SynapseGroupInternal::getSparseConnectivityInitialiser,
-                                      &SynapseConnectivityHostInitGroupMerged::isConnectivityInitParamHeterogeneous);
-        groupEnv.addInitialiserDerivedParams("", &SynapseGroupInternal::getSparseConnectivityInitialiser,
-                                             &SynapseConnectivityHostInitGroupMerged::isConnectivityInitDerivedParamHeterogeneous);
+        groupEnv.addInitialiserParams("", &SynapseGroupInternal::getSparseConnectivityInitialiser);
+        groupEnv.addInitialiserDerivedParams("", &SynapseGroupInternal::getSparseConnectivityInitialiser);
 
         // Loop through EGPs
         for(const auto &egp : connectInit.getSnippet()->getExtraGlobalParams()) {
@@ -844,16 +812,6 @@ void SynapseConnectivityHostInitGroupMerged::generateInit(const BackendBase &bac
         Transpiler::ErrorHandler errorHandler("Synapse group '" + getArchetype().getName() + "' sparse connectivity host init code");
         prettyPrintStatements(connectInit.getHostInitCodeTokens(), getTypeContext(), groupEnv, errorHandler);
     }
-}
-//----------------------------------------------------------------------------
-bool SynapseConnectivityHostInitGroupMerged::isConnectivityInitParamHeterogeneous(const std::string &paramName) const
-{
-    return isParamValueHeterogeneous(paramName, [](const SynapseGroupInternal &sg){ return sg.getSparseConnectivityInitialiser().getParams(); });
-}
-//----------------------------------------------------------------------------
-bool SynapseConnectivityHostInitGroupMerged::isConnectivityInitDerivedParamHeterogeneous(const std::string &paramName) const
-{
-    return isParamValueHeterogeneous(paramName, [](const SynapseGroupInternal &sg) { return sg.getSparseConnectivityInitialiser().getDerivedParams(); });
 }
 
 // ----------------------------------------------------------------------------

--- a/src/genn/genn/code_generator/neuronUpdateGroupMerged.cc
+++ b/src/genn/genn/code_generator/neuronUpdateGroupMerged.cc
@@ -30,8 +30,8 @@ void NeuronUpdateGroupMerged::CurrentSource::generate(EnvironmentExternalBase &e
 
     // Substitute parameter and derived parameter names
     csEnv.addParams(cm->getParams(), fieldSuffix, &CurrentSourceInternal::getParams,
-                    &CurrentSource::isParamHeterogeneous, &CurrentSourceInternal::isParamDynamic);
-    csEnv.addDerivedParams(cm->getDerivedParams(), fieldSuffix, &CurrentSourceInternal::getDerivedParams, &CurrentSource::isDerivedParamHeterogeneous);
+                    &CurrentSourceInternal::isParamDynamic);
+    csEnv.addDerivedParams(cm->getDerivedParams(), fieldSuffix, &CurrentSourceInternal::getDerivedParams);
     csEnv.addExtraGlobalParams(cm->getExtraGlobalParams(), "", fieldSuffix);
 
     // Add neuron variable references
@@ -662,8 +662,8 @@ void NeuronUpdateGroupMerged::generateNeuronUpdate(const BackendBase &backend, E
 
     // Substitute parameter and derived parameter names
     neuronEnv.addParams(nm->getParams(), "", &NeuronGroupInternal::getParams,
-                        &NeuronUpdateGroupMerged::isParamHeterogeneous, &NeuronGroupInternal::isParamDynamic);
-    neuronEnv.addDerivedParams(nm->getDerivedParams(), "", &NeuronGroupInternal::getDerivedParams, &NeuronUpdateGroupMerged::isDerivedParamHeterogeneous);
+                        &NeuronGroupInternal::isParamDynamic);
+    neuronEnv.addDerivedParams(nm->getDerivedParams(), "", &NeuronGroupInternal::getDerivedParams);
     neuronEnv.addExtraGlobalParams(nm->getExtraGlobalParams());
     
     // Substitute spike time

--- a/src/genn/genn/code_generator/neuronUpdateGroupMerged.cc
+++ b/src/genn/genn/code_generator/neuronUpdateGroupMerged.cc
@@ -59,16 +59,6 @@ void NeuronUpdateGroupMerged::CurrentSource::updateHash(boost::uuids::detail::sh
     updateParamHash([](const CurrentSourceInternal &g) { return g.getParams(); }, hash);
     updateParamHash([](const CurrentSourceInternal &g) { return g.getDerivedParams(); }, hash);
 }
-//----------------------------------------------------------------------------
-bool NeuronUpdateGroupMerged::CurrentSource::isParamHeterogeneous(const std::string &paramName) const
-{
-    return isParamValueHeterogeneous(paramName, [](const CurrentSourceInternal &cs) { return cs.getParams(); });
-}
-//----------------------------------------------------------------------------
-bool NeuronUpdateGroupMerged::CurrentSource::isDerivedParamHeterogeneous( const std::string &paramName) const
-{
-    return isParamValueHeterogeneous(paramName, [](const CurrentSourceInternal &cs) { return cs.getDerivedParams(); });
-}
 
 //----------------------------------------------------------------------------
 // GeNN::CodeGenerator::NeuronUpdateGroupMerged::InSynPSM
@@ -112,8 +102,8 @@ void NeuronUpdateGroupMerged::InSynPSM::generate(const BackendBase &backend, Env
 
     // Add parameters, derived parameters and extra global parameters to environment
     psmEnv.addInitialiserParams(fieldSuffix, &SynapseGroupInternal::getPSInitialiser, 
-                                &InSynPSM::isParamHeterogeneous, &SynapseGroupInternal::isPSParamDynamic);
-    psmEnv.addInitialiserDerivedParams(fieldSuffix, &SynapseGroupInternal::getPSInitialiser, &InSynPSM::isDerivedParamHeterogeneous);
+                                &SynapseGroupInternal::isPSParamDynamic);
+    psmEnv.addInitialiserDerivedParams(fieldSuffix, &SynapseGroupInternal::getPSInitialiser);
     psmEnv.addExtraGlobalParams(psm->getExtraGlobalParams(), "", fieldSuffix);
     
     // Add neuron variable references
@@ -146,16 +136,6 @@ void NeuronUpdateGroupMerged::InSynPSM::updateHash(boost::uuids::detail::sha1 &h
 {
     updateParamHash([](const SynapseGroupInternal &g) { return g.getPSInitialiser().getParams(); }, hash);
     updateParamHash([](const SynapseGroupInternal &g) { return g.getPSInitialiser().getDerivedParams(); }, hash);
-}
-//----------------------------------------------------------------------------
-bool NeuronUpdateGroupMerged::InSynPSM::isParamHeterogeneous(const std::string &paramName) const
-{
-    return isParamValueHeterogeneous(paramName, [](const SynapseGroupInternal &sg) { return sg.getPSInitialiser().getParams(); });
-}
-//----------------------------------------------------------------------------
-bool NeuronUpdateGroupMerged::InSynPSM::isDerivedParamHeterogeneous( const std::string &paramName) const
-{
-    return isParamValueHeterogeneous(paramName, [](const SynapseGroupInternal &sg) { return sg.getPSInitialiser().getDerivedParams(); });
 }
 
 //----------------------------------------------------------------------------
@@ -255,8 +235,8 @@ void NeuronUpdateGroupMerged::SynSpikeEvent::generateEventCondition(EnvironmentE
 
     // Add parameters, derived parameters and extra global parameters to environment
     synEnv.addInitialiserParams(fieldSuffix, &SynapseGroupInternal::getWUInitialiser, 
-                                &SynSpikeEvent::isParamHeterogeneous, &SynapseGroupInternal::isWUParamDynamic);
-    synEnv.addInitialiserDerivedParams(fieldSuffix, &SynapseGroupInternal::getWUInitialiser, &SynSpikeEvent::isDerivedParamHeterogeneous);
+                                &SynapseGroupInternal::isWUParamDynamic);
+    synEnv.addInitialiserDerivedParams(fieldSuffix, &SynapseGroupInternal::getWUInitialiser);
     synEnv.addExtraGlobalParams(wum->getExtraGlobalParams(), "", fieldSuffix);
 
     // **NOTE** for an incoming and outgoing synapse group to be merged together, the getPreEventHashDigest and getPostEventHashDigest 
@@ -311,16 +291,6 @@ void NeuronUpdateGroupMerged::SynSpikeEvent::updateHash(boost::uuids::detail::sh
     updateParamHash([](const SynapseGroupInternal &g) { return g.getWUInitialiser().getDerivedParams(); }, hash);
 }
 //----------------------------------------------------------------------------
-bool NeuronUpdateGroupMerged::SynSpikeEvent::isParamHeterogeneous(const std::string &paramName) const
-{
-    return isParamValueHeterogeneous(paramName, [](const SynapseGroupInternal &sg) { return sg.getWUInitialiser().getParams(); });
-}
-//----------------------------------------------------------------------------
-bool NeuronUpdateGroupMerged::SynSpikeEvent::isDerivedParamHeterogeneous( const std::string &paramName) const
-{
-    return isParamValueHeterogeneous(paramName, [](const SynapseGroupInternal &sg) { return sg.getWUInitialiser().getDerivedParams(); });
-}
-//----------------------------------------------------------------------------
 void NeuronUpdateGroupMerged::SynSpikeEvent::generateEventConditionInternal(EnvironmentExternalBase &env, NeuronUpdateGroupMerged &ng,
                                                                             unsigned int batchSize, BackendBase::GroupHandlerEnv<SynSpikeEvent> genEmitSpikeLikeEvent,
                                                                             const std::vector<Transpiler::Token> &conditionTokens, const std::string &errorContext)
@@ -372,8 +342,8 @@ void NeuronUpdateGroupMerged::InSynWUMPostCode::generate(EnvironmentExternalBase
         
         // Add parameters, derived parameters and extra global parameters to environment
         synEnv.addInitialiserParams(fieldSuffix, &SynapseGroupInternal::getWUInitialiser, 
-                                    &InSynWUMPostCode::isParamHeterogeneous, &SynapseGroupInternal::isWUParamDynamic);
-        synEnv.addInitialiserDerivedParams(fieldSuffix, &SynapseGroupInternal::getWUInitialiser, &InSynWUMPostCode::isDerivedParamHeterogeneous);
+                                    &SynapseGroupInternal::isWUParamDynamic);
+        synEnv.addInitialiserDerivedParams(fieldSuffix, &SynapseGroupInternal::getWUInitialiser);
         synEnv.addExtraGlobalParams(wum->getExtraGlobalParams(), "", fieldSuffix);
 
         // If we're generating dynamics code, add local neuron variable references
@@ -432,16 +402,6 @@ void NeuronUpdateGroupMerged::InSynWUMPostCode::updateHash(boost::uuids::detail:
     updateParamHash([](const SynapseGroupInternal &g) { return g.getWUInitialiser().getParams(); }, hash);
     updateParamHash([](const SynapseGroupInternal &g) { return g.getWUInitialiser().getDerivedParams(); }, hash);
 }
-//----------------------------------------------------------------------------
-bool NeuronUpdateGroupMerged::InSynWUMPostCode::isParamHeterogeneous(const std::string &paramName) const
-{
-    return isParamValueHeterogeneous(paramName, [](const SynapseGroupInternal &sg) { return sg.getWUInitialiser().getParams(); });
-}
-//----------------------------------------------------------------------------
-bool NeuronUpdateGroupMerged::InSynWUMPostCode::isDerivedParamHeterogeneous( const std::string &paramName) const
-{
-    return isParamValueHeterogeneous(paramName, [](const SynapseGroupInternal &sg) { return sg.getWUInitialiser().getDerivedParams(); });
-}
 
 //----------------------------------------------------------------------------
 // GeNN::CodeGenerator::NeuronUpdateGroupMerged::OutSynWUMPreCode
@@ -462,8 +422,8 @@ void NeuronUpdateGroupMerged::OutSynWUMPreCode::generate(EnvironmentExternalBase
         
         // Add parameters, derived parameters and extra global parameters to environment
         synEnv.addInitialiserParams(fieldSuffix, &SynapseGroupInternal::getWUInitialiser, 
-                                    &OutSynWUMPreCode::isParamHeterogeneous, &SynapseGroupInternal::isWUParamDynamic);
-        synEnv.addInitialiserDerivedParams(fieldSuffix, &SynapseGroupInternal::getWUInitialiser, &OutSynWUMPreCode::isDerivedParamHeterogeneous);
+                                    &SynapseGroupInternal::isWUParamDynamic);
+        synEnv.addInitialiserDerivedParams(fieldSuffix, &SynapseGroupInternal::getWUInitialiser);
         synEnv.addExtraGlobalParams(wum->getExtraGlobalParams(), "", fieldSuffix);
 
         // If we're generating dynamics code, add local neuron variable references
@@ -518,16 +478,6 @@ void NeuronUpdateGroupMerged::OutSynWUMPreCode::updateHash(boost::uuids::detail:
 {
     updateParamHash([](const SynapseGroupInternal &g) { return g.getWUInitialiser().getParams(); }, hash);
     updateParamHash([](const SynapseGroupInternal &g) { return g.getWUInitialiser().getDerivedParams(); }, hash);
-}
-//----------------------------------------------------------------------------
-bool NeuronUpdateGroupMerged::OutSynWUMPreCode::isParamHeterogeneous(const std::string &paramName) const
-{
-    return isParamValueHeterogeneous(paramName, [](const SynapseGroupInternal &sg) { return sg.getWUInitialiser().getParams(); });
-}
-//----------------------------------------------------------------------------
-bool NeuronUpdateGroupMerged::OutSynWUMPreCode::isDerivedParamHeterogeneous( const std::string &paramName) const
-{
-    return isParamValueHeterogeneous(paramName, [](const SynapseGroupInternal &sg) { return sg.getWUInitialiser().getDerivedParams(); });
 }
 
 //----------------------------------------------------------------------------
@@ -903,16 +853,6 @@ std::string NeuronUpdateGroupMerged::getWriteVarIndex(bool delay, unsigned int b
     else {
         return getVarIndex(batchSize, varDims, index);
     }
-}
-//----------------------------------------------------------------------------
-bool NeuronUpdateGroupMerged::isParamHeterogeneous(const std::string &paramName) const
-{
-    return isParamValueHeterogeneous(paramName, [](const NeuronGroupInternal &ng) { return ng.getParams(); });
-}
-//----------------------------------------------------------------------------
-bool NeuronUpdateGroupMerged::isDerivedParamHeterogeneous(const std::string &paramName) const
-{
-    return isParamValueHeterogeneous(paramName, [](const NeuronGroupInternal &ng) { return ng.getDerivedParams(); });
 }
 
 //----------------------------------------------------------------------------


### PR DESCRIPTION
One of the really awkward things with the initial implementation of merging groups was that we had to add a manual mechanism for detecting whether parameters (and derived parameters) were heterogeneous across the merged group or not and handle them separately. With the improved type information present in GeNN 5 I always had in mind that this could be automated and applied to 'internal' parameters like number of neurons etc.

I had also always been intending to implement the "N-bit unsigned division via N-bit multiply-add" [10.1109/ARITH.2005.31](https://doi.org/10.1109/ARITH.2005.31) algorithm to get rid of various places where we divide by constants that are known at code generation time (as GPUs do not have integer divide in hardware). Essentially this algorithm pre-calculates 3 constants (a, b and m):
```c++
const uint32_t m = (uint32_t)std::floor(std::log2(d));

const uint32_t uintMax = std::numeric_limits<uint32_t>::max();
if(d == (1 << m)) {
    return std::make_tuple(uintMax, uintMax, m);
}
else {
    const uint32_t t = (1ull << (m + 32)) / d;
    const uint32_t r = ((t * d) + d) & uintMax;
    if(r <= (1 << m)) {
        return std::make_tuple(t + 1, 0, m);
    }
    else {
        return std::make_tuple(t, t, m);
    }
}
```
These can then be used at runtime to:
```c++
(((uint64_t)x * a) + b) >> (32 + m);
```
Sadly GPUs also don't have the _fused_ integer multiply accumulate instructions ( ``(((uint64_t)x * a) + b) >> 32``) targeted by the original paper but benchmarking suggests this is probably an improvement.