### PR TITLE
Fixed several issues working with sparse connectivity in PyGeNN

### DIFF
--- a/pygenn/model_preprocessor.py
+++ b/pygenn/model_preprocessor.py
@@ -283,12 +283,6 @@ class SynapseVariable(VariableBase):
             (sg.matrix_type & SynapseMatrixWeight.KERNEL)):
             self._view[:] = vals
         elif (sg.matrix_type & SynapseMatrixConnectivity.SPARSE):
-            # Sort variable to match GeNN order
-            if len(self._view.shape) == 1:
-                sorted_var = vals[sg.synapse_order]
-            else:
-                sorted_var = vals[:,sg.synapse_order]
-
             # Create range containing the index
             # where each row starts in ind
             row_start_idx = range(0, sg.weight_update_var_size,
@@ -299,9 +293,9 @@ class SynapseVariable(VariableBase):
             for i, r in zip(row_start_idx, sg.row_lengths):
                 # Copy row from non-padded indices into correct location
                 if len(self._view.shape) == 1:
-                    self._view[i:i + r] = sorted_var[syn:syn + r]
+                    self._view[i:i + r] = vals[syn:syn + r]
                 else:
-                    self._view[:,i:i + r] = sorted_var[:,syn:syn + r]
+                    self._view[:,i:i + r] = vals[:,syn:syn + r]
                 syn += r
         else:
             raise Exception("Matrix format not supported")

--- a/pygenn/model_preprocessor.py
+++ b/pygenn/model_preprocessor.py
@@ -252,13 +252,17 @@ class SynapseVariable(VariableBase):
         elif sg.matrix_type & SynapseMatrixWeight.KERNEL:
             return np.copy(self._view)
         elif sg.matrix_type & SynapseMatrixConnectivity.SPARSE:
-            max_rl = sg.max_connections
-            row_ls = (sg._row_lengths._view 
-                      if sg._connectivity_initialiser_provided
-                      else sg.row_lengths)
+            # If this synapse group isn't modified by any 
+            # custom connectivity updates and connectivity
+            # was set manually, it's fine to use cached copy,
+            # otherwise use view
+            row_ls = (sg.row_lengths 
+                      if not sg._any_ccu_references and sg.connections_set
+                      else sg._row_lengths.view)
 
             # Create range containing the index where each row starts in ind
-            row_start_idx = range(0, sg.weight_update_var_size, max_rl)
+            row_start_idx = range(0, sg.weight_update_var_size, 
+                                  sg.max_connections)
 
             # Build list of subviews representing each row
             if len(self._view.shape) == 1:
@@ -288,9 +292,17 @@ class SynapseVariable(VariableBase):
             row_start_idx = range(0, sg.weight_update_var_size,
                                   sg.max_connections)
 
-            # Loop through ragged matrix rows
+            # If this synapse group isn't modified by any 
+            # custom connectivity updates and connectivity
+            # was set manually, it's fine to use cached copy,
+            # otherwise use view
+            row_ls = (sg.row_lengths 
+                      if not sg._any_ccu_references and sg.connections_set
+                      else sg._row_lengths.view)
+
+            # Loop through sparse matrix rows
             syn = 0
-            for i, r in zip(row_start_idx, sg.row_lengths):
+            for i, r in zip(row_start_idx, row_ls):
                 # Copy row from non-padded indices into correct location
                 if len(self._view.shape) == 1:
                     self._view[i:i + r] = vals[syn:syn + r]

--- a/pygenn/src/genn.cc
+++ b/pygenn/src/genn.cc
@@ -659,6 +659,13 @@ PYBIND11_MODULE(_genn, m)
         .def_property_readonly("_wu_post_model_fused", &SynapseGroupInternal::isWUPostModelFused)
         .def_property_readonly("_sparse_ind_type", &SynapseGroupInternal::getSparseIndType)
         
+        .def_property_readonly("_any_ccu_references", 
+            [](const SynapseGroup &sg)
+            {
+                const auto &sgInternal = static_cast<const SynapseGroupInternal&>(sg);
+                return !sgInternal.getCustomConnectivityUpdateReferences().empty();
+            })
+
         //--------------------------------------------------------------------
         // Methods
         //--------------------------------------------------------------------

--- a/tests/features/test_sparse.py
+++ b/tests/features/test_sparse.py
@@ -1,0 +1,73 @@
+import numpy as np
+import pytest
+from pygenn import types
+
+from pygenn import VarAccess, VarAccessMode
+
+from pygenn import (create_custom_update_model, create_neuron_model, 
+                    create_wu_var_ref, init_postsynaptic, init_weight_update)
+
+# Neuron model which does nothing
+empty_neuron_model = create_neuron_model("empty")
+
+double_custom_update_model = create_custom_update_model(
+        "double_custom_update",
+         update_code=
+         """
+         X *= 2.0;
+         """,
+         var_refs=[("X", "scalar")])
+
+@pytest.mark.parametrize("precision", [types.Double, types.Float])
+def test_host_sparsity(make_model, backend, precision, batch_size):
+    model = make_model(precision, "test_host_sparsity", backend=backend)
+    model.dt = 1.0
+    model.batch_size = batch_size
+
+    # Add empty pre and postsynatic populations
+    pre_pop = model.add_neuron_population("Pre", 10, empty_neuron_model)
+    post_pop = model.add_neuron_population("Post", 10, empty_neuron_model)
+
+    pre_ind = np.random.randint(10, size=20)
+    post_ind = np.random.randint(1, 10, size=20)
+    g = pre_ind / post_ind
+
+    # Connect with synapse population
+    sg = model.add_synapse_population(
+        "Synapses", "SPARSE",
+        pre_pop, post_pop,
+        init_weight_update("StaticPulse", {}, {"g": g}),
+        init_postsynaptic("DeltaCurr"))
+    sg.set_sparse_connections(pre_ind, post_ind)
+
+    # Add custom update to double weights
+    model.add_custom_update("DoubleG", "Double", double_custom_update_model,
+                            {}, {}, {"X": create_wu_var_ref(sg, "g")})
+   
+
+    # Build model and load
+    model.build()
+    model.load(num_recording_timesteps=100)
+
+    baseline_g = sg.get_sparse_pre_inds() / sg.get_sparse_post_inds()
+    double_baseline_g = 2.0 * baseline_g
+
+    # Run custom update to double
+    model.custom_update("Double")
+
+    # Pull g and check it's doubled
+    sg.vars["g"].pull_from_device()
+    assert np.allclose(sg.vars["g"].values, double_baseline_g)
+    
+    # Restore and push
+    sg.vars["g"].values = baseline_g
+    sg.vars["g"].push_to_device()
+
+    # Run custom update to double
+    model.custom_update("Double")
+
+    # Pull g and check it's doubled
+    sg.vars["g"].pull_from_device()
+    assert np.allclose(sg.vars["g"].values, double_baseline_g)
+
+

--- a/tests/features/test_sparse.py
+++ b/tests/features/test_sparse.py
@@ -5,7 +5,9 @@ from pygenn import types
 from pygenn import VarAccess, VarAccessMode
 
 from pygenn import (create_custom_update_model, create_neuron_model, 
-                    create_wu_var_ref, init_postsynaptic, init_weight_update)
+                    create_var_init_snippet, create_wu_var_ref, 
+                    init_postsynaptic, init_sparse_connectivity,
+                    init_var, init_weight_update)
 
 # Neuron model which does nothing
 empty_neuron_model = create_neuron_model("empty")
