### PR TITLE
Fixes RNG initialisation issues

### DIFF
--- a/src/genn/genn/code_generator/modelSpecMerged.cc
+++ b/src/genn/genn/code_generator/modelSpecMerged.cc
@@ -107,13 +107,14 @@ using namespace GeNN::CodeGenerator;
                         &SynapseGroupInternal::getDendriticDelayUpdateHashDigest);
 
     createMergedGroups(getModel().getNeuronGroups(), m_MergedNeuronInitGroups,
-                       [](const NeuronGroupInternal &ng)
+                       [&backend](const NeuronGroupInternal &ng)
                        { 
                            return (ng.isSpikeEventRequired() || ng.isTrueSpikeRequired()
                                    || ng.isSpikeTimeRequired() || ng.isPrevSpikeTimeRequired()
                                    || ng.isSpikeEventTimeRequired() || ng.isPrevSpikeEventTimeRequired()
                                    || !ng.getFusedPSMInSyn().empty() || !ng.getFusedPreOutputOutSyn().empty()
-                                   || ng.isVarInitRequired());
+                                   || ng.isVarInitRequired()
+                                   || (backend.isPopulationRNGInitialisedOnDevice() && ng.isSimRNGRequired()));
                        },
                        &NeuronGroupInternal::getInitHashDigest);
 


### PR DESCRIPTION
If neuron groups are really simple i.e. they have no variables but use an RNG, they were not being correctly initialised when using the CUDA backend. This is because ``NeuronInitGroupMerged`` objects were not being created. This is fixed by creating these if neuron groups (including current sources etc) require an RNG and, the current backend initialises RNGs on device.

Fixes #684 