### PR TITLE
Fix: Raise error for unknown preferences in GeNNModel constructor

### DIFF
--- a/pygenn/genn_model.py
+++ b/pygenn/genn_model.py
@@ -661,6 +661,12 @@ class GeNNModel(ModelSpec):
         # Create suitable preferences object for backend
         self._preferences = self._backend_module.Preferences()
 
+        # Validate preference kwargs
+        for k, v in self._preference_kwargs.items():
+            if not hasattr(self._preferences, k):
+                raise ValueError(f"Unknown preference '{k}'")
+        
+            
         # Set attributes on preferences object from kwargs
         for k, v in self._preference_kwargs.items():
             if hasattr(self._preferences, k):

--- a/pygenn/genn_model.py
+++ b/pygenn/genn_model.py
@@ -661,16 +661,12 @@ class GeNNModel(ModelSpec):
         # Create suitable preferences object for backend
         self._preferences = self._backend_module.Preferences()
 
-        # Validate preference kwargs
-        for k, v in self._preference_kwargs.items():
-            if not hasattr(self._preferences, k):
-                raise ValueError(f"Unknown preference '{k}'")
-        
-            
         # Set attributes on preferences object from kwargs
         for k, v in self._preference_kwargs.items():
             if hasattr(self._preferences, k):
                 setattr(self._preferences, k, v)
+            else:
+                raise ValueError(f"Unknown preference '{k}'")
         
         # Create backend
         self._backend = self._backend_module._create_backend(


### PR DESCRIPTION
This pull request addresses issue #622 by modifying the GeNNModel constructor to raise a ValueError when an unknown preference keyword is provided.