### PR TITLE
Allow variable names to start with an underscore

### DIFF
--- a/src/genn/genn/transpiler/scanner.cc
+++ b/src/genn/genn/transpiler/scanner.cc
@@ -431,8 +431,8 @@ void scanToken(ScanState &scanState, std::vector<Token> &tokens)
             if(std::isdigit(c) || c == '.') {
                 scanNumber(c, scanState, tokens);
             }
-            // Otherwise, scan identifier
-            else if(std::isalpha(c)) {
+            // Otherwise, scan identifier. Identifiers may start with an underscore
+            else if(std::isalpha(c) || c == '_') {
                 scanIdentifier(scanState, tokens);
             }
             else {


### PR DESCRIPTION
In C variable naming, variable names may start with an underscore (see https://en.cppreference.com/w/cpp/language/identifiers). Currently, variable names starting with an underscore are not lexed correctly and result in an error during code generation. This PR fixes the issue.