### PR TITLE
Fix pretty print bugs

### DIFF
--- a/include/genn/genn/code_generator/environment.h
+++ b/include/genn/genn/code_generator/environment.h
@@ -502,9 +502,11 @@ public:
                                     [getFieldValue](Runtime::Runtime&, const auto &g, size_t i){ return getFieldValue(g, i); }};
             this->addInternal(type, name, std::make_tuple(false, LazyString{"", *this}, std::make_optional(field)));
         }
-        // Otherwise, just add value
+        // Otherwise, just add parenthesised value
+        // **NOTE** parentheses are necessary because literals are being used with the 
+        // semantics of identifiers and, while -identifier is correct, --12 is not
         else {
-            this->add(type, name, Type::writeNumeric(archetypeValue, type));
+            this->add(type, name, "(" + Type::writeNumeric(archetypeValue, type) + ")");
         }
     }
 

--- a/src/genn/genn/code_generator/standardLibrary.cc
+++ b/src/genn/genn/code_generator/standardLibrary.cc
@@ -123,7 +123,7 @@ const auto libraryTypes = initLibraryTypes(
     std::make_pair("abs", std::make_pair(Type::ResolvedType::createFunction(Type::Int64, {Type::Int64}), "abs($(0))")),
 
     // Printf
-    std::make_pair("printf", std::make_pair(Type::ResolvedType::createFunction(Type::Int32, {Type::Int8.addConst().createPointer()}, Type::FunctionFlags::VARIADIC), "printf($(0), $(@))")),
+    std::make_pair("printf", std::make_pair(Type::ResolvedType::createFunction(Type::Int32, {Type::Int8.addConst().createPointer()}, Type::FunctionFlags::VARIADIC), "printf($(0)$(@))")),
 
     // Assert
     std::make_pair("assert", std::make_pair(Type::ResolvedType::createFunction(Type::Void, {Type::Bool}), "assert($(0))")));

--- a/src/genn/genn/transpiler/prettyPrinter.cc
+++ b/src/genn/genn/transpiler/prettyPrinter.cc
@@ -275,14 +275,18 @@ private:
                 const size_t found = name.find(variadicPlaceholder);
                 if (found != std::string::npos) {
                     // Concatenate together all remaining arguments
+                    // **NOTE** variadic function templates shouldn't have a comma 
+                    // between required and variadic arguments e.g. "printf($(0)$(@))"
+                    // so, arguments simply require leading printing with leading comma
                     std::ostringstream variadicArgumentsStream;
-                    std::copy(m_CallArguments.top().second.cbegin() + i, m_CallArguments.top().second.cend(),
-                                std::ostream_iterator<std::string>(variadicArgumentsStream, ", "));
-
-                    // Replace variadic placeholder with all remaining arguments (after trimming trailing ", ")
-                    std::string variadicArguments = variadicArgumentsStream.str();
-                    name.replace(found, variadicPlaceholder.length(),
-                                 variadicArguments.substr(0, variadicArguments.length() - 2));
+                    const auto varArgBegin = m_CallArguments.top().second.cbegin() + i;
+                    const auto varArgEnd = m_CallArguments.top().second.cend();
+                    for(auto a = varArgBegin; a != varArgEnd; a++) {
+                        variadicArgumentsStream << ", " << *a;
+                    }
+             
+                    // Replace variadic placeholder with all remaining arguments 
+                    name.replace(found, variadicPlaceholder.length(), variadicArgumentsStream.str());
                 }
                 else {
                     throw std::runtime_error("Variadic function template for '" + variable.getName().lexeme + "' (" + name + ") has "

--- a/tests/unit/prettyPrinter.cc
+++ b/tests/unit/prettyPrinter.cc
@@ -1,0 +1,53 @@
+// Standard C++ includes
+#include <sstream>
+
+// Google test includes
+#include "gtest/gtest.h"
+
+// GeNN transpiler includes
+#include "transpiler/errorHandler.h"
+#include "transpiler/parser.h"
+#include "transpiler/scanner.h"
+
+// GeNN code generator includes
+#include "code_generator/codeGenUtils.h"
+#include "code_generator/environment.h"
+#include "code_generator/standardLibrary.h"
+
+using namespace GeNN;
+using namespace GeNN::CodeGenerator;
+using namespace GeNN::Transpiler;
+
+
+//--------------------------------------------------------------------------
+// Tests
+//--------------------------------------------------------------------------
+TEST(PrettyPrinter, Printf)
+{
+    ErrorHandler errorHandler("");
+
+    // Printf with no variadic arguments
+    {
+        std::ostringstream stringStream;
+        CodeStream codeStream(stringStream);
+
+        EnvironmentLibrary env(codeStream, StandardLibrary::getMathsFunctions());
+        const auto tokens = Scanner::scanSource("printf(\"hello\");", errorHandler);
+        prettyPrintStatements(tokens, {}, env, errorHandler, nullptr, nullptr);
+
+        ASSERT_EQ(stringStream.str(), "printf(\"hello\");\n");
+    }
+
+    // Printf with arguments
+    {
+        std::ostringstream stringStream;
+        CodeStream codeStream(stringStream);
+
+        EnvironmentLibrary env(codeStream, StandardLibrary::getMathsFunctions());
+        const auto tokens = Scanner::scanSource("printf(\"hello %d, %f\", 12, 15.0f);", errorHandler);
+        prettyPrintStatements(tokens, {}, env, errorHandler, nullptr, nullptr);
+
+        ASSERT_EQ(stringStream.str(), "printf(\"hello %d, %f\", 12, 15.0f);\n");
+    }
+ 
+}

--- a/tests/unit/unit.vcxproj
+++ b/tests/unit/unit.vcxproj
@@ -28,6 +28,7 @@
     <ClCompile Include="neuronModels.cc" />
     <ClCompile Include="parser.cc" />
     <ClCompile Include="postsynapticModels.cc" />
+    <ClCompile Include="prettyPrinter.cc" />
     <ClCompile Include="scanner.cc" />
     <ClCompile Include="synapseGroup.cc" />
     <ClCompile Include="models.cc" />


### PR DESCRIPTION
This PR fixes a small issue (#677) where invalid code was generated if parameters with negative values get hard-coded into a unary minus expression e.g. if ``R=-10`` then ``-R`` would result in ``--10`` being pretty-printed which in invalid C code. Solution is simply to _always_ parenthesise so this becomes ``-(-10)`` which is fine.

While I was pretty-printing I also fixed the issue with printf issue (#650). Apologies to @gitsofaryan - who implemented what was probably a valid fix, the complexity of which just made me realise the way we were specifying variadic functions was silly. By changing the template from ``"printf($(0), $(@))"`` to ``"printf($(0)$(@))"`` the task becomes _much_ simpler as you just have to insert _leading_ commas with each argument rather than removing bits of the template if you call printf with no extra arguments.

Closes #677 
Closes #650 