### PR TITLE
Don't keep box muller transform state between kernel launches

### DIFF
--- a/include/genn/backends/cuda/backend.h
+++ b/include/genn/backends/cuda/backend.h
@@ -174,9 +174,6 @@ public:
                                   AtomicOperation op = AtomicOperation::ADD, 
                                   AtomicMemSpace memSpace = AtomicMemSpace::GLOBAL) const final;
 
-    //! Get type of population RNG
-    virtual Type::ResolvedType getPopulationRNGType() const final;
-
     //--------------------------------------------------------------------------
     // CodeGenerator::BackendBase virtuals
     //--------------------------------------------------------------------------
@@ -190,10 +187,6 @@ public:
         \param location     location of array e.g. device-only*/
     virtual std::unique_ptr<Runtime::ArrayBase> createArray(const Type::ResolvedType &type, size_t count, 
                                                             VarLocation location, bool uninitialized) const final;
-
-    //! Create array of backend-specific population RNGs (if they are initialised on host this will occur here)
-    /*! \param count        number of RNGs required*/
-    virtual std::unique_ptr<Runtime::ArrayBase> createPopulationRNG(size_t count) const final;
 
     //! Generate code to allocate variable with a size known at runtime
     virtual void genLazyVariableDynamicAllocation(CodeStream &os, 
@@ -233,6 +226,9 @@ protected:
     {
         return m_ChosenDevice.totalConstMem - getPreferences<Preferences>().constantCacheOverhead;
     }
+
+    //! Get internal type population RNG gets loaded into
+    virtual Type::ResolvedType getPopulationRNGInternalType() const final;
 
     //! Get library of RNG functions to use
     virtual const EnvironmentLibrary::Library &getRNGFunctions(const Type::ResolvedType &precision) const final;

--- a/include/genn/backends/hip/backend.h
+++ b/include/genn/backends/hip/backend.h
@@ -165,9 +165,6 @@ public:
                                   AtomicOperation op = AtomicOperation::ADD, 
                                   AtomicMemSpace memSpace = AtomicMemSpace::GLOBAL) const final;
 
-    //! Get type of population RNG
-    virtual Type::ResolvedType getPopulationRNGType() const final;
-
     //--------------------------------------------------------------------------
     // CodeGenerator::BackendBase virtuals
     //--------------------------------------------------------------------------
@@ -181,10 +178,6 @@ public:
         \param location     location of array e.g. device-only*/
     virtual std::unique_ptr<Runtime::ArrayBase> createArray(const Type::ResolvedType &type, size_t count, 
                                                             VarLocation location, bool uninitialized) const final;
-
-    //! Create array of backend-specific population RNGs (if they are initialised on host this will occur here)
-    /*! \param count        number of RNGs required*/
-    virtual std::unique_ptr<Runtime::ArrayBase> createPopulationRNG(size_t count) const final;
 
     //! Generate code to allocate variable with a size known at runtime
     virtual void genLazyVariableDynamicAllocation(CodeStream &os, 
@@ -225,6 +218,9 @@ protected:
         return m_ChosenDevice.totalConstMem - getPreferences<Preferences>().constantCacheOverhead;
     }
 
+    //! Get internal type population RNG gets loaded into
+    virtual Type::ResolvedType getPopulationRNGInternalType() const final;
+    
     //! Get library of RNG functions to use
     virtual const EnvironmentLibrary::Library &getRNGFunctions(const Type::ResolvedType &precision) const final;
 

--- a/include/genn/genn/code_generator/backendCUDAHIP.h
+++ b/include/genn/genn/code_generator/backendCUDAHIP.h
@@ -90,7 +90,10 @@ public:
     virtual Type::ResolvedType getPopulationRNGType() const final;
 
     //! Generate a preamble to add substitution name for population RNG
-    virtual void addPopulationRNG(EnvironmentGroupMergedField<NeuronUpdateGroupMerged> &env) const final;
+    virtual void buildPopulationRNGEnvironment(EnvironmentGroupMergedField<NeuronUpdateGroupMerged> &env) const final;
+
+    //! Add $(_rng) to environment based on $(_rng_internal) field with any initialisers and destructors required
+    virtual void buildPopulationRNGEnvironment(EnvironmentGroupMergedField<CustomConnectivityUpdateGroupMerged> &env) const final;
 
     //--------------------------------------------------------------------------
     // CodeGenerator::BackendBase virtuals

