### PR TITLE
Fix generation of debug code in PyGeNN on Windows

### DIFF
--- a/pygenn/genn_model.py
+++ b/pygenn/genn_model.py
@@ -683,8 +683,12 @@ class GeNNModel(ModelSpec):
         # Build code
         if not never_rebuild:
             if system() == "Windows":
-                check_call([_msbuild, "/p:Configuration=Release", "/m", "/verbosity:quiet",
-                            path.join(output_path, "runner.vcxproj")])
+                debug = self._preference_kwargs.get("debug_code", False)
+                check_call(
+                    [_msbuild, 
+                     f"/p:Configuration={'Debug' if debug else 'Release'}",
+                     "/m", "/verbosity:quiet",
+                     path.join(output_path, "runner.vcxproj")])
             else:
                 check_call(["make", "-j", str(cpu_count(logical=False)), "-C", output_path])
 


### PR DESCRIPTION
This probably affects no one aside from me but, while investigating https://github.com/genn-team/genn/issues/669, I realised passing ``debug_code=True`` to the ``GeNNModel`` constructor didn't work properly on Windows. This is because ``runner.vcxproj`` is configured to build either release or debug code but we were always selecting release when we build from PyGeNN. The runtime then fails as _it's_ looking for a debug library. This mirrors the existing logic used in the C++ code generator (https://github.com/genn-team/genn/blob/master/src/genn/generator/generator.cc#L127-L128)