### PR TITLE
Post PSM variable references

### DIFF
--- a/include/genn/genn/currentSource.h
+++ b/include/genn/genn/currentSource.h
@@ -73,8 +73,8 @@ public:
 protected:
     CurrentSource(const std::string &name, const CurrentSourceModels::Base *model,
                   const std::map<std::string, Type::NumericValue> &params, const std::map<std::string, InitVarSnippet::Init> &varInitialisers,
-                  const std::map<std::string, Models::VarReference> &neuronVarReferences, const NeuronGroupInternal *trgNeuronGroup, 
-                  VarLocation defaultVarLocation, VarLocation defaultExtraGlobalParamLocation);
+                  const std::map<std::string, std::variant<std::string, Models::VarReference>> &neuronVarReferences, 
+                  NeuronGroupInternal *trgNeuronGroup, VarLocation defaultVarLocation, VarLocation defaultExtraGlobalParamLocation);
 
     //------------------------------------------------------------------------
     // Protected methods

--- a/include/genn/genn/currentSourceInternal.h
+++ b/include/genn/genn/currentSourceInternal.h
@@ -15,8 +15,8 @@ public:
 
     CurrentSourceInternal(const std::string &name, const CurrentSourceModels::Base *currentSourceModel,
                           const std::map<std::string, Type::NumericValue> &params, const std::map<std::string, InitVarSnippet::Init> &varInitialisers,
-                          const std::map<std::string, Models::VarReference> &neuronVarReferences, const NeuronGroupInternal *targetNeuronGroup, 
-                          VarLocation defaultVarLocation, VarLocation defaultExtraGlobalParamLocation)
+                          const std::map<std::string, std::variant<std::string, Models::VarReference>> &neuronVarReferences, 
+                          NeuronGroupInternal *targetNeuronGroup, VarLocation defaultVarLocation, VarLocation defaultExtraGlobalParamLocation)
     :   CurrentSource(name, currentSourceModel, params, varInitialisers, neuronVarReferences, 
                       targetNeuronGroup, defaultVarLocation, defaultExtraGlobalParamLocation)
     {

--- a/include/genn/genn/modelSpec.h
+++ b/include/genn/genn/modelSpec.h
@@ -42,6 +42,7 @@ namespace GeNN
 {
 using VarValues = std::map<std::string, InitVarSnippet::Init>;
 using VarReferences = std::map<std::string, Models::VarReference>;
+using LocalVarReferences = std::map<std::string, std::variant<std::string, Models::VarReference>>;
 using WUVarReferences = std::map<std::string, Models::WUVarReference>;
 using EGPReferences = std::map<std::string, Models::EGPReference>;
 
@@ -100,7 +101,7 @@ inline InitToeplitzConnectivitySnippet::Init initToeplitzConnectivity(const Para
     \return                 PostsynapticModels::Init object for passing to ``ModelSpec::addSynapsePopulation``*/
 template<typename S>
 inline PostsynapticModels::Init initPostsynaptic(const ParamValues &params = {}, const VarValues &vars = {}, 
-                                                 const VarReferences &neuronVarRefs = {})
+                                                 const LocalVarReferences &neuronVarRefs = {})
 {
     return PostsynapticModels::Init(S::getInstance(), params, vars, neuronVarRefs);
 }
@@ -117,8 +118,8 @@ inline PostsynapticModels::Init initPostsynaptic(const ParamValues &params = {},
 template<typename S>
 inline WeightUpdateModels::Init initWeightUpdate(const ParamValues &params = {}, const VarValues &vars = {}, 
                                                  const VarValues &preVars = {}, const VarValues &postVars = {}, 
-                                                 const VarReferences &preNeuronVarRefs = {}, 
-                                                 const VarReferences &postNeuronVarRefs = {})
+                                                 const LocalVarReferences &preNeuronVarRefs = {}, 
+                                                 const LocalVarReferences &postNeuronVarRefs = {})
 {
     return WeightUpdateModels::Init(S::getInstance(), params, vars, preVars, postVars, 
                                     preNeuronVarRefs, postNeuronVarRefs);

--- a/include/genn/genn/modelSpec.h
+++ b/include/genn/genn/modelSpec.h
@@ -114,15 +114,17 @@ inline PostsynapticModels::Init initPostsynaptic(const ParamValues &params = {},
     \param postVars             postsynaptic variables for snippet wrapped in VarValues object.
     \param preNeuronVarRefs     presynaptic neuron variable references for snippet wrapped in VarReferences object.
     \param postNeuronVarRefs    postsynaptic neuron variable references for snippet wrapped in VarReferences object.
+    \param psmVarRefs           postsynaptic modelvariable references for snippet wrapped in VarReferences object.
     \return                     PostsynapticModels::Init object for passing to ``ModelSpec::addSynapsePopulation``*/
 template<typename S>
 inline WeightUpdateModels::Init initWeightUpdate(const ParamValues &params = {}, const VarValues &vars = {}, 
                                                  const VarValues &preVars = {}, const VarValues &postVars = {}, 
                                                  const LocalVarReferences &preNeuronVarRefs = {}, 
-                                                 const LocalVarReferences &postNeuronVarRefs = {})
+                                                 const LocalVarReferences &postNeuronVarRefs = {},
+                                                 const LocalVarReferences &psmVarRefs = {})
 {
     return WeightUpdateModels::Init(S::getInstance(), params, vars, preVars, postVars, 
-                                    preNeuronVarRefs, postNeuronVarRefs);
+                                    preNeuronVarRefs, postNeuronVarRefs, psmVarRefs);
 }
 
 //! Creates a reference to a neuron group variable.

--- a/include/genn/genn/modelSpec.h
+++ b/include/genn/genn/modelSpec.h
@@ -442,7 +442,8 @@ public:
         \param varInitialisers state variable initialiser snippets and parameters wrapped in VarValues object.
         \return pointer to newly created CurrentSource */
     CurrentSource *addCurrentSource(const std::string &currentSourceName, const CurrentSourceModels::Base *model, NeuronGroup *neuronGroup,
-                                    const ParamValues &paramValues = {}, const VarValues &varInitialisers = {}, const VarReferences &neuronVarReferences = {});
+                                    const ParamValues &paramValues = {}, const VarValues &varInitialisers = {},
+                                    const LocalVarReferences &neuronVarReferences = {});
 
     //! Adds a new current source to the model using a singleton current source model created using standard DECLARE_MODEL and IMPLEMENT_MODEL macros
     /*! \tparam CurrentSourceModel type of neuron model (derived from CurrentSourceModel::Base).
@@ -454,7 +455,7 @@ public:
     template<typename CurrentSourceModel>
     CurrentSource *addCurrentSource(const std::string &currentSourceName, NeuronGroup *neuronGroup,
                                     const ParamValues &paramValues = {}, const VarValues &varInitialisers = {}, 
-                                    const VarReferences &neuronVarReferences = {})
+                                    const LocalVarReferences &neuronVarReferences = {})
     {
         return addCurrentSource(currentSourceName, CurrentSourceModel::getInstance(),
                                 neuronGroup, paramValues, varInitialisers, neuronVarReferences);

--- a/include/genn/genn/models.h
+++ b/include/genn/genn/models.h
@@ -503,6 +503,25 @@ void checkVarReferenceTypes(const std::map<std::string, V> &varRefs, const Base:
     }
 }
 
+template<typename G, typename C>
+void resolveVarReferences(const std::map<std::string, std::variant<std::string, VarReference>> &unresolvedVarRefs,
+                          std::map<std::string, VarReference> &varRefs, G *group, C createVarRef)
+{
+    // Loop through unresolved variable references
+    for(const auto &v : unresolvedVarRefs) {
+        varRefs.try_emplace(v.first,
+                            Utils::Overload{
+                                [](const std::string &name)
+                                {
+                                    return createVarRef(group, name);
+                                },
+                                [](const Models::VarReference &v)
+                                {
+                                    return v;
+                                }},
+                            v.second);
+    }
+}
 GENN_EXPORT void checkEGPReferenceTypes(const std::map<std::string, EGPReference> &egpRefs,
                                         const Base::EGPRefVec &modelEGPRefs);
 

--- a/include/genn/genn/models.h
+++ b/include/genn/genn/models.h
@@ -186,6 +186,9 @@ public:
     
     //! Does this variable reference's target belong to neuron group
     bool isTargetNeuronGroup(const NeuronGroupInternal *ng) const;
+
+    //! Does this variable reference's target belong to synapse group postsynaptic model
+    bool isTargetSynapseGroupPSM(const SynapseGroupInternal *sg) const;
     
     //! If variable is delayed, get neuron group which manages its delay
     NeuronGroup *getDelayNeuronGroup() const;
@@ -485,8 +488,30 @@ GENN_EXPORT void updateHash(const Base::EGPRef &e, boost::uuids::detail::sha1 &h
 // Free functions
 //----------------------------------------------------------------------------
 //! Helper function to check if local variable references are configured correctly
-GENN_EXPORT void checkLocalVarReferences(const std::map<std::string, VarReference> &varRefs, const Base::VarRefVec &modelVarRefs,
-                                         const NeuronGroupInternal *ng, const std::string &targetErrorDescription);
+template<typename G>
+void checkLocalVarReferences(const std::map<std::string, VarReference> &varRefs, const Base::VarRefVec &modelVarRefs,
+                             const G *g, const std::string &targetErrorDescription, 
+                             bool (VarReference::*isTargetCorrectFn)(const G*) const)
+{
+    // Loop through all variable references
+    for(const auto &modelVarRef : modelVarRefs) {
+        const auto &varRef = varRefs.at(modelVarRef.name);
+
+        // If (neuron) variable being targetted doesn't have BATCH or ELEMENT axis,
+        // check it's only accessed read-only
+        const auto varDims = varRef.getVarDims();
+        if((!(varDims & VarAccessDim::BATCH) || !(varDims & VarAccessDim::ELEMENT))
+            && (modelVarRef.access != VarAccessMode::READ_ONLY))
+        {
+            throw std::runtime_error("Variable references to SHARED_NEURON or SHARED neuron variables cannot be read-write.");
+        }
+
+        // If variable reference target doesn't have correct target, give error
+        if(!std::invoke(isTargetCorrectFn, varRef, g)) {
+            throw std::runtime_error(targetErrorDescription);
+        }
+    }
+}
 //! Helper function to check if variable reference types match those specified in model
 template<typename V>
 void checkVarReferenceTypes(const std::map<std::string, V> &varRefs, const Base::VarRefVec &modelVarRefs)

--- a/include/genn/genn/models.h
+++ b/include/genn/genn/models.h
@@ -503,6 +503,7 @@ void checkVarReferenceTypes(const std::map<std::string, V> &varRefs, const Base:
     }
 }
 
+//! Helper function to 'resolve' local variable references which may be specified with just a string
 template<typename G, typename C>
 void resolveVarReferences(const std::map<std::string, std::variant<std::string, VarReference>> &unresolvedVarRefs,
                           std::map<std::string, VarReference> &varRefs, G *group, C createVarRef)
@@ -510,16 +511,17 @@ void resolveVarReferences(const std::map<std::string, std::variant<std::string, 
     // Loop through unresolved variable references
     for(const auto &v : unresolvedVarRefs) {
         varRefs.try_emplace(v.first,
-                            Utils::Overload{
-                                [](const std::string &name)
-                                {
-                                    return createVarRef(group, name);
-                                },
-                                [](const Models::VarReference &v)
-                                {
-                                    return v;
-                                }},
-                            v.second);
+                            std::visit(
+                                Utils::Overload{
+                                    [createVarRef, group](const std::string &name)
+                                    {
+                                        return createVarRef(group, name);
+                                    },
+                                    [](const Models::VarReference &v)
+                                    {
+                                        return v;
+                                    }},
+                                v.second));
     }
 }
 GENN_EXPORT void checkEGPReferenceTypes(const std::map<std::string, EGPReference> &egpRefs,

--- a/include/genn/genn/neuronGroup.h
+++ b/include/genn/genn/neuronGroup.h
@@ -225,7 +225,7 @@ protected:
     //! Tokens produced by scanner from reset code
     const auto &getResetCodeTokens() const { return m_ResetCodeTokens; }
 
-    bool isVarQueueRequired(const std::string &var) const;
+    bool isVarQueueRequired(const std::string &var) const{ return (m_VarQueueRequired.count(var) == 0) ? false : true; }
 
     bool isSpikeQueueRequired() const{ return m_SpikeQueueRequired; }
 

--- a/include/genn/genn/postsynapticModels.h
+++ b/include/genn/genn/postsynapticModels.h
@@ -58,7 +58,7 @@ class GENN_EXPORT Init : public Snippet::Init<Base>
 public:
     Init(const Base *snippet, const std::map<std::string, Type::NumericValue> &params, 
          const std::map<std::string, InitVarSnippet::Init> &varInitialisers, 
-         const std::map<std::string, Models::VarReference> &neuronVarReferences);
+         const std::map<std::string, std::variant<std::string, Models::VarReference>> &neuronVarReferences);
 
     //------------------------------------------------------------------------
     // Public API
@@ -80,7 +80,7 @@ private:
     std::vector<Transpiler::Token> m_SimCodeTokens;
 
     std::map<std::string, InitVarSnippet::Init> m_VarInitialisers;
-    std::map<std::string, Models::VarReference> m_NeuronVarReferences;
+    std::map<std::string, std::variant<std::string, Models::VarReference>> m_NeuronVarReferences;
 };
 
 //----------------------------------------------------------------------------

--- a/include/genn/genn/postsynapticModels.h
+++ b/include/genn/genn/postsynapticModels.h
@@ -47,7 +47,7 @@ public:
     //! Validate names of parameters etc
     void validate(const std::map<std::string, Type::NumericValue> &paramValues, 
                   const std::map<std::string, InitVarSnippet::Init> &varValues,
-                  const std::map<std::string, Models::VarReference> &varRefTargets) const;
+                  const std::map<std::string, std::variant<std::string, Models::VarReference>> &varRefTargets) const;
 };
 
 //----------------------------------------------------------------------------

--- a/include/genn/genn/synapseGroup.h
+++ b/include/genn/genn/synapseGroup.h
@@ -228,13 +228,16 @@ public:
     const auto &getPSInitialiser() const{ return m_PSInitialiser; }
     const auto &getWUInitialiser() const{ return m_WUInitialiser; }
     
-    //! Get 'resolved' variable references to presynaptic neuron varaibles used in weight update model
+    //! Get 'resolved' variable references to presynaptic neuron variables used in weight update model
     const auto &getWUMPreNeuronVarReferences() const{ return m_WUMPreNeuronVarReferences; }
 
-    //! Get 'resolved' variable references to presynaptic neurons varaibles used in weight update model
+    //! Get 'resolved' variable references to presynaptic neurons variables used in weight update model
     const auto &getWUMPostNeuronVarReferences() const{ return m_WUMPostNeuronVarReferences; }
     
-    //! Get 'resolved' variable references to neurons varaibles used in postsynaptic update model
+    //! Get 'resolved' variable references to presynaptic model variables used in weight update model
+    const auto &getWUMPSMVarReferences() const{ return m_WUMPSMVarReferences; }
+    
+    //! Get 'resolved' variable references to neurons variables used in postsynaptic update model
     const auto &getPSNeuronVarReferences() const{ return m_PSNeuronVarReferences; }
 
     const auto &getSparseConnectivityInitialiser() const{ return m_SparseConnectivityInitialiser; }
@@ -604,13 +607,16 @@ private:
     /*! Because, if connectivity is sparse, all groups share connectivity this is required if connectivity changes. */
     std::vector<CustomUpdateWUInternal*> m_CustomUpdateReferences;
 
-    //! 'Resolved' variable references to presynaptic neuron varaibles used in weight update model
+    //! 'Resolved' variable references to presynaptic neuron variables used in weight update model
     std::map<std::string, Models::VarReference> m_WUMPreNeuronVarReferences;
 
-    //! 'Resolved' variable references to presynaptic neurons varaibles used in weight update model
+    //! 'Resolved' variable references to presynaptic neurons variables used in weight update model
     std::map<std::string, Models::VarReference> m_WUMPostNeuronVarReferences;
+
+    //! 'Resolved' variable references to postsynaptic model variables used in weight update model
+    std::map<std::string, Models::VarReference> m_WUMPSMVarReferences;
     
-    //! 'Resolved' variable references to neurons varaibles used in postsynaptic update model
+    //! 'Resolved' variable references to neurons variables used in postsynaptic update model
     std::map<std::string, Models::VarReference> m_PSNeuronVarReferences;
     
 };