--- a/include/genn/genn/code_generator/backendCUDAHIP.h
+++ b/include/genn/genn/code_generator/backendCUDAHIP.h
@@ -58,10 +58,6 @@ public:
     {}
 
     //--------------------------------------------------------------------------
-    // Declared virtuals
-    //--------------------------------------------------------------------------
-    
-    //--------------------------------------------------------------------------
     // CodeGenerator::BackendSIMT virtuals
     //--------------------------------------------------------------------------
     //! Get the prefix to use for shared memory variables
@@ -87,15 +83,14 @@ public:
     //! For SIMT backends which initialize RNGs on device, initialize population RNG with specified seed and sequence
     virtual void genPopulationRNGInit(CodeStream &os, const std::string &globalRNG, const std::string &seed, const std::string &sequence) const final;
 
-    //! Generate a preamble to add substitution name for population RNG
-    virtual std::string genPopulationRNGPreamble(CodeStream &os, const std::string &globalRNG) const final;
-
-    //! If required, generate a postamble for population RNG
-    /*! For example, in OpenCL, this is used to write local RNG state back to global memory*/
-    virtual void genPopulationRNGPostamble(CodeStream &os, const std::string &globalRNG) const final;
-
     //! Generate code to skip ahead local copy of global RNG
     virtual std::string genGlobalRNGSkipAhead(CodeStream &os, const std::string &sequence) const final;
+
+    //! Get type of population RNG
+    virtual Type::ResolvedType getPopulationRNGType() const final;
+
+    //! Generate a preamble to add substitution name for population RNG
+    virtual void addPopulationRNG(EnvironmentGroupMergedField<NeuronUpdateGroupMerged> &env) const final;
 
     //--------------------------------------------------------------------------
     // CodeGenerator::BackendBase virtuals
@@ -117,6 +112,10 @@ public:
     virtual void genAllocateMemPreamble(CodeStream &os, const ModelSpecMerged &modelMerged) const final;
     virtual void genFreeMemPreamble(CodeStream &os, const ModelSpecMerged &modelMerged) const final;
     virtual void genStepTimeFinalisePreamble(CodeStream &os, const ModelSpecMerged &modelMerged) const final;
