### PR TITLE
Add NVTX profiling support to CUDA backend (resolves #635)

### DIFF
--- a/include/genn/backends/cuda/backend.h
+++ b/include/genn/backends/cuda/backend.h
@@ -73,6 +73,9 @@ struct Preferences : public PreferencesCUDAHIP
 
     //! Should line info be included in resultant executable for debugging/profiling purposes?
     bool generateLineInfo = false;
+    
+    //! Should NVTX markers be inserted to make profiling easier?
+    bool enableNVTX = false;
 
     //! How to select GPU device
     DeviceSelect deviceSelectMethod = DeviceSelect::MANUAL;
@@ -107,6 +110,7 @@ struct Preferences : public PreferencesCUDAHIP
         //! Update hash with preferences
         Utils::updateHash(deviceSelectMethod, hash);
         Utils::updateHash(constantCacheOverhead, hash);
+        Utils::updateHash(enableNVTX, hash);
     }
 };
 
@@ -266,6 +270,15 @@ public:
 
     //! Get hash digest of this backends identification and the preferences it has been configured with
     virtual boost::uuids::detail::sha1::digest_type getHashDigest() const final;
+
+    //! Check if NVTX markers are enabled for this backend
+    virtual bool isNVTXMarkerEnabled() const final { return getPreferences<Preferences>().enableNVTX; }
+    
+    //! Push a named NVTX range marker for profiling
+    virtual void pushNVTXRange(const std::string &name) const final;
+    
+    //! Pop the current NVTX range marker
+    virtual void popNVTXRange() const final;
 
     //--------------------------------------------------------------------------
     // Public API

--- a/include/genn/backends/cuda/backend.h
+++ b/include/genn/backends/cuda/backend.h
@@ -271,14 +271,11 @@ public:
     //! Get hash digest of this backends identification and the preferences it has been configured with
     virtual boost::uuids::detail::sha1::digest_type getHashDigest() const final;
 
-    //! Check if NVTX markers are enabled for this backend
-    virtual bool isNVTXMarkerEnabled() const final { return getPreferences<Preferences>().enableNVTX; }
+    //! Generate code to push a profiler range marker 
+    virtual void genPushProfilerRange(CodeStream &os, const std::string &name) const final;
     
-    //! Push a named NVTX range marker for profiling
-    virtual void pushNVTXRange(const std::string &name) const final;
-    
-    //! Pop the current NVTX range marker
-    virtual void popNVTXRange() const final;
+    //! Generate code to pop the current profiler range marker
+    virtual void genPopProfilerRange(CodeStream &os) const final;
 
     //--------------------------------------------------------------------------
     // Public API

--- a/include/genn/genn/code_generator/backendBase.h
+++ b/include/genn/genn/code_generator/backendBase.h
@@ -326,6 +326,15 @@ public:
     //! Get hash digest of this backends identification and the preferences it has been configured with
     virtual boost::uuids::detail::sha1::digest_type getHashDigest() const = 0;
 
+    //! Check if NVTX markers are enabled for this backend
+    virtual bool isNVTXMarkerEnabled() const { return false; }
+    
+    //! Push a named NVTX range marker for profiling
+    virtual void pushNVTXRange(const std::string &) const {}
+    
+    //! Pop the current NVTX range marker
+    virtual void popNVTXRange() const {}
+
     //--------------------------------------------------------------------------
     // Public API
     //--------------------------------------------------------------------------

--- a/include/genn/genn/code_generator/backendBase.h
+++ b/include/genn/genn/code_generator/backendBase.h
@@ -330,7 +330,7 @@ public:
     virtual void genPushProfilerRange(CodeStream&, const std::string&) const {}
     
     //! Generate code to pop the current profiler range marker
-    virtual void genPopProfilerRange(CodeStream &os) const {}
+    virtual void genPopProfilerRange(CodeStream&) const {}
 
     //--------------------------------------------------------------------------
     // Public API

--- a/include/genn/genn/code_generator/backendBase.h
+++ b/include/genn/genn/code_generator/backendBase.h
@@ -327,7 +327,7 @@ public:
     virtual boost::uuids::detail::sha1::digest_type getHashDigest() const = 0;
 
     //! Generate code to push a profiler range marker
-    virtual void genPushProfilerRange(CodeStream &os, const std::string &name) const {}
+    virtual void genPushProfilerRange(CodeStream&, const std::string&) const {}
     
     //! Generate code to pop the current profiler range marker
     virtual void genPopProfilerRange(CodeStream &os) const {}

--- a/include/genn/genn/code_generator/backendBase.h
+++ b/include/genn/genn/code_generator/backendBase.h
@@ -326,14 +326,11 @@ public:
     //! Get hash digest of this backends identification and the preferences it has been configured with
     virtual boost::uuids::detail::sha1::digest_type getHashDigest() const = 0;
 
-    //! Check if NVTX markers are enabled for this backend
-    virtual bool isNVTXMarkerEnabled() const { return false; }
+    //! Generate code to push a profiler range marker
+    virtual void genPushProfilerRange(CodeStream &os, const std::string &name) const {}
     
-    //! Push a named NVTX range marker for profiling
-    virtual void pushNVTXRange(const std::string &) const {}
-    
-    //! Pop the current NVTX range marker
-    virtual void popNVTXRange() const {}
+    //! Generate code to pop the current profiler range marker
+    virtual void genPopProfilerRange(CodeStream &os) const {}
 
     //--------------------------------------------------------------------------
     // Public API