--- a/include/genn/genn/synapseGroup.h
+++ b/include/genn/genn/synapseGroup.h
@@ -275,6 +275,9 @@ protected:
     void setFusedWUPrePostTarget(const NeuronGroup *ng, const SynapseGroup &target);
     void setFusedPreOutputTarget(const NeuronGroup *ng, const SynapseGroup &target);
     
+    // Set a variable as requiring queueing
+    void setPSMVarQueueRequired(const std::string &varName){ m_PSMVarQueueRequired.insert(varName); }
+
     void finalise(double dt);
 
     //! Add reference to custom connectivity update, referencing this synapse group
@@ -350,6 +353,8 @@ protected:
 
     //! Are any postsynaptic weight update model variable heterogeneously delayed?
     bool areAnyWUPostVarHeterogeneouslyDelayed() const;
+
+    bool isPSMVarQueueRequired(const std::string &var) const{ return (m_PSMVarQueueRequired.count(var) == 0) ? false : true; }
 
     //! Does this synapse group provide presynaptic output?
     bool isPresynapticOutputRequired() const; 
@@ -485,6 +490,9 @@ private:
 
     //! Maximum dendritic delay timesteps supported for synapses in this population
     std::optional<unsigned int> m_MaxDendriticDelayTimesteps;
+    
+    //! Set of names of PSM variable requiring queueing
+    std::set<std::string> m_PSMVarQueueRequired;
 
     //! Kernel size 
     std::vector<unsigned int> m_KernelSize;

--- a/include/genn/genn/synapseGroup.h
+++ b/include/genn/genn/synapseGroup.h
@@ -354,7 +354,11 @@ protected:
     //! Are any postsynaptic weight update model variable heterogeneously delayed?
     bool areAnyWUPostVarHeterogeneouslyDelayed() const;
 
-    bool isPSMVarQueueRequired(const std::string &var) const{ return (m_PSMVarQueueRequired.count(var) == 0) ? false : true; }
+    //! Is the named postsynaptic  model variable heterogeneously delayed?
+    bool isPSMVarHeterogeneouslyDelayed(const std::string &var) const;
+
+    //! Is the named postsynaptic model variable referenced in synapse code?
+    bool isPSMVarQueueRequired(const std::string &var) const;
 
     //! Does this synapse group provide presynaptic output?
     bool isPresynapticOutputRequired() const; 
@@ -532,6 +536,10 @@ private:
     //! Set of names of postsynaptic weight update 
     //! model variables which are heterogeneously delayed
     std::set<std::string> m_HeterogeneouslyDelayedWUPostVars;
+
+    //! Set of names of postsynaptic model variables
+    //! which are heterogeneously delayed
+    std::set<std::string> m_HeterogeneouslyDelayedPSMVars;
     
     //! Location of individual per-synapse state variables.
     /*! This is ignored for simulations on hardware with a single memory space */

--- a/include/genn/genn/synapseGroup.h
+++ b/include/genn/genn/synapseGroup.h
@@ -227,7 +227,16 @@ public:
 
     const auto &getPSInitialiser() const{ return m_PSInitialiser; }
     const auto &getWUInitialiser() const{ return m_WUInitialiser; }
-      
+    
+    //! Get 'resolved' variable references to presynaptic neuron varaibles used in weight update model
+    const auto &getWUMPreNeuronVarReferences() const{ return m_WUMPreNeuronVarReferences; }
+
+    //! Get 'resolved' variable references to presynaptic neurons varaibles used in weight update model
+    const auto &getWUMPostNeuronVarReferences() const{ return m_WUMPostNeuronVarReferences; }
+    
+    //! Get 'resolved' variable references to neurons varaibles used in postsynaptic update model
+    const auto &getPSNeuronVarReferences() const{ return m_PSNeuronVarReferences; }
+
     const auto &getSparseConnectivityInitialiser() const{ return m_SparseConnectivityInitialiser; }
     const auto &getToeplitzConnectivityInitialiser() const { return m_ToeplitzConnectivityInitialiser; }
 
@@ -594,6 +603,15 @@ private:
     //! Custom updates which reference this synapse group.
     /*! Because, if connectivity is sparse, all groups share connectivity this is required if connectivity changes. */
     std::vector<CustomUpdateWUInternal*> m_CustomUpdateReferences;
+
+    //! 'Resolved' variable references to presynaptic neuron varaibles used in weight update model
+    std::map<std::string, Models::VarReference> m_WUMPreNeuronVarReferences;
+
+    //! 'Resolved' variable references to presynaptic neurons varaibles used in weight update model
+    std::map<std::string, Models::VarReference> m_WUMPostNeuronVarReferences;
+    
+    //! 'Resolved' variable references to neurons varaibles used in postsynaptic update model
+    std::map<std::string, Models::VarReference> m_PSNeuronVarReferences;
     
 };
 }   // namespace GeNN

--- a/include/genn/genn/synapseGroupInternal.h
+++ b/include/genn/genn/synapseGroupInternal.h
@@ -348,4 +348,29 @@ private:
     //----------------------------------------------------------------------------
     const SynapseGroupInternal &m_SG;
 };
+
+//----------------------------------------------------------------------------
+// SynapseWUPSMVarRefAdapter
+//----------------------------------------------------------------------------
+class SynapseWUPSMVarRefAdapter
+{
+public:
+    SynapseWUPSMVarRefAdapter(const SynapseGroupInternal &sg) : m_SG(sg)
+    {}
+
+    using RefType = Models::VarReference;
+
+    //----------------------------------------------------------------------------
+    // Public methods
+    //----------------------------------------------------------------------------
+    auto getDefs() const{ return m_SG.getWUInitialiser().getSnippet()->getPSMVarRefs(); }
+
+    const auto &getInitialisers() const{ return m_SG.getWUMPSMVarReferences(); }
+
+private:
+    //----------------------------------------------------------------------------
+    // Members
+    //----------------------------------------------------------------------------
+    const SynapseGroupInternal &m_SG;
+};
 }   // namespace GeNN

--- a/include/genn/genn/synapseGroupInternal.h
+++ b/include/genn/genn/synapseGroupInternal.h
@@ -61,6 +61,7 @@ public:
     using SynapseGroup::isDendriticOutputDelayRequired;
     using SynapseGroup::isWUPostVarHeterogeneouslyDelayed;
     using SynapseGroup::areAnyWUPostVarHeterogeneouslyDelayed;
+    using SynapseGroup::isPSMVarHeterogeneouslyDelayed;
     using SynapseGroup::isPSMVarQueueRequired;
     using SynapseGroup::isPresynapticOutputRequired; 
     using SynapseGroup::isPostsynapticOutputRequired;
@@ -113,7 +114,11 @@ public:
 
     std::optional<unsigned int> getNumVarDelaySlots(const std::string &varName) const
     {
-        if(m_SG.getBackPropDelaySteps() != 0 || m_SG.isWUPostVarHeterogeneouslyDelayed(varName)) {
+        // PSM variables are only delayed if they are referenced in synapse code and either
+        // there is a homogeneous backpropation delay or they are referenced with a heterogeneous delay
+        if(m_SG.isPSMVarQueueRequired(varName) 
+           && (m_SG.getBackPropDelaySteps() != 0 || m_SG.isPSMVarHeterogeneouslyDelayed(varName))) 
+        {
             return m_SG.getTrgNeuronGroup()->getNumDelaySlots();
         }
         else {

--- a/include/genn/genn/synapseGroupInternal.h
+++ b/include/genn/genn/synapseGroupInternal.h
@@ -160,7 +160,7 @@ public:
     //----------------------------------------------------------------------------
     auto getDefs() const{ return m_SG.getPSInitialiser().getSnippet()->getNeuronVarRefs(); }
 
-    const auto &getInitialisers() const{ return m_SG.getPSInitialiser().getNeuronVarReferences(); }
+    const auto &getInitialisers() const{ return m_SG.getPSNeuronVarReferences(); }
 
 private:
     //----------------------------------------------------------------------------
@@ -315,7 +315,7 @@ public:
     //----------------------------------------------------------------------------
     auto getDefs() const{ return m_SG.getWUInitialiser().getSnippet()->getPreNeuronVarRefs(); }
 
-    const auto &getInitialisers() const{ return m_SG.getWUInitialiser().getPreNeuronVarReferences(); }
+    const auto &getInitialisers() const{ return m_SG.getWUMPreNeuronVarReferences(); }
 
 private:
     //----------------------------------------------------------------------------
@@ -340,7 +340,7 @@ public:
     //----------------------------------------------------------------------------
     auto getDefs() const{ return m_SG.getWUInitialiser().getSnippet()->getPostNeuronVarRefs(); }
 
-    const auto &getInitialisers() const{ return m_SG.getWUInitialiser().getPostNeuronVarReferences(); }
+    const auto &getInitialisers() const{ return m_SG.getWUMPostNeuronVarReferences(); }
 
 private:
     //----------------------------------------------------------------------------

--- a/include/genn/genn/synapseGroupInternal.h
+++ b/include/genn/genn/synapseGroupInternal.h
@@ -61,6 +61,7 @@ public:
     using SynapseGroup::isDendriticOutputDelayRequired;
     using SynapseGroup::isWUPostVarHeterogeneouslyDelayed;
     using SynapseGroup::areAnyWUPostVarHeterogeneouslyDelayed;
+    using SynapseGroup::isPSMVarQueueRequired;
     using SynapseGroup::isPresynapticOutputRequired; 
     using SynapseGroup::isPostsynapticOutputRequired;
     using SynapseGroup::isProceduralConnectivityRNGRequired;
@@ -110,7 +111,15 @@ public:
 
     const SynapseGroup &getTarget() const{ return m_SG.getFusedPSTarget(); }
 
-    std::optional<unsigned int> getNumVarDelaySlots(const std::string&) const{ return std::nullopt; }
+    std::optional<unsigned int> getNumVarDelaySlots(const std::string &varName) const
+    {
+        if(m_SG.getBackPropDelaySteps() != 0 || m_SG.isWUPostVarHeterogeneouslyDelayed(varName)) {
+            return m_SG.getTrgNeuronGroup()->getNumDelaySlots();
+        }
+        else {
+            return std::nullopt;
+        }
+    }
 
     VarAccessDim getVarDims(const Models::Base::Var &var) const{ return getVarAccessDim(var.access); }
 

--- a/include/genn/genn/weightUpdateModels.h
+++ b/include/genn/genn/weightUpdateModels.h
@@ -1,5 +1,8 @@
 #pragma once
 
+// Standard C++ includes
+#include <variant>
+
 // GeNN includes
 #include "models.h"
 
@@ -157,8 +160,8 @@ public:
          const std::map<std::string, InitVarSnippet::Init> &varInitialisers, 
          const std::map<std::string, InitVarSnippet::Init> &preVarInitialisers, 
          const std::map<std::string, InitVarSnippet::Init> &postVarInitialisers,
-         const std::map<std::string, Models::VarReference> &preNeuronVarReferences, 
-         const std::map<std::string, Models::VarReference> &postNeuronVarReferences);
+         const std::map<std::string, std::variant<std::string, Models::VarReference>> &preNeuronVarReferences, 
+         const std::map<std::string, std::variant<std::string, Models::VarReference>> &postNeuronVarReferences);
 
     //------------------------------------------------------------------------
     // Public API
@@ -206,8 +209,8 @@ private:
     std::map<std::string, InitVarSnippet::Init> m_VarInitialisers;
     std::map<std::string, InitVarSnippet::Init> m_PreVarInitialisers;
     std::map<std::string, InitVarSnippet::Init> m_PostVarInitialisers;
-    std::map<std::string, Models::VarReference> m_PreNeuronVarReferences;
-    std::map<std::string, Models::VarReference> m_PostNeuronVarReferences;
+    std::map<std::string, std::variant<std::string, Models::VarReference>> m_PreNeuronVarReferences;
+    std::map<std::string, std::variant<std::string, Models::VarReference>> m_PostNeuronVarReferences;
 };
 
 //----------------------------------------------------------------------------