+
+    //! Create array of backend-specific population RNGs (if they are initialised on host this will occur here)
+    /*! \param count        number of RNGs required*/
+    virtual std::unique_ptr<GeNN::Runtime::ArrayBase> createPopulationRNG(size_t count) const final;
 
     //! Generate code for pushing a variable with a size known at runtime to the 'device'
     virtual void genLazyVariableDynamicPush(CodeStream &os, 
@@ -172,6 +171,9 @@ protected:
     //--------------------------------------------------------------------------
     //! Get the safe amount of constant cache we can use
     virtual size_t getChosenDeviceSafeConstMemBytes() const = 0;
+
+    //! Get internal type population RNG gets loaded into
+    virtual Type::ResolvedType getPopulationRNGInternalType() const = 0;
 
     //! Get library of RNG functions to use
     virtual const EnvironmentLibrary::Library &getRNGFunctions(const Type::ResolvedType &precision) const = 0;

--- a/include/genn/genn/code_generator/backendSIMT.h
+++ b/include/genn/genn/code_generator/backendSIMT.h
@@ -103,13 +103,9 @@ public:
     //! For SIMT backends which initialize RNGs on device, initialize population RNG with specified seed and sequence
     virtual void genPopulationRNGInit(CodeStream &os, const std::string &globalRNG, const std::string &seed, const std::string &sequence) const = 0;
 
-    //! Generate a preamble to add substitution name for population RNG
-    virtual std::string genPopulationRNGPreamble(CodeStream &os, const std::string &globalRNG) const = 0;
+    //! Add $(_rng) to environment based on $(_rng_internal) field with any initialisers and destructors required
+    virtual void addPopulationRNG(EnvironmentGroupMergedField<NeuronUpdateGroupMerged> &env) const = 0;
     
-    //! If required, generate a postamble for population RNG
-    /*! For example, in OpenCL, this is used to write local RNG state back to global memory*/
-    virtual void genPopulationRNGPostamble(CodeStream &os, const std::string &globalRNG) const = 0;
-
     //! Generate code to skip ahead local copy of global RNG
     virtual std::string genGlobalRNGSkipAhead(CodeStream &os, const std::string &sequence) const = 0;
 

--- a/include/genn/genn/code_generator/backendSIMT.h
+++ b/include/genn/genn/code_generator/backendSIMT.h
@@ -104,8 +104,11 @@ public:
     virtual void genPopulationRNGInit(CodeStream &os, const std::string &globalRNG, const std::string &seed, const std::string &sequence) const = 0;
 
     //! Add $(_rng) to environment based on $(_rng_internal) field with any initialisers and destructors required
-    virtual void addPopulationRNG(EnvironmentGroupMergedField<NeuronUpdateGroupMerged> &env) const = 0;
+    virtual void buildPopulationRNGEnvironment(EnvironmentGroupMergedField<NeuronUpdateGroupMerged> &env) const = 0;
     
+    //! Add $(_rng) to environment based on $(_rng_internal) field with any initialisers and destructors required
+    virtual void buildPopulationRNGEnvironment(EnvironmentGroupMergedField<CustomConnectivityUpdateGroupMerged> &env) const = 0;
+
     //! Generate code to skip ahead local copy of global RNG
     virtual std::string genGlobalRNGSkipAhead(CodeStream &os, const std::string &sequence) const = 0;
 

--- a/include/genn/genn/type.h
+++ b/include/genn/genn/type.h
@@ -346,6 +346,12 @@ struct GENN_EXPORT ResolvedType
         return ResolvedType{Value{name, sizeof(T), ffiType, device, false, std::nullopt}, isConst};
     }
 
+    static ResolvedType createValue(const std::string &name, size_t size, bool isConst = false, 
+                                    ffi_type *ffiType = nullptr, bool device = false)
+    {
+        return ResolvedType{Value{name, size, ffiType, device, false, std::nullopt}, isConst};
+    }
+
     static ResolvedType createFunction(const ResolvedType &returnType, const std::vector<ResolvedType> &argTypes,
                                        FunctionFlags flags=FunctionFlags{0})
     {

--- a/src/genn/backends/cuda/backend.cc
+++ b/src/genn/backends/cuda/backend.cc
@@ -353,11 +353,6 @@ std::string Backend::getAtomic(const Type::ResolvedType &type, AtomicOperation o
     }
 }
 //--------------------------------------------------------------------------
-Type::ResolvedType Backend::getPopulationRNGType() const
-{
-    return CURandState;
-}
-//--------------------------------------------------------------------------
 std::unique_ptr<GeNN::Runtime::StateBase> Backend::createState(const Runtime::Runtime &runtime) const
 {
     return std::make_unique<State>(runtime);
@@ -367,11 +362,6 @@ std::unique_ptr<Runtime::ArrayBase> Backend::createArray(const Type::ResolvedTyp
                                                          VarLocation location, bool uninitialized) const
 {
     return std::make_unique<Array>(type, count, location, uninitialized);
-}
-//--------------------------------------------------------------------------
-std::unique_ptr<Runtime::ArrayBase> Backend::createPopulationRNG(size_t count) const
-{
-    return createArray(CURandState, count, VarLocation::DEVICE, false);
 }
 //--------------------------------------------------------------------------
 void Backend::genLazyVariableDynamicAllocation(CodeStream &os, const Type::ResolvedType &type, const std::string &name,
@@ -548,6 +538,11 @@ std::string Backend::getNVCCFlags() const
     }
 
     return nvccFlags;
+}
+//--------------------------------------------------------------------------
+Type::ResolvedType Backend::getPopulationRNGInternalType() const
+{
+    return CURandState;
 }
 //--------------------------------------------------------------------------
 const EnvironmentLibrary::Library &Backend::getRNGFunctions(const Type::ResolvedType &precision) const