--- a/pygenn/src/cudaBackend.cc
+++ b/pygenn/src/cudaBackend.cc
@@ -65,6 +65,7 @@ PYBIND11_MODULE(cuda_backend, m)
         
         WRAP_ATTR("show_ptx_info", Preferences, showPtxInfo)
         WRAP_ATTR("generate_line_info", Preferences, generateLineInfo)
+        WRAP_ATTR("enable_nvtx", Preferences, enableNVTX)
         WRAP_ATTR("device_select_method", Preferences, deviceSelectMethod)
         WRAP_ATTR("manual_device_id", Preferences, manualDeviceID)
         WRAP_ATTR("block_size_select_method", Preferences, blockSizeSelectMethod)

--- a/pygenn/src/cudaBackendDocStrings.h
+++ b/pygenn/src/cudaBackendDocStrings.h
@@ -139,6 +139,8 @@ static const char *__doc_CodeGenerator_CUDA_Preferences_deviceSelectMethod = R"d
 
 static const char *__doc_CodeGenerator_CUDA_Preferences_generateLineInfo = R"doc(Should line info be included in resultant executable for debugging/profiling purposes?)doc";
 
+static const char *__doc_CodeGenerator_CUDA_Preferences_enableNVTX = R"doc(Should NVTX markers be inserted to make profiling easier?)doc";
+
 static const char *__doc_CodeGenerator_CUDA_Preferences_manualBlockSizes = R"doc(If block size select method is set to BlockSizeSelect::MANUAL, block size to use for each kernel)doc";
 
 static const char *__doc_CodeGenerator_CUDA_Preferences_manualDeviceID = R"doc(If device select method is set to DeviceSelect::MANUAL, id of device to use)doc";

--- a/src/genn/genn/code_generator/generateRunner.cc
+++ b/src/genn/genn/code_generator/generateRunner.cc
@@ -275,7 +275,7 @@ void GeNN::CodeGenerator::generateRunner(const filesystem::path &outputPath, Mod
         CodeStream::Scope b(runner);
 
         // Add profiler range for step time
-        backend.genPushProfilerRange(runner, "stepTime");
+        backend.genPushProfilerRange(runner, "stepTime (" + std::to_string(timestep) + ")");
 
         runner << "const " << model.getTimePrecision().getName() << " t = timestep * " << Type::writeNumeric(model.getDT(), model.getTimePrecision()) << ";" << std::endl;
 

--- a/src/genn/genn/code_generator/generateRunner.cc
+++ b/src/genn/genn/code_generator/generateRunner.cc
@@ -275,7 +275,7 @@ void GeNN::CodeGenerator::generateRunner(const filesystem::path &outputPath, Mod
         CodeStream::Scope b(runner);
 
         // Add profiler range for step time
-        backend.genPushProfilerRange(runner, "stepTime (" + std::to_string(timestep) + ")");
+        backend.genPushProfilerRange(runner, "stepTime");
 
         runner << "const " << model.getTimePrecision().getName() << " t = timestep * " << Type::writeNumeric(model.getDT(), model.getTimePrecision()) << ";" << std::endl;
 

--- a/src/genn/genn/runtime/runtime.cc
+++ b/src/genn/genn/runtime/runtime.cc
@@ -700,11 +700,6 @@ void Runtime::stepTime()
 //----------------------------------------------------------------------------
 void Runtime::customUpdate(const std::string &name)
 {
-    // If NVTX markers are enabled, push range
-    if(m_Backend.get().isNVTXMarkerEnabled()) {
-        m_Backend.get().pushNVTXRange("customUpdate:" + name);
-    }
-
     // If there are column length arrays that must be zeroed 
     // before making connectivity update in this group
     auto colLengthArrays = m_CustomUpdateColLengthArrays.find(name);
@@ -722,11 +717,6 @@ void Runtime::customUpdate(const std::string &name)
 
     // Run custom update
     m_CustomUpdateFunctions.at(name)(getTimestep());
-
-    // If NVTX markers are enabled, pop range
-    if(m_Backend.get().isNVTXMarkerEnabled()) {
-        m_Backend.get().popNVTXRange();
-    }
 }
 //----------------------------------------------------------------------------
 double Runtime::getTime() const

--- a/src/genn/genn/runtime/runtime.cc
+++ b/src/genn/genn/runtime/runtime.cc
@@ -700,6 +700,11 @@ void Runtime::stepTime()
 //----------------------------------------------------------------------------
 void Runtime::customUpdate(const std::string &name)
 {
+    // If NVTX markers are enabled, push range
+    if(m_Backend.get().isNVTXMarkerEnabled()) {
+        m_Backend.get().pushNVTXRange("customUpdate:" + name);
+    }
+
     // If there are column length arrays that must be zeroed 
     // before making connectivity update in this group
     auto colLengthArrays = m_CustomUpdateColLengthArrays.find(name);
@@ -717,6 +722,11 @@ void Runtime::customUpdate(const std::string &name)
 
     // Run custom update
     m_CustomUpdateFunctions.at(name)(getTimestep());
+
+    // If NVTX markers are enabled, pop range
+    if(m_Backend.get().isNVTXMarkerEnabled()) {
+        m_Backend.get().popNVTXRange();
+    }
 }
 //----------------------------------------------------------------------------
 double Runtime::getTime() const


### PR DESCRIPTION
- Added `enableNVTX` preference flag to the CUDA backend
- Added linking against nvToolsExt library when NVTX is enabled
- I've implemented NVTX range markers around key simulation components:
  - Overall simulation steps
  - Neuron updates
  - Synapse updates
  - Custom updates