--- a/include/genn/genn/weightUpdateModels.h
+++ b/include/genn/genn/weightUpdateModels.h
@@ -104,6 +104,9 @@ public:
     //! Gets names and types of variable references to postsynaptic neuron
     virtual VarRefVec getPostNeuronVarRefs() const{ return {}; }
 
+    //! Gets names and types of variable references to postsynaptic model
+    virtual VarRefVec getPSMVarRefs() const{ return {}; }
+
     //------------------------------------------------------------------------
     // Public methods
     //------------------------------------------------------------------------
@@ -146,7 +149,8 @@ public:
                   const std::map<std::string, InitVarSnippet::Init> &preVarValues,
                   const std::map<std::string, InitVarSnippet::Init> &postVarValues,
                   const std::map<std::string, std::variant<std::string, Models::VarReference>> &preVarRefTargets,
-                  const std::map<std::string, std::variant<std::string, Models::VarReference>> &postVarRefTargets) const;
+                  const std::map<std::string, std::variant<std::string, Models::VarReference>> &postVarRefTargets,
+                  const std::map<std::string, std::variant<std::string, Models::VarReference>> &psmVarRefTargets) const;
 };
 
 
@@ -161,7 +165,8 @@ public:
          const std::map<std::string, InitVarSnippet::Init> &preVarInitialisers, 
          const std::map<std::string, InitVarSnippet::Init> &postVarInitialisers,
          const std::map<std::string, std::variant<std::string, Models::VarReference>> &preNeuronVarReferences, 
-         const std::map<std::string, std::variant<std::string, Models::VarReference>> &postNeuronVarReferences);
+         const std::map<std::string, std::variant<std::string, Models::VarReference>> &postNeuronVarReferences,
+         const std::map<std::string, std::variant<std::string, Models::VarReference>> &psmVarReferences);
 
     //------------------------------------------------------------------------
     // Public API
@@ -173,6 +178,7 @@ public:
     const auto &getPostVarInitialisers() const{ return m_PostVarInitialisers; }
     const auto &getPreNeuronVarReferences() const{ return m_PreNeuronVarReferences;  }
     const auto &getPostNeuronVarReferences() const{ return m_PostNeuronVarReferences;  }
+    const auto &getPSMVarReferences() const{ return m_PSMVarReferences;  }
     
     const auto &getPreSpikeSynCodeTokens() const{ return m_PreSpikeSynCodeTokens; }
     const auto &getPreEventSynCodeTokens() const{ return m_PreEventSynCodeTokens; }
@@ -211,6 +217,7 @@ private:
     std::map<std::string, InitVarSnippet::Init> m_PostVarInitialisers;
     std::map<std::string, std::variant<std::string, Models::VarReference>> m_PreNeuronVarReferences;
     std::map<std::string, std::variant<std::string, Models::VarReference>> m_PostNeuronVarReferences;
+    std::map<std::string, std::variant<std::string, Models::VarReference>> m_PSMVarReferences;
 };
 
 //----------------------------------------------------------------------------

--- a/include/genn/genn/weightUpdateModels.h
+++ b/include/genn/genn/weightUpdateModels.h
@@ -27,6 +27,7 @@
 
 #define SET_PRE_NEURON_VAR_REFS(...) virtual VarRefVec getPreNeuronVarRefs() const override{ return __VA_ARGS__; }
 #define SET_POST_NEURON_VAR_REFS(...) virtual VarRefVec getPostNeuronVarRefs() const override{ return __VA_ARGS__; }
+#define SET_PSM_VAR_REFS(...) virtual VarRefVec getPSMVarRefs() const override{ return __VA_ARGS__; }
 
 //----------------------------------------------------------------------------
 // GeNN::WeightUpdateModels::Base

--- a/include/genn/genn/weightUpdateModels.h
+++ b/include/genn/genn/weightUpdateModels.h
@@ -145,8 +145,8 @@ public:
                   const std::map<std::string, InitVarSnippet::Init> &varValues,
                   const std::map<std::string, InitVarSnippet::Init> &preVarValues,
                   const std::map<std::string, InitVarSnippet::Init> &postVarValues,
-                  const std::map<std::string, Models::VarReference> &preVarRefTargets,
-                  const std::map<std::string, Models::VarReference> &postVarRefTargets) const;
+                  const std::map<std::string, std::variant<std::string, Models::VarReference>> &preVarRefTargets,
+                  const std::map<std::string, std::variant<std::string, Models::VarReference>> &postVarRefTargets) const;
 };
 
 

--- a/include/genn/genn/weightUpdateModels.h
+++ b/include/genn/genn/weightUpdateModels.h
@@ -194,7 +194,8 @@ public:
     const auto &getPostDynamicsCodeTokens() const{ return m_PostDynamicsCodeTokens; }
 
     bool isVarHeterogeneouslyDelayedInSynCode(const std::string &name) const;
-
+    bool isVarReferencedInSynCode(const std::string &name) const;
+    
     void finalise(double dt);
     
 private:

--- a/pygenn/genn_model.py
+++ b/pygenn/genn_model.py
@@ -56,6 +56,7 @@ ModelEGPType = Optional[Sequence[Tuple[str, TypeType]]]
 PopParamVals = Dict[str, Union[int, float]]
 PopVarVals = Dict[str, Union[VarInit, int, float, np.ndarray, Sequence]]
 PopVarRefs = Dict[str, VarReference] 
+PopLocalVarRefs = Dict[str, Union[VarReference, str]] 
 PopWUVarRefs = Dict[str, WUVarReference]
 PopEGPRefs = Dict[str, EGPReference]
 
@@ -875,7 +876,7 @@ def init_sparse_connectivity(snippet: Union[InitSparseConnectivitySnippetBase, s
 
 def init_postsynaptic(snippet: Union[PostsynapticModelBase, str], 
                       params: PopParamVals = {}, vars: PopVarVals = {}, 
-                      var_refs: PopVarVals = {}):
+                      PopLocalVarRefs: PopVarVals = {}):
     """Initialises a postsynaptic model with parameter values, 
     variable initialisers and variable references
 
@@ -915,7 +916,8 @@ def init_postsynaptic(snippet: Union[PostsynapticModelBase, str],
 
 def init_weight_update(snippet, params: PopParamVals = {}, vars: PopVarVals = {},
                        pre_vars: PopVarVals = {}, post_vars: PopVarVals = {}, 
-                       pre_var_refs: PopVarRefs = {}, post_var_refs: PopVarRefs = {}):
+                       pre_var_refs: PopLocalVarRefs = {}, 
+                       post_var_refs: PopLocalVarRefs = {}):
     """Initialises a weight update model with parameter values, 
     variable initialisers and variable references.
 

--- a/pygenn/genn_model.py
+++ b/pygenn/genn_model.py
@@ -460,7 +460,7 @@ class GeNNModel(ModelSpec):
 
     def add_current_source(self, cs_name: str, current_source_model: Union[CurrentSourceModelBase, str], 
                            pop: NeuronGroup, params: PopParamVals = {}, vars: PopVarVals = {}, 
-                           var_refs: PopVarRefs = {}) -> CurrentSource:
+                           var_refs: PopLocalVarRefs = {}) -> CurrentSource:
         """Add a current source to the GeNN model
 
         Args:
@@ -473,7 +473,7 @@ class GeNNModel(ModelSpec):
             vars:                   initial variable values or initialisers 
                                     for the current source model (see :ref:`section-variables`)
             var_refs:               variables references to neuron variables in ``pop``,
-                                    typically created using :func:`.create_var_ref`
+                                    either specified by name or created using :func:`.create_var_ref`
                                     (see :ref:`section-variables-references`)
 
         For example, a current source to inject a Gaussian noise current can be added to a model as follows:
@@ -876,7 +876,7 @@ def init_sparse_connectivity(snippet: Union[InitSparseConnectivitySnippetBase, s
 
 def init_postsynaptic(snippet: Union[PostsynapticModelBase, str], 
                       params: PopParamVals = {}, vars: PopVarVals = {}, 
-                      PopLocalVarRefs: PopVarVals = {}):
+                      var_refs: PopLocalVarRefs = {}):
     """Initialises a postsynaptic model with parameter values, 
     variable initialisers and variable references
 