--- a/src/genn/backends/hip/backend.cc
+++ b/src/genn/backends/hip/backend.cc
@@ -345,11 +345,6 @@ std::string Backend::getAtomic(const Type::ResolvedType &type, AtomicOperation o
     }
 }
 //--------------------------------------------------------------------------
-Type::ResolvedType Backend::getPopulationRNGType() const
-{
-    return HIPRandState;
-}
-//--------------------------------------------------------------------------
 std::unique_ptr<GeNN::Runtime::StateBase> Backend::createState(const Runtime::Runtime &runtime) const
 {
     return std::make_unique<State>(runtime);
@@ -359,11 +354,6 @@ std::unique_ptr<Runtime::ArrayBase> Backend::createArray(const Type::ResolvedTyp
                                                          VarLocation location, bool uninitialized) const
 {
     return std::make_unique<Array>(type, count, location, uninitialized);
-}
-//--------------------------------------------------------------------------
-std::unique_ptr<Runtime::ArrayBase> Backend::createPopulationRNG(size_t count) const
-{
-    return createArray(HIPRandState, count, VarLocation::DEVICE, false);
 }
 //--------------------------------------------------------------------------
 void Backend::genLazyVariableDynamicAllocation(CodeStream &os, const Type::ResolvedType &type, const std::string &name,
@@ -548,6 +538,11 @@ std::string Backend::getHIPCCFlags() const
     assert(false);
     return "";
 #endif
+}
+//--------------------------------------------------------------------------
+Type::ResolvedType Backend::getPopulationRNGInternalType() const
+{
+    return HIPRandState;
 }
 //--------------------------------------------------------------------------
 const EnvironmentLibrary::Library &Backend::getRNGFunctions(const Type::ResolvedType &precision) const

--- a/src/genn/genn/code_generator/backendCUDAHIP.cc
+++ b/src/genn/genn/code_generator/backendCUDAHIP.cc
@@ -201,19 +201,19 @@ void buildPopulationRNGEnvironment(EnvironmentGroupMergedField<G> &env, const st
     // Zero box-muller flag
     init << "rngState.boxmuller_flag = 0;" << std::endl;
 
-    // Generate destructor code to copy CURandState back into internal RNG state
-    std::stringstream destroy;
+    // Generate finaliser code to copy CURandState back into internal RNG state
+    std::stringstream finalise;
 
     // Copy useful components into internal object
-    destroy << "$(_rng_internal).d = rngState.d;" << std::endl;
+    finalise << "$(_rng_internal).d = rngState.d;" << std::endl;
     for(int i = 0; i < 5; i++) {
-        destroy << "$(_rng_internal).v[" << i << "] = rngState.v[" << i << "];" << std::endl;
+        finalise << "$(_rng_internal).v[" << i << "] = rngState.v[" << i << "];" << std::endl;
     }
 
     // Add alias with initialiser and destructor statements
     env.add(popRNGInternalType, "_rng", "rngState",
             {env.addInitialiser(init.str())},
-            {env.addDestructor(destroy.str())});
+            {env.addFinaliser(finalise.str())});
 }
 }   // Anonymous namespace
 


### PR DESCRIPTION
This builds on the  new hybrid HIP/CUDA backend from #647 so review that first!

As described in #648, beyond its (arguably excessive) 192 bit of state, the curand XORWOW RNG used to provide randomness for neuron and custom connectivity updates also stores 160 bits of [box muller transform](https://en.wikipedia.org/wiki/Box%E2%80%93Muller_transform) state in the ``curandState`` struct (BM draws two numbers and produces two normally distributed values so this state is used to cache one of those results for subsequent calls to ``curand_normal``). 

In this PR, when using CUDA and HIP backends, we create our own ``XORWowStateInternal`` struct in definitions.h without the BM state and store this in memory. At the start of the neuron and custom connectivity update kernels, we copy the fields from the  ``XORWowStateInternal`` struct into a local ``curandState`` and, at the end, we copy them back.

Excitingly, because we are very memory bandwidth bound, this makes the neuron kernel on the cortical microcircuit model about 60% faster. On my A5000 (running for 1 second):

|                                | Before[seconds] | After [seconds] |
|--------------------- |-------------------|------------------|
|neuron update        | 0.18                    | 0.11                  |
|presynaptic update | 0.23                    | 0.24                  |