@@ -18,6 +20,17 @@ double_custom_update_model = create_custom_update_model(
          """,
          var_refs=[("X", "scalar")])
 
+weight_init_snippet = create_var_init_snippet(
+        "weight_init",
+        var_init_code=
+        """
+        value = (scalar)id_pre / id_post;
+        """)
+
+def _safe_check(a, b):
+    assert (np.allclose(a[np.isfinite(a)], b[np.isfinite(b)]) 
+            and np.array_equal(np.isfinite(a), np.isfinite(b)))
+
 @pytest.mark.parametrize("precision", [types.Double, types.Float])
 def test_host_sparsity(make_model, backend, precision, batch_size):
     model = make_model(precision, "test_host_sparsity", backend=backend)
@@ -29,7 +42,7 @@ def test_host_sparsity(make_model, backend, precision, batch_size):
     post_pop = model.add_neuron_population("Post", 10, empty_neuron_model)
 
     pre_ind = np.random.randint(10, size=20)
-    post_ind = np.random.randint(1, 10, size=20)
+    post_ind = np.random.randint(10, size=20)
     g = pre_ind / post_ind
 
     # Connect with synapse population
@@ -57,7 +70,7 @@ def test_host_sparsity(make_model, backend, precision, batch_size):
 
     # Pull g and check it's doubled
     sg.vars["g"].pull_from_device()
-    assert np.allclose(sg.vars["g"].values, double_baseline_g)
+    _safe_check(sg.vars["g"].values, double_baseline_g)
     
     # Restore and push
     sg.vars["g"].values = baseline_g
@@ -68,6 +81,55 @@ def test_host_sparsity(make_model, backend, precision, batch_size):
 
     # Pull g and check it's doubled
     sg.vars["g"].pull_from_device()
-    assert np.allclose(sg.vars["g"].values, double_baseline_g)
+    _safe_check(sg.vars["g"].values, double_baseline_g)
+
+
+@pytest.mark.parametrize("precision", [types.Double, types.Float])
+def test_device_sparsity(make_model, backend, precision, batch_size):
+    model = make_model(precision, "test_device_sparsity", backend=backend)
+    model.dt = 1.0
+    model.batch_size = batch_size
+
+    # Add empty pre and postsynatic populations
+    pre_pop = model.add_neuron_population("Pre", 10, empty_neuron_model)
+    post_pop = model.add_neuron_population("Post", 10, empty_neuron_model)
+
+    # Connect with synapse population
+    sg = model.add_synapse_population(
+        "Synapses", "SPARSE",
+        pre_pop, post_pop,
+        init_weight_update("StaticPulse", {}, {"g": init_var(weight_init_snippet)}),
+        init_postsynaptic("DeltaCurr"),
+        init_sparse_connectivity("FixedNumberTotalWithReplacement", {"num": 20}))
+
+    # Add custom update to double weights
+    model.add_custom_update("DoubleG", "Double", double_custom_update_model,
+                            {}, {}, {"X": create_wu_var_ref(sg, "g")})
+   
+    # Build model and load
+    model.build()
+    model.load(num_recording_timesteps=100)
+
+    sg.pull_connectivity_from_device()
+    baseline_g = sg.get_sparse_pre_inds() / sg.get_sparse_post_inds()
+    double_baseline_g = 2.0 * baseline_g
+
+    # Run custom update to double
+    model.custom_update("Double")
+
+    # Pull g and check it's doubled
+    sg.vars["g"].pull_from_device()
+    _safe_check(sg.vars["g"].values, double_baseline_g)
+    
+    # Restore and push
+    sg.vars["g"].values = baseline_g
+    sg.vars["g"].push_to_device()
+
+    # Run custom update to double
+    model.custom_update("Double")
+
+    # Pull g and check it's doubled
+    sg.vars["g"].pull_from_device()
+    _safe_check(sg.vars["g"].values, double_baseline_g)
 
 


### PR DESCRIPTION
Trying to work with sparse connectivity in PyGeNN (and hence mlGeNN) has previously been pretty annoying due to some odd design decisions which have accumulated over time. Specifically, the following perfectly sensible 'user journeys'  were _all_ broken in some way:

### Host-specified connectivity
1. Use ``SynapseGroup.set_sparse_connections`` to configure connectivity on the host and provide initial values for variables as arrays specified in the same order. Internally both the initial values for the variables and the pre and postsynaptic indices all get re-ordered (this is necessary due to the nature of sparse matrices).
2. Simulate something that modifies variables associated with sparse matrices
3. Pull variables associated with sparse matrices and access via ``SynapseVariable.values`` getter. These will be in the re-ordered order. At this point, a cached version of the sparse matrix will be used to access the variables - this is ok as long as a custom connectivity update hasn't been used to mess with the connectivity.
4. Update the variables, write back using ``SynapseVariable.values`` setter and push. The first serious bug in this workflow happens here as the values you're writing would get re-ordered again into the wrong order.

### Device-specified connectivity
1. Set connectivity and value of associated variables via initialisers
2. Simulate something that modifies variables associated with sparse matrices
3. Pull connectivity and variables associated with it; and access via ``SynapseVariable.values`` getter. This works.
4. Update the variables, write back using ``SynapseVariable.values`` setter and push. This totally fails as it tries to re-order without the required data structure to do so as the device order **is** the order.

### Host-specified connectivity and custom connectivity updates
1. Use ``SynapseGroup.set_sparse_connections`` to configure connectivity on the host and provide initial values for variables as arrays specified in the same order. Internally both the initial values for the variables and the pre and postsynaptic indices all get re-ordered (this is necessary due to the nature of sparse matrices).
2. Run a custom connectivity update which modifies the connectivity
3. Pull connectivity and variables associated with sparse matrices; and access via ``SynapseVariable.values`` getter. Because connectivity was initialised on the host, the cached version rather than the version updated by the custom update will be used.

In this PR, I've added feature tests reproducing each of these user journeys and fixed the underlying bugs that break all of them. Changes ended up being pretty simple but basically now:

* Synapse variables are _only_ re-ordered when initially loading host-specified variables into host-specified connectivity
* Whether any custom connectivity update groups access a synapse group (this test is a bit conservative) is now exposed to PyGeNN and, if this is the case, cached variables are never used.

One thing that does not work (and I'm not 100% sure what the correct behaviour should be) is calling ``SynapseGroup.set_sparse_connections`` to reconfigure connectivity at runtime as potentially this would involve modifying not only the variables in the associated synapse group but also in any custom updates or custom connectivity updates which reference it.

Fixes #628 
Fixes #620