@@ -889,7 +889,7 @@ def init_postsynaptic(snippet: Union[PostsynapticModelBase, str],
         vars:           initial synaptic variable values or initialisers 
                         for the postsynaptic model (see :ref:`section-variables`)
         var_refs:       references to postsynaptic neuron variables,
-                        typically created using :func:`.create_var_ref`
+                        either specified by name or created using :func:`.create_var_ref`
                         (see :ref:`section-variables-references`)
 
     For example, the built-in conductance model with exponential 
@@ -934,10 +934,10 @@ def init_weight_update(snippet, params: PopParamVals = {}, vars: PopVarVals = {}
         post_vars:      initial postsynaptic variable values or initialisers
                         (see :ref:`section-variables`)
         pre_var_refs:   references to presynaptic neuron variables,
-                        typically created using :func:`.create_var_ref`
+                        either specified by name or created using :func:`.create_var_ref`
                         (see :ref:`section-variables-references`)
         post_var_refs:  references to postsynaptic neuron variables,
-                        typically created using :func:`.create_var_ref`
+                        either specified by name or created using :func:`.create_var_ref`
                         (see :ref:`section-variables-references`)
 
     For example, the built-in static pulse model with 

--- a/pygenn/genn_model.py
+++ b/pygenn/genn_model.py
@@ -917,7 +917,8 @@ def init_postsynaptic(snippet: Union[PostsynapticModelBase, str],
 def init_weight_update(snippet, params: PopParamVals = {}, vars: PopVarVals = {},
                        pre_vars: PopVarVals = {}, post_vars: PopVarVals = {}, 
                        pre_var_refs: PopLocalVarRefs = {}, 
-                       post_var_refs: PopLocalVarRefs = {}):
+                       post_var_refs: PopLocalVarRefs = {},
+                       psm_var_refs: PopLocalVarRefs = {}):
     """Initialises a weight update model with parameter values, 
     variable initialisers and variable references.
 
@@ -939,6 +940,8 @@ def init_weight_update(snippet, params: PopParamVals = {}, vars: PopVarVals = {}
         post_var_refs:  references to postsynaptic neuron variables,
                         either specified by name or created using :func:`.create_var_ref`
                         (see :ref:`section-variables-references`)
+        psm_var_refs:   references to postsynaptic model variables,
+                        specified by name (see :ref:`section-variables-references`)
 
     For example, the built-in static pulse model with 
     constant weights could be initialised as follows:
@@ -957,7 +960,7 @@ def init_weight_update(snippet, params: PopParamVals = {}, vars: PopVarVals = {}
     
     return (WeightUpdateInit(snippet, _prepare_param_vals(params), var_init, 
                              pre_var_init, post_var_init,
-                             pre_var_refs, post_var_refs),
+                             pre_var_refs, post_var_refs, psm_var_refs),
             vars, pre_vars, post_vars)
 
 @deprecated("The name of this function was ambiguous, use init_sparse_connectivity instead")
@@ -1265,6 +1268,7 @@ def create_weight_update_model(
         post_vars: ModelVarsType = None, post_var_name_types=None,
         pre_neuron_var_refs: ModelVarRefsType = None,
         post_neuron_var_refs: ModelVarRefsType = None,
+        psm_var_refs: ModelVarRefsType = None,
         derived_params: ModelDerivedParamsType = None, sim_code=None,
         pre_spike_syn_code: Optional[str] = None, event_code=None,
         pre_event_syn_code: Optional[str] = None,
@@ -1338,6 +1342,9 @@ def create_weight_update_model(
         post_neuron_var_refs:                   names, types and optional variable access
                                                 of references to be assigned to postsynaptic
                                                 neuron variables
+        psm_var_refs:                           names, types and optional variable access
+                                                of references to be assigned to postsynaptic
+                                                model variables
         derived_params:                         names, types and callables to calculate
                                                 derived parameter values from params
         pre_spike_syn_code:                     string with the presynaptic spike code
@@ -1584,6 +1591,10 @@ def create_weight_update_model(
     if post_neuron_var_refs is not None:
         body["get_post_neuron_var_refs"] =\
             lambda self: [VarRef(*v) for v in post_neuron_var_refs]
+
+    if psm_var_refs is not None:
+        body["get_psm_var_refs"] =\
+            lambda self: [VarRef(*v) for v in psm_var_refs]
     
     return _create_model(class_name, WeightUpdateModelBase, params,
                          param_names, derived_params,

--- a/pygenn/src/docStrings.h
+++ b/pygenn/src/docStrings.h
@@ -2575,6 +2575,8 @@ static const char *__doc_Models_VarReference_getVarType = R"doc()doc";
 
 static const char *__doc_Models_VarReference_isTargetNeuronGroup = R"doc(Does this variable reference's target belong to neuron group)doc";
 
+static const char *__doc_Models_VarReference_isTargetSynapseGroupPSM = R"doc(Does this variable reference's target belong to synapse group postsynaptic model)doc";
+
 static const char *__doc_Models_VarReference_m_Detail = R"doc()doc";
 
 static const char *__doc_Models_VarReference_operator_lt = R"doc()doc";
@@ -2644,6 +2646,8 @@ static const char *__doc_Models_checkEGPReferenceTypes = R"doc()doc";
 static const char *__doc_Models_checkLocalVarReferences = R"doc(Helper function to check if local variable references are configured correctly)doc";
 
 static const char *__doc_Models_checkVarReferenceTypes = R"doc(Helper function to check if variable reference types match those specified in model)doc";
+
+static const char *__doc_Models_resolveVarReferences = R"doc(Helper function to 'resolve' local variable references which may be specified with just a string)doc";
 
 static const char *__doc_Models_updateHash = R"doc()doc";
 
@@ -3618,6 +3622,8 @@ NOTE: this can only be called after model is finalized)doc";
 
 static const char *__doc_SynapseGroup_getPSInitialiser = R"doc()doc";
 
+static const char *__doc_SynapseGroup_getPSNeuronVarReferences = R"doc(Get 'resolved' variable references to neurons variables used in postsynaptic update model)doc";
+
 static const char *__doc_SynapseGroup_getPSVarLocation = R"doc(Get location of postsynaptic model state variable)doc";
 
 static const char *__doc_SynapseGroup_getParallelismHint = R"doc()doc";
@@ -3671,6 +3677,12 @@ R"doc(Generate hash of initialisation component of this synapse group
 NOTE: this can only be called after model is finalized)doc";
 
 static const char *__doc_SynapseGroup_getWUInitialiser = R"doc()doc";
+
+static const char *__doc_SynapseGroup_getWUMPSMVarReferences = R"doc(Get 'resolved' variable references to presynaptic model variables used in weight update model)doc";
+
+static const char *__doc_SynapseGroup_getWUMPostNeuronVarReferences = R"doc(Get 'resolved' variable references to presynaptic neurons variables used in weight update model)doc";
+
+static const char *__doc_SynapseGroup_getWUMPreNeuronVarReferences = R"doc(Get 'resolved' variable references to presynaptic neuron variables used in weight update model)doc";
 
 static const char *__doc_SynapseGroup_getWUPostVarLocation = R"doc(Get location of weight update model postsynaptic state variable)doc";
 
@@ -3858,6 +3870,8 @@ This is ignored for simulations on hardware with a single memory space)doc";
 
 static const char *__doc_SynapseGroup_m_PSInitialiser = R"doc(Initialiser used for creating postsynaptic update model)doc";
 
+static const char *__doc_SynapseGroup_m_PSNeuronVarReferences = R"doc('Resolved' variable references to neurons variables used in postsynaptic update model)doc";
+
 static const char *__doc_SynapseGroup_m_PSVarLocation =
 R"doc(Location of postsynaptic model variables.
 This is ignored for simulations on hardware with a single memory space)doc";
@@ -3891,6 +3905,12 @@ R"doc(Location of weight update model extra global parameters.
 This is ignored for simulations on hardware with a single memory space)doc";
 
 static const char *__doc_SynapseGroup_m_WUInitialiser = R"doc(Initialiser used for creating weight update model)doc";
+
+static const char *__doc_SynapseGroup_m_WUMPSMVarReferences = R"doc('Resolved' variable references to postsynaptic model variables used in weight update model)doc";
+
+static const char *__doc_SynapseGroup_m_WUMPostNeuronVarReferences = R"doc('Resolved' variable references to presynaptic neurons variables used in weight update model)doc";
+
+static const char *__doc_SynapseGroup_m_WUMPreNeuronVarReferences = R"doc('Resolved' variable references to presynaptic neuron variables used in weight update model)doc";
 
 static const char *__doc_SynapseGroup_m_WUPostVarLocation =
 R"doc(Location of individual postsynaptic state variables.
@@ -4071,6 +4091,16 @@ static const char *__doc_SynapseWUEGPAdapter_getDefs = R"doc()doc";
 static const char *__doc_SynapseWUEGPAdapter_getLoc = R"doc()doc";
 
 static const char *__doc_SynapseWUEGPAdapter_m_SG = R"doc()doc";
+
+static const char *__doc_SynapseWUPSMVarRefAdapter = R"doc()doc";
+
+static const char *__doc_SynapseWUPSMVarRefAdapter_SynapseWUPSMVarRefAdapter = R"doc()doc";
+
+static const char *__doc_SynapseWUPSMVarRefAdapter_getDefs = R"doc()doc";
+
+static const char *__doc_SynapseWUPSMVarRefAdapter_getInitialisers = R"doc()doc";
+
+static const char *__doc_SynapseWUPSMVarRefAdapter_m_SG = R"doc()doc";
 
 static const char *__doc_SynapseWUPostNeuronVarRefAdapter = R"doc()doc";
 
@@ -4503,6 +4533,8 @@ static const char *__doc_WeightUpdateModels_Base = R"doc(Base class for all weig
 
 static const char *__doc_WeightUpdateModels_Base_getHashDigest = R"doc(Update hash from model)doc";
 
+static const char *__doc_WeightUpdateModels_Base_getPSMVarRefs = R"doc(Gets names and types of variable references to postsynaptic model)doc";
+
 static const char *__doc_WeightUpdateModels_Base_getPostDynamicsCode =
 R"doc(Gets code to be run after postsynaptic neuron update
 This is typically for the code to update postsynaptic variables. Presynaptic
@@ -4582,6 +4614,8 @@ static const char *__doc_WeightUpdateModels_Init_Init = R"doc()doc";
 
 static const char *__doc_WeightUpdateModels_Init_finalise = R"doc()doc";
 
+static const char *__doc_WeightUpdateModels_Init_getPSMVarReferences = R"doc()doc";
+
 static const char *__doc_WeightUpdateModels_Init_getPostDynamicsCodeTokens = R"doc()doc";
 
 static const char *__doc_WeightUpdateModels_Init_getPostEventSynCodeTokens = R"doc()doc";
@@ -4617,6 +4651,8 @@ static const char *__doc_WeightUpdateModels_Init_getVarInitialisers = R"doc()doc
 static const char *__doc_WeightUpdateModels_Init_isRNGRequired = R"doc()doc";
 
 static const char *__doc_WeightUpdateModels_Init_isVarHeterogeneouslyDelayedInSynCode = R"doc()doc";
+
+static const char *__doc_WeightUpdateModels_Init_m_PSMVarReferences = R"doc()doc";
 
 static const char *__doc_WeightUpdateModels_Init_m_PostDynamicsCodeTokens = R"doc()doc";
 
@@ -4949,6 +4985,11 @@ $Parameter ``preNeuronVarRefs``:
 $Parameter ``postNeuronVarRefs``:
 
     postsynaptic neuron variable references for snippet wrapped in VarReferences object.
+
+
+$Parameter ``psmVarRefs``:
+
+           postsynaptic modelvariable references for snippet wrapped in VarReferences object.
 
 
 $Returns:

--- a/pygenn/src/genn.cc
+++ b/pygenn/src/genn.cc
@@ -220,6 +220,7 @@ public:
     
     virtual std::vector<Models::Base::VarRef> getPreNeuronVarRefs() const override { PYBIND11_OVERRIDE_NAME(std::vector<Models::Base::VarRef> , Base, "get_pre_neuron_var_refs", getPreNeuronVarRefs); }
     virtual std::vector<Models::Base::VarRef> getPostNeuronVarRefs() const override { PYBIND11_OVERRIDE_NAME(std::vector<Models::Base::VarRef> , Base, "get_post_neuron_var_refs", getPostNeuronVarRefs); }
+    virtual std::vector<Models::Base::VarRef> getPSMVarRefs() const override { PYBIND11_OVERRIDE_NAME(std::vector<Models::Base::VarRef> , Base, "get_psm_var_refs", getPSMVarRefs); }
 };
 
 const CodeGenerator::ModelSpecMerged *generateCode(ModelSpecInternal &model, CodeGenerator::BackendBase &backend, 
@@ -932,7 +933,8 @@ PYBIND11_MODULE(_genn, m)
         WRAP_NS_METHOD("get_pre_vars", WeightUpdateModels, Base, getPreVars)
         WRAP_NS_METHOD("get_post_vars", WeightUpdateModels, Base, getPostVars)
         WRAP_NS_METHOD("get_pre_neuron_var_refs", WeightUpdateModels, Base, getPreNeuronVarRefs)
-        WRAP_NS_METHOD("get_post_neuron_var_refs", WeightUpdateModels, Base, getPostNeuronVarRefs);
+        WRAP_NS_METHOD("get_post_neuron_var_refs", WeightUpdateModels, Base, getPostNeuronVarRefs)
+        WRAP_NS_METHOD("get_psm_var_refs", WeightUpdateModels, Base, getPSMVarRefs);
 
     //------------------------------------------------------------------------
     // genn.SparseConnectivityInit
@@ -960,7 +962,7 @@ PYBIND11_MODULE(_genn, m)
     // genn.WeightUpdateInit
     //------------------------------------------------------------------------
     pybind11::class_<WeightUpdateModels::Init>(m, "WeightUpdateInit")
-        .def(pybind11::init<const WeightUpdateModels::Base*, const ParamValues&, const VarValues&, const VarValues&, const VarValues&, const LocalVarReferences&, const LocalVarReferences&>())
+        .def(pybind11::init<const WeightUpdateModels::Base*, const ParamValues&, const VarValues&, const VarValues&, const VarValues&, const LocalVarReferences&, const LocalVarReferences&, const LocalVarReferences&>())
         .def_property_readonly("snippet", &WeightUpdateModels::Init::getSnippet, pybind11::return_value_policy::reference);
     
     //------------------------------------------------------------------------

--- a/pygenn/src/genn.cc
+++ b/pygenn/src/genn.cc
@@ -452,7 +452,7 @@ PYBIND11_MODULE(_genn, m)
         .def("_add_current_source",  
              static_cast<CurrentSource* (ModelSpec::*)(
                 const std::string&, const CurrentSourceModels::Base*, NeuronGroup*, 
-                const ParamValues&, const VarValues&, const VarReferences&)>(&ModelSpec::addCurrentSource),
+                const ParamValues&, const VarValues&, const LocalVarReferences&)>(&ModelSpec::addCurrentSource),
             pybind11::return_value_policy::reference)
         .def("_add_custom_connectivity_update",  
              static_cast<CustomConnectivityUpdate* (ModelSpec::*)(

--- a/pygenn/src/genn.cc
+++ b/pygenn/src/genn.cc
@@ -960,14 +960,14 @@ PYBIND11_MODULE(_genn, m)
     // genn.WeightUpdateInit
     //------------------------------------------------------------------------
     pybind11::class_<WeightUpdateModels::Init>(m, "WeightUpdateInit")
-        .def(pybind11::init<const WeightUpdateModels::Base*, const ParamValues&, const VarValues&, const VarValues&, const VarValues&, const VarReferences&, const VarReferences&>())
+        .def(pybind11::init<const WeightUpdateModels::Base*, const ParamValues&, const VarValues&, const VarValues&, const VarValues&, const LocalVarReferences&, const LocalVarReferences&>())
         .def_property_readonly("snippet", &WeightUpdateModels::Init::getSnippet, pybind11::return_value_policy::reference);
     
     //------------------------------------------------------------------------
     // genn.PostsynapticInit
     //------------------------------------------------------------------------
     pybind11::class_<PostsynapticModels::Init>(m, "PostsynapticInit")
-        .def(pybind11::init<const PostsynapticModels::Base*, const ParamValues&, const VarValues&, const VarReferences&>())
+        .def(pybind11::init<const PostsynapticModels::Base*, const ParamValues&, const VarValues&, const LocalVarReferences&>())
         .def_property_readonly("snippet", &PostsynapticModels::Init::getSnippet, pybind11::return_value_policy::reference);
     
     //------------------------------------------------------------------------

--- a/pygenn/src/genn.cc
+++ b/pygenn/src/genn.cc
@@ -677,7 +677,9 @@ PYBIND11_MODULE(_genn, m)
         WRAP_METHOD("set_ps_var_location", SynapseGroup, setPSVarLocation)
         
         // **NOTE** we use the 'publicist' pattern to expose some protected methods
-        .def("_is_wu_post_var_heterogeneously_delayed", &SynapseGroupInternal::isWUPostVarHeterogeneouslyDelayed);
+        .def("_is_wu_post_var_heterogeneously_delayed", &SynapseGroupInternal::isWUPostVarHeterogeneouslyDelayed)
+        .def("_is_psm_var_heterogeneously_delayed", &SynapseGroupInternal::isPSMVarHeterogeneouslyDelayed)
+        .def("_is_psm_var_queue_required", &SynapseGroupInternal::isPSMVarQueueRequired);
         
     //------------------------------------------------------------------------
     // genn.NumericValue

--- a/src/genn/genn/code_generator/neuronUpdateGroupMerged.cc
+++ b/src/genn/genn/code_generator/neuronUpdateGroupMerged.cc
@@ -119,9 +119,13 @@ void NeuronUpdateGroupMerged::InSynPSM::generate(const BackendBase &backend, Env
     // Create an environment which caches variables in local variables if they are accessed
     EnvironmentLocalVarCache<SynapsePSMVarAdapter, InSynPSM, NeuronUpdateGroupMerged> varEnv(
         *this, ng, getTypeContext(), psmEnv, fieldSuffix, "l", false,
-        [batchSize, &ng](const std::string&, VarAccess d, bool)
+        [batchSize, &ng](const std::string&, VarAccess d, bool delayed)
         {
-            return ng.getVarIndex(batchSize, getVarAccessDim(d), "$(id)");
+            return ng.getReadVarIndex(delayed, batchSize, getVarAccessDim(d), "$(id)");
+        },
+        [batchSize, &ng](const std::string&, VarAccess d, bool delayed)
+        {
+            return ng.getWriteVarIndex(delayed, batchSize, getVarAccessDim(d), "$(id)");
         });
 
     // Pretty print code back to environment

--- a/src/genn/genn/code_generator/synapseUpdateGroupMerged.cc
+++ b/src/genn/genn/code_generator/synapseUpdateGroupMerged.cc
@@ -40,13 +40,13 @@ void applySynapseSubstitutions(const BackendBase &backend, EnvironmentExternalBa
     for(const auto &v : sg.getArchetype().getWUInitialiser().getSnippet()->getPostNeuronVarRefs()) {
         // If variable refernce is accessed with delay in synapse code tokens
         const auto resolvedType = v.type.resolve(sg.getTypeContext());
-        const Models::VarReference &archetypeVarRef = sg.getArchetype().getWUInitialiser().getPostNeuronVarReferences().at(v.name);
+        const Models::VarReference &archetypeVarRef = sg.getArchetype().getWUMPostNeuronVarReferences().at(v.name);
         if(Utils::isIdentifierDelayed(v.name, tokens)) {
             synEnv.addField(Type::getArraySubscript(resolvedType.addConst()), v.name,
                             resolvedType.createPointer(), v.name,
                             [v](auto &runtime, const auto &g, size_t) 
                             { 
-                                return g.getWUInitialiser().getPostNeuronVarReferences().at(v.name).getTargetArray(runtime); 
+                                return g.getWUMPostNeuronVarReferences().at(v.name).getTargetArray(runtime); 
                             },
                             sg.getPostVarHetDelayIndex(batchSize, archetypeVarRef.getVarDims(), "$(id_post)"));
         }
@@ -55,7 +55,7 @@ void applySynapseSubstitutions(const BackendBase &backend, EnvironmentExternalBa
                             resolvedType.createPointer(), v.name,
                             [v](auto &runtime, const auto &g, size_t) 
                             { 
-                                return g.getWUInitialiser().getPostNeuronVarReferences().at(v.name).getTargetArray(runtime); 
+                                return g.getWUMPostNeuronVarReferences().at(v.name).getTargetArray(runtime); 
                             },
                             sg.getPostVarIndex(archetypeVarRef.getDelayNeuronGroup() != nullptr, batchSize,
                                                archetypeVarRef.getVarDims(), "$(id_post)"));

--- a/src/genn/genn/code_generator/synapseUpdateGroupMerged.cc
+++ b/src/genn/genn/code_generator/synapseUpdateGroupMerged.cc
@@ -62,6 +62,16 @@ void applySynapseSubstitutions(const BackendBase &backend, EnvironmentExternalBa
         }
     }
 
+    // Add referenced postsynaptic model variables
+    // **TODO** delay
+    synEnv.template addVarRefs<SynapseWUPSMVarRefAdapter>(
+        [&sg, batchSize](VarAccessMode, const Models::VarReference &v)
+        {
+            return sg.getPostVarIndex(false, batchSize, 
+                                      v.getVarDims(), "$(id_post)");
+        }, 
+        "", true);
+
     // Substitute names of preynaptic weight update variables
     synEnv.template addVars<SynapseWUPreVarAdapter>(
         [&sg, batchSize](VarAccess a, const std::string&) 

--- a/src/genn/genn/code_generator/synapseUpdateGroupMerged.cc
+++ b/src/genn/genn/code_generator/synapseUpdateGroupMerged.cc
@@ -14,6 +14,38 @@ using namespace GeNN::CodeGenerator;
 //--------------------------------------------------------------------------
 namespace
 {
+template<typename A, typename G>
+void addHeterogeneousDelayPostVarRefs(EnvironmentGroupMergedField<G> &env, const std::vector<Transpiler::Token> &tokens,
+                                      G &sg, unsigned int batchSize)
+{
+    // Loop through variable references
+    const A archetypeAdaptor(sg.getArchetype());
+    for(const auto &v : archetypeAdaptor.getDefs()) {
+        // If variable refernce is accessed with delay in synapse code tokens
+        const auto resolvedType = v.type.resolve(sg.getTypeContext());
+        const Models::VarReference &archetypeVarRef = archetypeAdaptor.getInitialisers().at(v.name);
+        if(Utils::isIdentifierDelayed(v.name, tokens)) {
+            env.addField(Type::getArraySubscript(resolvedType.addConst()), v.name,
+                         resolvedType.createPointer(), v.name,
+                         [v](auto &runtime, const auto &g, size_t) 
+                         { 
+                             return A(g).getInitialisers().at(v.name).getTargetArray(runtime); 
+                         },
+                         sg.getPostVarHetDelayIndex(batchSize, archetypeVarRef.getVarDims(), "$(id_post)"));
+        }
+        else {
+            env.addField(resolvedType.addConst(), v.name,
+                         resolvedType.createPointer(), v.name,
+                         [v](auto &runtime, const auto &g, size_t) 
+                         { 
+                             return A(g).getInitialisers().at(v.name).getTargetArray(runtime); 
+                         },
+                         sg.getPostVarIndex(archetypeVarRef.getDelayNeuronGroup() != nullptr, batchSize,
+                                            archetypeVarRef.getVarDims(), "$(id_post)"));
+        }
+    }
+}
+//--------------------------------------------------------------------------
 template<typename G>
 void applySynapseSubstitutions(const BackendBase &backend, EnvironmentExternalBase &env, const std::vector<Transpiler::Token> &tokens, const std::string &errorContext,
                                G &sg, unsigned int batchSize, double dt)
@@ -36,41 +68,9 @@ void applySynapseSubstitutions(const BackendBase &backend, EnvironmentExternalBa
         }, 
         "", true);
 
-    // Loop through referenced postsynaptic neuron variables
-    for(const auto &v : sg.getArchetype().getWUInitialiser().getSnippet()->getPostNeuronVarRefs()) {
-        // If variable refernce is accessed with delay in synapse code tokens
-        const auto resolvedType = v.type.resolve(sg.getTypeContext());
-        const Models::VarReference &archetypeVarRef = sg.getArchetype().getWUMPostNeuronVarReferences().at(v.name);
-        if(Utils::isIdentifierDelayed(v.name, tokens)) {
-            synEnv.addField(Type::getArraySubscript(resolvedType.addConst()), v.name,
-                            resolvedType.createPointer(), v.name,
-                            [v](auto &runtime, const auto &g, size_t) 
-                            { 
-                                return g.getWUMPostNeuronVarReferences().at(v.name).getTargetArray(runtime); 
-                            },
-                            sg.getPostVarHetDelayIndex(batchSize, archetypeVarRef.getVarDims(), "$(id_post)"));
-        }
-        else {
-            synEnv.addField(resolvedType.addConst(), v.name,
-                            resolvedType.createPointer(), v.name,
-                            [v](auto &runtime, const auto &g, size_t) 
-                            { 
-                                return g.getWUMPostNeuronVarReferences().at(v.name).getTargetArray(runtime); 
-                            },
-                            sg.getPostVarIndex(archetypeVarRef.getDelayNeuronGroup() != nullptr, batchSize,
-                                               archetypeVarRef.getVarDims(), "$(id_post)"));
-        }
-    }
-
-    // Add referenced postsynaptic model variables
-    // **TODO** delay
-    synEnv.template addVarRefs<SynapseWUPSMVarRefAdapter>(
-        [&sg, batchSize](VarAccessMode, const Models::VarReference &v)
-        {
-            return sg.getPostVarIndex(false, batchSize, 
-                                      v.getVarDims(), "$(id_post)");
-        }, 
-        "", true);
+    // Add, potentially heterogeneously-delayed, references to postsynaptic model and neuron variables
+    addHeterogeneousDelayPostVarRefs<SynapseWUPostNeuronVarRefAdapter>(synEnv, tokens, sg, batchSize);
+    addHeterogeneousDelayPostVarRefs<SynapseWUPSMVarRefAdapter>(synEnv, tokens, sg, batchSize);
 
     // Substitute names of preynaptic weight update variables
     synEnv.template addVars<SynapseWUPreVarAdapter>(

--- a/src/genn/genn/currentSource.cc
+++ b/src/genn/genn/currentSource.cc
@@ -74,7 +74,8 @@ CurrentSource::CurrentSource(const std::string &name, const CurrentSourceModels:
 
     // Check additional local variable reference constraints
     Models::checkLocalVarReferences(getNeuronVarReferences(), getModel()->getNeuronVarRefs(),
-                                    getTrgNeuronGroup(), "Variable references to in current source can only point to target neuron group.");
+                                    getTrgNeuronGroup(), "Variable references to in current source can only point to target neuron group.",
+                                    &Models::VarReference::isTargetNeuronGroup);
     
     // Scan current source model code string
     m_InjectionCodeTokens = Utils::scanCode(getModel()->getInjectionCode(), 

--- a/src/genn/genn/currentSource.cc
+++ b/src/genn/genn/currentSource.cc
@@ -54,12 +54,17 @@ void CurrentSource::setTargetVar(const std::string &varName)
 //----------------------------------------------------------------------------
 CurrentSource::CurrentSource(const std::string &name, const CurrentSourceModels::Base *model,
                              const std::map<std::string, Type::NumericValue> &params, const std::map<std::string, InitVarSnippet::Init> &varInitialisers,
-                             const std::map<std::string, Models::VarReference> &neuronVarReferences, const NeuronGroupInternal *trgNeuronGroup, 
-                             VarLocation defaultVarLocation, VarLocation defaultExtraGlobalParamLocation)
+                             const std::map<std::string, std::variant<std::string, Models::VarReference>> &neuronVarReferences, 
+                             NeuronGroupInternal *trgNeuronGroup, VarLocation defaultVarLocation, VarLocation defaultExtraGlobalParamLocation)
 :   m_Name(name), m_Model(model), m_Params(params), m_VarInitialisers(varInitialisers),
-    m_NeuronVarReferences(neuronVarReferences), m_TrgNeuronGroup(trgNeuronGroup), m_VarLocation(defaultVarLocation), 
+    m_TrgNeuronGroup(trgNeuronGroup), m_VarLocation(defaultVarLocation), 
     m_ExtraGlobalParamLocation(defaultExtraGlobalParamLocation), m_TargetVar("Isyn")
 {
+    // 'Resolve' local variable references
+    Models::resolveVarReferences(neuronVarReferences,
+                                 m_NeuronVarReferences, trgNeuronGroup,
+                                 static_cast<Models::VarReference(*)(NeuronGroup*, const std::string&)>(&Models::VarReference::createVarRef));
+
     // Validate names
     Utils::validatePopName(name, "Current source");
     getModel()->validate(getParams(), getVarInitialisers(), getNeuronVarReferences(), "Current source " + getName());

--- a/src/genn/genn/modelSpec.cc
+++ b/src/genn/genn/modelSpec.cc
@@ -239,7 +239,7 @@ CurrentSource *ModelSpec::findCurrentSource(const std::string &name)
 }
 // ---------------------------------------------------------------------------
 CurrentSource *ModelSpec::addCurrentSource(const std::string &currentSourceName, const CurrentSourceModels::Base *model, NeuronGroup *neuronGroup, 
-                                           const ParamValues &paramValues, const VarValues &varInitialisers, const VarReferences &neuronVarReferences)
+                                           const ParamValues &paramValues, const VarValues &varInitialisers, const LocalVarReferences &neuronVarReferences)
 {
     // Add current source to map
     auto *neuronGroupInternal = static_cast<NeuronGroupInternal*>(neuronGroup);

--- a/src/genn/genn/models.cc
+++ b/src/genn/genn/models.cc
@@ -133,6 +133,13 @@ bool VarReference::isTargetSynapseGroupPSM(const SynapseGroupInternal *sg) const
             [](const auto&) { return false; }},
         m_Detail);
 }
+/*// PSM variables are only delayed if they are referenced in synapse code and either
+        // there is a homogeneous backpropation delay or they are referenced with a heterogeneous delay
+        if(m_SG.isPSMVarQueueRequired(varName) 
+           && (m_SG.getBackPropDelaySteps() != 0 || m_SG.isPSMVarHeterogeneouslyDelayed(varName))) 
+        {
+            return m_SG.getTrgNeuronGroup()->getNumDelaySlots();
+        }*/
 //----------------------------------------------------------------------------
 NeuronGroup *VarReference::getDelayNeuronGroup() const
 { 
@@ -148,6 +155,11 @@ NeuronGroup *VarReference::getDelayNeuronGroup() const
             [](const WUPostRef &ref)->NeuronGroup* {
                 return (ref.group->getBackPropDelaySteps() > 0 
                         || ref.group->getWUInitialiser().isVarHeterogeneouslyDelayedInSynCode(ref.var.name)) ? ref.group->getTrgNeuronGroup() : nullptr;
+            },
+            [](const PSMRef &ref)->NeuronGroup* {
+                return (ref.group->isPSMVarQueueRequired(ref.var.name)
+                        && (ref.group->getBackPropDelaySteps() > 0 
+                            || ref.group->isPSMVarHeterogeneouslyDelayed(ref.var.name))) ? ref.group->getTrgNeuronGroup() : nullptr;
             },
             [](const InternalNGRef &ref)->NeuronGroup* {
                 return ref.group->isSpikeQueueRequired() ? ref.group : nullptr;

--- a/src/genn/genn/neuronGroup.cc
+++ b/src/genn/genn/neuronGroup.cc
@@ -557,11 +557,6 @@ std::vector<SynapseGroupInternal*> NeuronGroup::getFusedOutSynWithPreVars() cons
     return vec;
 }
 //----------------------------------------------------------------------------
-bool NeuronGroup::isVarQueueRequired(const std::string &var) const
-{
-    return (m_VarQueueRequired.count(var) == 0) ? false : true;
-}
-//----------------------------------------------------------------------------
 boost::uuids::detail::sha1::digest_type NeuronGroup::getHashDigest() const
 {
     boost::uuids::detail::sha1 hash;

--- a/src/genn/genn/postsynapticModels.cc
+++ b/src/genn/genn/postsynapticModels.cc
@@ -49,14 +49,11 @@ void Base::validate(const std::map<std::string, Type::NumericValue> &paramValues
 //----------------------------------------------------------------------------
 Init::Init(const Base *snippet, const std::map<std::string, Type::NumericValue> &params, 
            const std::map<std::string, InitVarSnippet::Init> &varInitialisers, 
-           const std::map<std::string, Models::VarReference> &neuronVarReferences)
+           const std::map<std::string, std::variant<std::string, Models::VarReference>> &neuronVarReferences)
 :   Snippet::Init<Base>(snippet, params), m_VarInitialisers(varInitialisers), m_NeuronVarReferences(neuronVarReferences)
 {
     // Validate
     getSnippet()->validate(getParams(), getVarInitialisers(), getNeuronVarReferences());
-
-    // Check variable reference types
-    Models::checkVarReferenceTypes(getNeuronVarReferences(), getSnippet()->getNeuronVarRefs());
 
     // Scan code tokens
     m_SimCodeTokens = Utils::scanCode(getSnippet()->getSimCode(), "Postsynaptic model sim code");

--- a/src/genn/genn/postsynapticModels.cc
+++ b/src/genn/genn/postsynapticModels.cc
@@ -28,7 +28,7 @@ boost::uuids::detail::sha1::digest_type Base::getHashDigest() const
 //----------------------------------------------------------------------------
 void Base::validate(const std::map<std::string, Type::NumericValue> &paramValues, 
                     const std::map<std::string, InitVarSnippet::Init> &varValues,
-                    const std::map<std::string, Models::VarReference> &varRefTargets) const
+                    const std::map<std::string, std::variant<std::string, Models::VarReference>> &varRefTargets) const
 {
     // Superclass
     Snippet::Base::validate(paramValues, "Postsynaptic model");

--- a/src/genn/genn/synapseGroup.cc
+++ b/src/genn/genn/synapseGroup.cc
@@ -291,9 +291,19 @@ SynapseGroup::SynapseGroup(const std::string &name, SynapseMatrixType matrixType
         m_FusedPSTarget(nullptr), m_FusedPreSpikeTarget(nullptr), m_FusedPostSpikeTarget(nullptr), m_FusedPreSpikeEventTarget(nullptr), m_FusedPostSpikeEventTarget(nullptr),
         m_FusedWUPreTarget(nullptr), m_FusedWUPostTarget(nullptr), m_FusedPreOutputTarget(nullptr), m_PostTargetVar("Isyn"), m_PreTargetVar("Isyn")
 {
+    // 'Resolve' local variable references
+    Models::resolveVarReferences(getPSInitialiser().getNeuronVarReferences(),
+                                 m_PSNeuronVarReferences, getTrgNeuronGroup(),
+                                 Models::VarReference::createVarRef)
     // Validate names
     Utils::validatePopName(name, "Synapse group");
     
+
+    // Check variable reference types
+    Models::checkVarReferenceTypes(getPreNeuronVarReferences(), getSnippet()->getPreNeuronVarRefs());
+    Models::checkVarReferenceTypes(getPostNeuronVarReferences(), getSnippet()->getPostNeuronVarRefs());
+    Models::checkVarReferenceTypes(getNeuronVarReferences(), getSnippet()->getNeuronVarRefs());
+
     // Check additional local variable reference constraints
     Models::checkLocalVarReferences(getPSInitialiser().getNeuronVarReferences(), getPSInitialiser().getSnippet()->getNeuronVarRefs(),
                                     getTrgNeuronGroup(), "Postsynaptic model variable references can only point to postsynaptic neuron group.");

--- a/src/genn/genn/synapseGroup.cc
+++ b/src/genn/genn/synapseGroup.cc
@@ -959,6 +959,15 @@ boost::uuids::detail::sha1::digest_type SynapseGroup::getWUHashDigest() const
         Utils::updateHash(v.second.getVarDims(), hash);
     }
 
+    // Loop through postsynapatic model variable references
+    for(const auto &v : getWUMPSMVarReferences()) {
+        // Update hash with whether variable references require delay
+        Utils::updateHash((v.second.getDelayNeuronGroup() == nullptr), hash);
+
+        // Update hash with target variable dimensions as this effects indexing code
+        Utils::updateHash(v.second.getVarDims(), hash);
+    }
+
     return hash.get_digest();
 }
 //----------------------------------------------------------------------------

--- a/src/genn/genn/synapseGroup.cc
+++ b/src/genn/genn/synapseGroup.cc
@@ -292,20 +292,27 @@ SynapseGroup::SynapseGroup(const std::string &name, SynapseMatrixType matrixType
         m_FusedWUPreTarget(nullptr), m_FusedWUPostTarget(nullptr), m_FusedPreOutputTarget(nullptr), m_PostTargetVar("Isyn"), m_PreTargetVar("Isyn")
 {
     // 'Resolve' local variable references
+    Models::resolveVarReferences(getWUInitialiser().getPreNeuronVarReferences(),
+                                 m_WUMPreNeuronVarReferences, getSrcNeuronGroup(),
+                                 static_cast<Models::VarReference(*)(NeuronGroup*, const std::string&)>(&Models::VarReference::createVarRef));
+    Models::resolveVarReferences(getWUInitialiser().getPostNeuronVarReferences(),
+                                 m_WUMPostNeuronVarReferences, getTrgNeuronGroup(),
+                                 static_cast<Models::VarReference(*)(NeuronGroup*, const std::string&)>(&Models::VarReference::createVarRef));
     Models::resolveVarReferences(getPSInitialiser().getNeuronVarReferences(),
                                  m_PSNeuronVarReferences, getTrgNeuronGroup(),
-                                 Models::VarReference::createVarRef);
+                                 static_cast<Models::VarReference(*)(NeuronGroup*, const std::string&)>(&Models::VarReference::createVarRef));
+
     // Validate names
     Utils::validatePopName(name, "Synapse group");
     
 
     // Check variable reference types
-    Models::checkVarReferenceTypes(getWUMPreNeuronVarReferences(), getSnippet()->getPreNeuronVarRefs());
-    Models::checkVarReferenceTypes(getWUMPostNeuronVarReferences(), getSnippet()->getPostNeuronVarRefs());
-    Models::checkVarReferenceTypes(getPSNeuronVarReferences(), getSnippet()->getNeuronVarRefs());
+    Models::checkVarReferenceTypes(getWUMPreNeuronVarReferences(), getWUInitialiser().getSnippet()->getPreNeuronVarRefs());
+    Models::checkVarReferenceTypes(getWUMPostNeuronVarReferences(), getWUInitialiser().getSnippet()->getPostNeuronVarRefs());
+    Models::checkVarReferenceTypes(getPSNeuronVarReferences(), getPSInitialiser().getSnippet()->getNeuronVarRefs());
 
     // Check additional local variable reference constraints
-    Models::checkLocalVarReferences(getPSNeuronVarReferences, getPSInitialiser().getSnippet()->getNeuronVarRefs(),
+    Models::checkLocalVarReferences(getPSNeuronVarReferences(), getPSInitialiser().getSnippet()->getNeuronVarRefs(),
                                     getTrgNeuronGroup(), "Postsynaptic model variable references can only point to postsynaptic neuron group.");
     Models::checkLocalVarReferences(getWUMPreNeuronVarReferences(), getWUInitialiser().getSnippet()->getPreNeuronVarRefs(),
                                     getSrcNeuronGroup(), "Weight update model presynaptic variable references can only point to presynaptic neuron group.");

--- a/src/genn/genn/weightUpdateModels.cc
+++ b/src/genn/genn/weightUpdateModels.cc
@@ -144,17 +144,14 @@ void Base::validate(const std::map<std::string, Type::NumericValue> &paramValues
 //----------------------------------------------------------------------------
 Init::Init(const Base *snippet, const std::map<std::string, Type::NumericValue> &params, const std::map<std::string, InitVarSnippet::Init> &varInitialisers, 
            const std::map<std::string, InitVarSnippet::Init> &preVarInitialisers, const std::map<std::string, InitVarSnippet::Init> &postVarInitialisers,
-           const std::map<std::string, Models::VarReference> &preNeuronVarReferences, const std::map<std::string, Models::VarReference> &postNeuronVarReferences)
+           const std::map<std::string, std::variant<std::string, Models::VarReference>> &preNeuronVarReferences,
+           const std::map<std::string, std::map<std::string, std::variant<std::string, Models::VarReference>>> &postNeuronVarReferences)
 :   Snippet::Init<Base>(snippet, params), m_VarInitialisers(varInitialisers), m_PreVarInitialisers(preVarInitialisers), m_PostVarInitialisers(postVarInitialisers), 
     m_PreNeuronVarReferences(preNeuronVarReferences), m_PostNeuronVarReferences(postNeuronVarReferences)
 {
     // Validate
     getSnippet()->validate(getParams(), getVarInitialisers(), getPreVarInitialisers(), getPostVarInitialisers(),
                            getPreNeuronVarReferences(), getPostNeuronVarReferences());
-
-    // Check variable reference types
-    Models::checkVarReferenceTypes(getPreNeuronVarReferences(), getSnippet()->getPreNeuronVarRefs());
-    Models::checkVarReferenceTypes(getPostNeuronVarReferences(), getSnippet()->getPostNeuronVarRefs());
 
     // Scan code tokens
     m_PreSpikeSynCodeTokens = Utils::scanCode(getSnippet()->getPreSpikeSynCode(), "Weight update model presynaptic spike synaptic code");

--- a/src/genn/genn/weightUpdateModels.cc
+++ b/src/genn/genn/weightUpdateModels.cc
@@ -103,8 +103,8 @@ void Base::validate(const std::map<std::string, Type::NumericValue> &paramValues
                     const std::map<std::string, InitVarSnippet::Init> &varValues,
                     const std::map<std::string, InitVarSnippet::Init> &preVarValues,
                     const std::map<std::string, InitVarSnippet::Init> &postVarValues,
-                    const std::map<std::string, Models::VarReference> &preVarRefTargets,
-                    const std::map<std::string, Models::VarReference> &postVarRefTargets) const
+                    const std::map<std::string, std::variant<std::string, Models::VarReference>> &preVarRefTargets,
+                    const std::map<std::string, std::variant<std::string, Models::VarReference>> &postVarRefTargets) const
 {
     // Superclass
     Snippet::Base::validate(paramValues, "Weight update model");
@@ -145,7 +145,7 @@ void Base::validate(const std::map<std::string, Type::NumericValue> &paramValues
 Init::Init(const Base *snippet, const std::map<std::string, Type::NumericValue> &params, const std::map<std::string, InitVarSnippet::Init> &varInitialisers, 
            const std::map<std::string, InitVarSnippet::Init> &preVarInitialisers, const std::map<std::string, InitVarSnippet::Init> &postVarInitialisers,
            const std::map<std::string, std::variant<std::string, Models::VarReference>> &preNeuronVarReferences,
-           const std::map<std::string, std::map<std::string, std::variant<std::string, Models::VarReference>>> &postNeuronVarReferences)
+           const std::map<std::string, std::variant<std::string, Models::VarReference>> &postNeuronVarReferences)
 :   Snippet::Init<Base>(snippet, params), m_VarInitialisers(varInitialisers), m_PreVarInitialisers(preVarInitialisers), m_PostVarInitialisers(postVarInitialisers), 
     m_PreNeuronVarReferences(preNeuronVarReferences), m_PostNeuronVarReferences(postNeuronVarReferences)
 {

--- a/src/genn/genn/weightUpdateModels.cc
+++ b/src/genn/genn/weightUpdateModels.cc
@@ -37,6 +37,7 @@ boost::uuids::detail::sha1::digest_type Base::getHashDigest() const
     Utils::updateHash(getPostVars(), hash);
     Utils::updateHash(getPreNeuronVarRefs(), hash);
     Utils::updateHash(getPostNeuronVarRefs(), hash);
+    Utils::updateHash(getPSMVarRefs(), hash);
 
     // Return digest
     return hash.get_digest();
@@ -94,6 +95,7 @@ boost::uuids::detail::sha1::digest_type Base::getPostEventHashDigest() const
     Utils::updateHash(getPostEventThresholdConditionCode(), hash);
     Utils::updateHash(getPostVars(), hash);
     Utils::updateHash(getPostNeuronVarRefs(), hash);
+    Utils::updateHash(getPSMVarRefs(), hash);
 
     // Return digest
     return hash.get_digest();
@@ -104,7 +106,8 @@ void Base::validate(const std::map<std::string, Type::NumericValue> &paramValues
                     const std::map<std::string, InitVarSnippet::Init> &preVarValues,
                     const std::map<std::string, InitVarSnippet::Init> &postVarValues,
                     const std::map<std::string, std::variant<std::string, Models::VarReference>> &preVarRefTargets,
-                    const std::map<std::string, std::variant<std::string, Models::VarReference>> &postVarRefTargets) const
+                    const std::map<std::string, std::variant<std::string, Models::VarReference>> &postVarRefTargets,
+                    const std::map<std::string, std::variant<std::string, Models::VarReference>> &psmVarRefTargets) const
 {
     // Superclass
     Snippet::Base::validate(paramValues, "Weight update model");
@@ -124,10 +127,13 @@ void Base::validate(const std::map<std::string, Type::NumericValue> &paramValues
     // Validate variable reference initialisers
     const auto preVarRefs = getPreNeuronVarRefs();
     const auto postVarRefs = getPostNeuronVarRefs();
+    const auto psmVarRefs = getPSMVarRefs();
     Utils::validateVecNames(preVarRefs, "Presynaptic neuron variable reference");
     Utils::validateVecNames(postVarRefs, "Postsynaptic neuron variable reference");
+    Utils::validateVecNames(psmVarRefs, "Postsynaptic model variable reference");
     Utils::validateInitialisers(preVarRefs, preVarRefTargets, "Presynaptic neuron variable reference", "Weight update model");
-    Utils::validateInitialisers(postVarRefs, postVarRefTargets, "Postsyanptic neuron variable reference", "Weight update model");
+    Utils::validateInitialisers(postVarRefs, postVarRefTargets, "Postsynaptic neuron variable reference", "Weight update model");
+    Utils::validateInitialisers(psmVarRefs, psmVarRefTargets, "Postsynaptic model variable reference", "Weight update model");
 
     // Check if event-threshold condition code is provided, then event-handler is also provided
     if(getPreEventSynCode().empty() != getPreEventThresholdConditionCode().empty()) {
@@ -145,13 +151,14 @@ void Base::validate(const std::map<std::string, Type::NumericValue> &paramValues
 Init::Init(const Base *snippet, const std::map<std::string, Type::NumericValue> &params, const std::map<std::string, InitVarSnippet::Init> &varInitialisers, 
            const std::map<std::string, InitVarSnippet::Init> &preVarInitialisers, const std::map<std::string, InitVarSnippet::Init> &postVarInitialisers,
            const std::map<std::string, std::variant<std::string, Models::VarReference>> &preNeuronVarReferences,
-           const std::map<std::string, std::variant<std::string, Models::VarReference>> &postNeuronVarReferences)
+           const std::map<std::string, std::variant<std::string, Models::VarReference>> &postNeuronVarReferences,
+           const std::map<std::string, std::variant<std::string, Models::VarReference>> &psmVarReferences)
 :   Snippet::Init<Base>(snippet, params), m_VarInitialisers(varInitialisers), m_PreVarInitialisers(preVarInitialisers), m_PostVarInitialisers(postVarInitialisers), 
-    m_PreNeuronVarReferences(preNeuronVarReferences), m_PostNeuronVarReferences(postNeuronVarReferences)
+    m_PreNeuronVarReferences(preNeuronVarReferences), m_PostNeuronVarReferences(postNeuronVarReferences), m_PSMVarReferences(psmVarReferences)
 {
     // Validate
     getSnippet()->validate(getParams(), getVarInitialisers(), getPreVarInitialisers(), getPostVarInitialisers(),
-                           getPreNeuronVarReferences(), getPostNeuronVarReferences());
+                           getPreNeuronVarReferences(), getPostNeuronVarReferences(), getPSMVarReferences());
 
     // Scan code tokens
     m_PreSpikeSynCodeTokens = Utils::scanCode(getSnippet()->getPreSpikeSynCode(), "Weight update model presynaptic spike synaptic code");

--- a/src/genn/genn/weightUpdateModels.cc
+++ b/src/genn/genn/weightUpdateModels.cc
@@ -183,6 +183,15 @@ bool Init::isVarHeterogeneouslyDelayedInSynCode(const std::string &name) const
             || Utils::isIdentifierDelayed(name, getSynapseDynamicsCodeTokens()));
 }
 //----------------------------------------------------------------------------
+bool Init::isVarReferencedInSynCode(const std::string &name) const
+{
+    return (Utils::isIdentifierReferenced(name, getPreSpikeSynCodeTokens())
+            || Utils::isIdentifierReferenced(name, getPreEventSynCodeTokens())
+            || Utils::isIdentifierReferenced(name, getPostEventSynCodeTokens())
+            || Utils::isIdentifierReferenced(name, getPostSpikeSynCodeTokens())
+            || Utils::isIdentifierReferenced(name, getSynapseDynamicsCodeTokens()));
+}
+//----------------------------------------------------------------------------
 void Init::finalise(double dt)
 {
     // Superclass

--- a/tests/features/test_post_psm_vars.py
+++ b/tests/features/test_post_psm_vars.py
@@ -49,7 +49,8 @@ post_event_weight_update_model = create_weight_update_model(
 @pytest.mark.parametrize("backend", ["single_threaded_cpu", "cuda"])
 @pytest.mark.parametrize("precision", [types.Double, types.Float])
 @pytest.mark.parametrize("delay", [0])#, 20])
-def test_post_psm_var(make_model, backend, precision, delay):
+@pytest.mark.parametrize("fuse", [False, True])
+def test_post_psm_var(make_model, backend, precision, delay, fuse):
     # Postsynaptic model which updates a state variable with time + per-neuron shift
     pattern_postsynaptic_model = create_postsynaptic_model(
         "pattern_postsynaptic_model",
@@ -74,6 +75,7 @@ def test_post_psm_var(make_model, backend, precision, delay):
 
     model = make_model(precision, "test_post_psm_var", backend=backend)
     model.dt = 1.0
+    model.fuse_postsynaptic_models = fuse
 
     # Create pre and postsynaptic neuron populations
     float_min = np.finfo(np.float32).min

--- a/tests/features/test_post_psm_vars.py
+++ b/tests/features/test_post_psm_vars.py
@@ -48,7 +48,7 @@ post_event_weight_update_model = create_weight_update_model(
     
 @pytest.mark.parametrize("backend", ["single_threaded_cpu", "cuda"])
 @pytest.mark.parametrize("precision", [types.Double, types.Float])
-@pytest.mark.parametrize("delay", [0])#, 20])
+@pytest.mark.parametrize("delay", [0, 20])
 @pytest.mark.parametrize("fuse", [False, True])
 def test_post_psm_var(make_model, backend, precision, delay, fuse):
     # Postsynaptic model which updates a state variable with time + per-neuron shift

--- a/tests/features/test_post_psm_vars.py
+++ b/tests/features/test_post_psm_vars.py
@@ -1,0 +1,138 @@
+import numpy as np
+import pytest
+from pygenn import types
+from scipy import stats
+
+from pygenn import VarAccess, VarAccessMode
+from pygenn import (create_neuron_model, create_postsynaptic_model,
+                    create_var_ref, create_weight_update_model,
+                    init_postsynaptic,
+                    init_sparse_connectivity,
+                    init_weight_update, init_var)
+
+# Weight update models which copy a POSTSYNAPTIC neuron variables
+# into synapse during various kinds of synaptic event
+post_sim_weight_update_model = create_weight_update_model(
+    "post_sim_weight_update",
+    vars=[("w", "scalar")],
+    psm_var_refs=[("s", "scalar", VarAccessMode.READ_ONLY)],
+
+    pre_spike_syn_code=
+    """
+    w = s;
+    """)
+
+post_learn_post_weight_update_model = create_weight_update_model(
+    "post_learn_post_weight_update",
+    vars=[("w", "scalar")],
+    psm_var_refs=[("s", "scalar", VarAccessMode.READ_ONLY)],
+
+    post_spike_syn_code=
+    """
+    w = s;
+    """)
+
+post_event_weight_update_model = create_weight_update_model(
+    "pre_sim_weight_update",
+    vars=[("w", "scalar")],
+    psm_var_refs=[("s", "scalar", VarAccessMode.READ_ONLY)],
+
+    pre_event_syn_code=
+    """
+    w = s;
+    """,
+    pre_event_threshold_condition_code=
+    """
+    t >= (scalar)id && fmod(t - (scalar)id, 10.0) < 1e-4
+    """)
+    
+@pytest.mark.parametrize("backend", ["single_threaded_cpu", "cuda"])
+@pytest.mark.parametrize("precision", [types.Double, types.Float])
+@pytest.mark.parametrize("delay", [0])#, 20])
+def test_post_psm_var(make_model, backend, precision, delay):
+    # Postsynaptic model which updates a state variable with time + per-neuron shift
+    pattern_postsynaptic_model = create_postsynaptic_model(
+        "pattern_postsynaptic_model",
+        sim_code=
+        """
+        s = t + shift;
+        """,
+        vars=[("s", "scalar"), ("shift", "scalar", VarAccess.READ_ONLY)])
+
+    # Neuron model which fires at t = id ms and every 10 ms after that
+    spike_neuron_model = create_neuron_model(
+        "pattern_spike_neuron",
+        threshold_condition_code=
+        """
+        t >= (scalar)id && fmod(t - (scalar)id, 10.0) < 1e-4
+        """)
+
+    # Empty neuron model
+    empty_neuron_model = create_neuron_model(
+        "empty_neuron")
+
+
+    model = make_model(precision, "test_post_psm_var", backend=backend)
+    model.dt = 1.0
+
+    # Create pre and postsynaptic neuron populations
+    float_min = np.finfo(np.float32).min
+    shift = np.arange(0.0, 100.0, 10.0)
+    pre_n_pop = model.add_neuron_population("PreNeurons", 10, spike_neuron_model)
+    post_n_pop = model.add_neuron_population("PostNeurons", 10, empty_neuron_model)
+
+    # Add synapse models testing various ways of reading PSM vars
+    s_post_learn_post_sparse_pop = model.add_synapse_population(
+        "PostLearnPostSparseSynapses", "SPARSE",
+        post_n_pop, pre_n_pop,
+        init_weight_update(post_learn_post_weight_update_model, {}, {"w": float_min},
+                           psm_var_refs={"s": "s"}),
+        init_postsynaptic(pattern_postsynaptic_model, {}, {"s": float_min, "shift": shift}),
+        init_sparse_connectivity("OneToOne"))
+    s_post_learn_post_sparse_pop.back_prop_delay_steps = delay
+    s_post_sim_sparse_pop = model.add_synapse_population(
+        "PostSimSparseSynapses", "SPARSE",
+        pre_n_pop, post_n_pop,
+        init_weight_update(post_sim_weight_update_model, {}, {"w": float_min},
+                           psm_var_refs={"s": "s"}),
+        init_postsynaptic(pattern_postsynaptic_model, {}, {"s": float_min, "shift": shift}),
+        init_sparse_connectivity("OneToOne"))
+    s_post_sim_sparse_pop.back_prop_delay_steps = delay
+    
+    s_post_event_sparse_pop = model.add_synapse_population(
+        "PostEventSparseSynapses", "SPARSE",
+        pre_n_pop, post_n_pop,
+        init_weight_update(post_event_weight_update_model, {}, {"w": float_min},
+                           psm_var_refs={"s": "s"}),
+        init_postsynaptic(pattern_postsynaptic_model, {}, {"s": float_min, "shift": shift}),
+        init_sparse_connectivity("OneToOne"))
+    s_post_event_sparse_pop.back_prop_delay_steps = delay
+
+    # Build model and load
+    model.build()
+    model.load()
+
+    # Pull all synaptic connectivity from device
+    synapse_groups = [s_post_sim_sparse_pop, 
+                      s_post_learn_post_sparse_pop,
+                      s_post_event_sparse_pop]
+    for s in synapse_groups:
+        s.pull_connectivity_from_device()
+    
+    while model.timestep < 100:
+        model.step_time()
+        
+        # Calculate time of spikes we SHOULD be reading
+        # **NOTE** we delay by delay + 2 timesteps because:
+        # 1) delay = delay
+        # 2) spike times are read in synapse kernel one timestep AFTER being emitted
+        # 3) t is incremented one timestep at te end of StepGeNN
+        delayed_time = (11 * np.arange(10)) + (10.0 * np.floor((model.t - delay - 2.0 - np.arange(10)) / 10.0))
+        delayed_time[delayed_time < (10 * np.arange(10))] = float_min
+        
+        # Loop through synapse groups and compare value of w with delayed time
+        for s in synapse_groups:
+            s.vars["w"].pull_from_device()
+            w_value = s.vars["w"].values
+            if not np.allclose(delayed_time, w_value):
+                assert False, f"{s.name} var has wrong value ({w_value} rather than {delayed_time})"

--- a/tests/features/test_pre_post_neuron_vars.py
+++ b/tests/features/test_pre_post_neuron_vars.py
@@ -125,7 +125,7 @@ def test_pre_post_neuron_var(make_model, backend, precision, delay):
         "PreLearnPostSparseSynapses", "SPARSE",
         post_n_pop, pre_n_pop,
         init_weight_update(pre_learn_post_weight_update_model, {}, {"w": float_min},
-                           pre_var_refs={"s": create_var_ref(post_n_pop, "s")}),
+                           pre_var_refs={"s": "s"}),
         init_postsynaptic("DeltaCurr"),
         init_sparse_connectivity("OneToOne"))
     s_pre_learn_post_sparse_pop.axonal_delay_steps = delay
@@ -143,7 +143,7 @@ def test_pre_post_neuron_var(make_model, backend, precision, delay):
         "PreEventSparseSynapses", "SPARSE",
         pre_n_pop, post_n_pop,
         init_weight_update(pre_event_weight_update_model, {}, {"w": float_min},
-                           pre_var_refs={"s": create_var_ref(pre_n_pop, "s")}),
+                           pre_var_refs={"s": "s"}),
         init_postsynaptic("DeltaCurr"),
         init_sparse_connectivity("OneToOne"))
     s_pre_event_sparse_pop.axonal_delay_steps = delay
@@ -161,7 +161,7 @@ def test_pre_post_neuron_var(make_model, backend, precision, delay):
         "PostSimSparseSynapses", "SPARSE",
         pre_n_pop, post_n_pop,
         init_weight_update(post_sim_weight_update_model, {}, {"w": float_min},
-                           post_var_refs={"s": create_var_ref(post_n_pop, "s")}),
+                           post_var_refs={"s": "s"}),
         init_postsynaptic("DeltaCurr"),
         init_sparse_connectivity("OneToOne"))
     s_post_sim_sparse_pop.back_prop_delay_steps = delay

--- a/tests/unit/neuronGroup.cc
+++ b/tests/unit/neuronGroup.cc
@@ -719,8 +719,8 @@ TEST(NeuronGroup, FuseSpikeEvent)
     VarValues synVarVals2{{"g", 0.2}};
     ParamValues synParamVals1{{"VThresh", -50.0}};
     ParamValues synParamVals2{{"VThresh", -55.0}};
-    VarReferences synPreVarReferences1{{"V", createVarRef(pre, "V")}};
-    VarReferences synPreVarReferences2{{"V", createVarRef(pre, "U")}};
+    LocalVarReferences synPreVarReferences1{{"V", createVarRef(pre, "V")}};
+    LocalVarReferences synPreVarReferences2{{"V", "U"}};
  
     // Add baseline synapse population
     auto *sg0 = model.addSynapsePopulation(

--- a/tests/unit/weightUpdateModels.cc
+++ b/tests/unit/weightUpdateModels.cc
@@ -115,8 +115,8 @@ TEST(WeightUpdateModels, ValidateParamValues)
     const VarValues varVals{{"g", uninitialisedVar()}};
     const VarValues preVarVals{{"preTrace", uninitialisedVar()}};
     const VarValues postVarVals{{"postTrace", uninitialisedVar()}};
-    const VarReferences preNeuronVarRefs{};
-    const VarReferences postNeuronVarRefs{};
+    const LocalVarReferences preNeuronVarRefs{};
+    const LocalVarReferences postNeuronVarRefs{};
 
     const ParamValues paramValsCorrect{{"tauPlus", 10.0}, {"tauMinus", 10.0}, {"Aplus", 0.01}, {"Aminus", 0.01}, {"Wmin", 0.0}, {"Wmax", 1.0}};
     const ParamValues paramValsMisSpelled{{"tauPlus", 10.0}, {"tauMinus", 10.0}, {"APlus", 0.01}, {"Aminus", 0.01}, {"Wmin", 0.0}, {"Wmax", 1.0}};
@@ -156,8 +156,8 @@ TEST(WeightUpdateModels, ValidateVarValues)
     const VarValues preVarVals{{"preTrace", 0.0}};
     const VarValues postVarVals{{"postTrace", 0.0}};
     const ParamValues paramVals{{"tauPlus", 10.0}, {"tauMinus", 10.0}, {"Aplus", 0.01}, {"Aminus", 0.01}, {"Wmin", 0.0}, {"Wmax", 1.0}};
-    const VarReferences preNeuronVarRefs{};
-    const VarReferences postNeuronVarRefs{};
+    const LocalVarReferences preNeuronVarRefs{};
+    const LocalVarReferences postNeuronVarRefs{};
     
     const VarValues varValsCorrect{{"g", uninitialisedVar()}};
     const VarValues varValsMisSpelled{{"G", uninitialisedVar()}};
@@ -197,8 +197,8 @@ TEST(WeightUpdateModels, ValidatePreVarValues)
     const VarValues postVarVals{{"postTrace", 0.0}};
     const VarValues varVals{{"g", uninitialisedVar()}};
     const ParamValues paramVals{{"tauPlus", 10.0}, {"tauMinus", 10.0}, {"Aplus", 0.01}, {"Aminus", 0.01}, {"Wmin", 0.0}, {"Wmax", 1.0}};
-    const VarReferences preNeuronVarRefs{};
-    const VarReferences postNeuronVarRefs{};
+    const LocalVarReferences preNeuronVarRefs{};
+    const LocalVarReferences postNeuronVarRefs{};
     
     const VarValues preVarValsCorrect{{"preTrace", 0.0}};
     const VarValues preVarValsMisSpelled{{"prETrace", 0.0}};
@@ -238,8 +238,8 @@ TEST(WeightUpdateModels, ValidatePostVarValues)
     const VarValues preVarVals{{"preTrace", 0.0}};
     const VarValues varVals{{"g", uninitialisedVar()}};
     const ParamValues paramVals{{"tauPlus", 10.0}, {"tauMinus", 10.0}, {"Aplus", 0.01}, {"Aminus", 0.01}, {"Wmin", 0.0}, {"Wmax", 1.0}};
-    const VarReferences preNeuronVarRefs{};
-    const VarReferences postNeuronVarRefs{};
+    const LocalVarReferences preNeuronVarRefs{};
+    const LocalVarReferences postNeuronVarRefs{};
     
     const VarValues postVarValsCorrect{{"postTrace", 0.0}};
     const VarValues postVarValsMisSpelled{{"PostTrace", 0.0}};

--- a/tests/unit/weightUpdateModels.cc
+++ b/tests/unit/weightUpdateModels.cc
@@ -117,6 +117,7 @@ TEST(WeightUpdateModels, ValidateParamValues)
     const VarValues postVarVals{{"postTrace", uninitialisedVar()}};
     const LocalVarReferences preNeuronVarRefs{};
     const LocalVarReferences postNeuronVarRefs{};
+    const LocalVarReferences psmVarRefs{};
 
     const ParamValues paramValsCorrect{{"tauPlus", 10.0}, {"tauMinus", 10.0}, {"Aplus", 0.01}, {"Aminus", 0.01}, {"Wmin", 0.0}, {"Wmax", 1.0}};
     const ParamValues paramValsMisSpelled{{"tauPlus", 10.0}, {"tauMinus", 10.0}, {"APlus", 0.01}, {"Aminus", 0.01}, {"Wmin", 0.0}, {"Wmax", 1.0}};
@@ -124,11 +125,11 @@ TEST(WeightUpdateModels, ValidateParamValues)
     const ParamValues paramValsExtra{{"tauPlus", 10.0}, {"tauMinus", 10.0}, {"Aplus", 0.01}, {"Aminus", 0.01}, {"Bminus", 0.01},{"Wmin", 0.0}, {"Wmax", 1.0}};
 
     STDPAdditive::getInstance()->validate(paramValsCorrect, varVals, preVarVals, postVarVals, 
-                                          preNeuronVarRefs, postNeuronVarRefs);
+                                          preNeuronVarRefs, postNeuronVarRefs, psmVarRefs);
 
     try {
         STDPAdditive::getInstance()->validate(paramValsMisSpelled, varVals, preVarVals, postVarVals, 
-                                              preNeuronVarRefs, postNeuronVarRefs);
+                                              preNeuronVarRefs, postNeuronVarRefs, psmVarRefs);
         FAIL();
     }
     catch(const std::runtime_error &) {
@@ -136,7 +137,7 @@ TEST(WeightUpdateModels, ValidateParamValues)
 
     try {
         STDPAdditive::getInstance()->validate(paramValsMissing, varVals, preVarVals, postVarVals, 
-                                              preNeuronVarRefs, postNeuronVarRefs);
+                                              preNeuronVarRefs, postNeuronVarRefs, psmVarRefs);
         FAIL();
     }
     catch(const std::runtime_error &) {
@@ -144,7 +145,7 @@ TEST(WeightUpdateModels, ValidateParamValues)
 
     try {
         STDPAdditive::getInstance()->validate(paramValsExtra, varVals, preVarVals, postVarVals, 
-                                              preNeuronVarRefs, postNeuronVarRefs);
+                                              preNeuronVarRefs, postNeuronVarRefs, psmVarRefs);
         FAIL();
     }
     catch(const std::runtime_error &) {
@@ -158,6 +159,7 @@ TEST(WeightUpdateModels, ValidateVarValues)
     const ParamValues paramVals{{"tauPlus", 10.0}, {"tauMinus", 10.0}, {"Aplus", 0.01}, {"Aminus", 0.01}, {"Wmin", 0.0}, {"Wmax", 1.0}};
     const LocalVarReferences preNeuronVarRefs{};
     const LocalVarReferences postNeuronVarRefs{};
+    const LocalVarReferences psmVarRefs{};
     
     const VarValues varValsCorrect{{"g", uninitialisedVar()}};
     const VarValues varValsMisSpelled{{"G", uninitialisedVar()}};
@@ -165,11 +167,11 @@ TEST(WeightUpdateModels, ValidateVarValues)
     const VarValues varValsExtra{{"g", uninitialisedVar()}, {"d", uninitialisedVar()}};
 
     STDPAdditive::getInstance()->validate(paramVals, varValsCorrect, preVarVals, postVarVals, 
-                                          preNeuronVarRefs, postNeuronVarRefs);
+                                          preNeuronVarRefs, postNeuronVarRefs, psmVarRefs);
 
     try {
         STDPAdditive::getInstance()->validate(paramVals, varValsMisSpelled, preVarVals, postVarVals, 
-                                              preNeuronVarRefs, postNeuronVarRefs);
+                                              preNeuronVarRefs, postNeuronVarRefs, psmVarRefs);
         FAIL();
     }
     catch(const std::runtime_error &) {
@@ -177,7 +179,7 @@ TEST(WeightUpdateModels, ValidateVarValues)
 
     try {
         STDPAdditive::getInstance()->validate(paramVals, varValsMissing, preVarVals, postVarVals, 
-                                              preNeuronVarRefs, postNeuronVarRefs);
+                                              preNeuronVarRefs, postNeuronVarRefs, psmVarRefs);
         FAIL();
     }
     catch(const std::runtime_error &) {
@@ -185,7 +187,7 @@ TEST(WeightUpdateModels, ValidateVarValues)
 
     try {
         STDPAdditive::getInstance()->validate(paramVals, varValsExtra, preVarVals, postVarVals, 
-                                              preNeuronVarRefs, postNeuronVarRefs);
+                                              preNeuronVarRefs, postNeuronVarRefs, psmVarRefs);
         FAIL();
     }
     catch(const std::runtime_error &) {
@@ -199,6 +201,7 @@ TEST(WeightUpdateModels, ValidatePreVarValues)
     const ParamValues paramVals{{"tauPlus", 10.0}, {"tauMinus", 10.0}, {"Aplus", 0.01}, {"Aminus", 0.01}, {"Wmin", 0.0}, {"Wmax", 1.0}};
     const LocalVarReferences preNeuronVarRefs{};
     const LocalVarReferences postNeuronVarRefs{};
+    const LocalVarReferences psmVarRefs{};
     
     const VarValues preVarValsCorrect{{"preTrace", 0.0}};
     const VarValues preVarValsMisSpelled{{"prETrace", 0.0}};
@@ -206,11 +209,11 @@ TEST(WeightUpdateModels, ValidatePreVarValues)
     const VarValues preVarValsExtra{{"preTrace", 0.0}, {"postTrace", 0.0}};
 
     STDPAdditive::getInstance()->validate(paramVals, varVals, preVarValsCorrect, postVarVals, 
-                                          preNeuronVarRefs, postNeuronVarRefs);
+                                          preNeuronVarRefs, postNeuronVarRefs, psmVarRefs);
 
     try {
         STDPAdditive::getInstance()->validate(paramVals, varVals, preVarValsMisSpelled, postVarVals, 
-                                              preNeuronVarRefs, postNeuronVarRefs);
+                                              preNeuronVarRefs, postNeuronVarRefs, psmVarRefs);
         FAIL();
     }
     catch(const std::runtime_error &) {
@@ -218,7 +221,7 @@ TEST(WeightUpdateModels, ValidatePreVarValues)
 
     try {
         STDPAdditive::getInstance()->validate(paramVals, varVals, preVarValsMissing, postVarVals, 
-                                              preNeuronVarRefs, postNeuronVarRefs);
+                                              preNeuronVarRefs, postNeuronVarRefs, psmVarRefs);
         FAIL();
     }
     catch(const std::runtime_error &) {
@@ -226,7 +229,7 @@ TEST(WeightUpdateModels, ValidatePreVarValues)
 
     try {
         STDPAdditive::getInstance()->validate(paramVals, varVals, preVarValsExtra, postVarVals, 
-                                              preNeuronVarRefs, postNeuronVarRefs);
+                                              preNeuronVarRefs, postNeuronVarRefs, psmVarRefs);
         FAIL();
     }
     catch(const std::runtime_error &) {
@@ -240,6 +243,7 @@ TEST(WeightUpdateModels, ValidatePostVarValues)
     const ParamValues paramVals{{"tauPlus", 10.0}, {"tauMinus", 10.0}, {"Aplus", 0.01}, {"Aminus", 0.01}, {"Wmin", 0.0}, {"Wmax", 1.0}};
     const LocalVarReferences preNeuronVarRefs{};
     const LocalVarReferences postNeuronVarRefs{};
+    const LocalVarReferences psmVarRefs{};
     
     const VarValues postVarValsCorrect{{"postTrace", 0.0}};
     const VarValues postVarValsMisSpelled{{"PostTrace", 0.0}};
@@ -247,11 +251,11 @@ TEST(WeightUpdateModels, ValidatePostVarValues)
     const VarValues postVarValsExtra{{"postTrace", 0.0}, {"preTrace", 0.0}};
 
     STDPAdditive::getInstance()->validate(paramVals, varVals, preVarVals, postVarValsCorrect, 
-                                          preNeuronVarRefs, postNeuronVarRefs);
+                                          preNeuronVarRefs, postNeuronVarRefs, psmVarRefs);
 
     try {
         STDPAdditive::getInstance()->validate(paramVals, varVals, preVarVals, postVarValsMisSpelled, 
-                                              preNeuronVarRefs, postNeuronVarRefs);
+                                              preNeuronVarRefs, postNeuronVarRefs, psmVarRefs);
         FAIL();
     }
     catch(const std::runtime_error &) {
@@ -259,7 +263,7 @@ TEST(WeightUpdateModels, ValidatePostVarValues)
 
     try {
         STDPAdditive::getInstance()->validate(paramVals, varVals, preVarVals, postVarValsMissing, 
-                                              preNeuronVarRefs, postNeuronVarRefs);
+                                              preNeuronVarRefs, postNeuronVarRefs, psmVarRefs);
         FAIL();
     }
     catch(const std::runtime_error &) {
@@ -267,7 +271,7 @@ TEST(WeightUpdateModels, ValidatePostVarValues)
 
     try {
         STDPAdditive::getInstance()->validate(paramVals, varVals, preVarVals, postVarValsExtra, 
-                                              preNeuronVarRefs, postNeuronVarRefs);
+                                              preNeuronVarRefs, postNeuronVarRefs, psmVarRefs);
         FAIL();
     }
     catch(const std::runtime_error &) {


### PR DESCRIPTION
This PR adds support for weight update model synapse code (presynaptic update, postsynaptic update and synapse dynamics) to access postsynaptic model variables in the same synapse group. This is more-or-less trivial: this PR adds a ``psm_var_refs`` keyword argument to the ``init_weight_update`` and ``create_weight_update_model`` functions. However, there are two complexities:

### Syntax
Current syntax for referencing neuron variables looks like this:
```python
model.add_synapse_population(
    "Syn", "DENSE",
    pre_n_pop, post_n_pop,
    init_weight_update(weight_update_model, {}, {},
                       post_var_refs={"s": create_var_ref(post_n_pop, "s")}),
    init_postsynaptic("DeltaCurr"))
```
Not only is it a bit redundant (as you can only target ``post_n_pop`` variables) but, it would be impossible to reference postsynaptic model variables in the same way as you'd need to have the synapse group object while you were still constructing it. The solution to both problems is a new "shorthand" syntax which enables you now to do:
```python
model.add_synapse_population(
    "Syn", "DENSE",
    pre_n_pop, post_n_pop,
    init_weight_update(weight_update_model, {}, {},
                       post_var_refs={"s": "s"}),
    init_postsynaptic("DeltaCurr"))
```
This can be used for references to neuron variables in current sources, postsynaptic models and weight update model; and the references to postsynaptic model variables in weight update models that this PR adds.

### Delays
Referencing postsynaptic model variables from synapses might mean they require buffering for backpropagation/heterogeneous delay. This requires some extra data structures in ``SynapseGroup`` but I have extended some feature test to cover this functionality and it all seems to be working.