### PR TITLE
Fixed nasty bug in Stream creator

### DIFF
--- a/src/genn/backends/cuda/optimiser.cc
+++ b/src/genn/backends/cuda/optimiser.cc
@@ -4,6 +4,7 @@
 #include <algorithm>
 #include <fstream>
 #include <iostream>
+#include <list>
 #include <map>
 #include <mutex>
 #include <numeric>
@@ -483,7 +484,7 @@ KernelOptimisationOutput optimizeBlockSize(int deviceID, const cudaDeviceProp &d
         // **NOTE** we don't really need to generate all the code but, on windows, generating code selectively seems to result in werid b
         const std::string dryRunSuffix = "CUDAOptim";
         {
-            std::vector<std::ofstream> fileStreams;
+            std::list<std::ofstream> fileStreams;
             auto fileStreamCreator =
                 [&dryRunSuffix, &fileStreams, &outputPath](const std::string &title, const std::string &extension) -> std::ostream &
                 {

--- a/src/genn/genn/code_generator/generateModules.cc
+++ b/src/genn/genn/code_generator/generateModules.cc
@@ -2,6 +2,7 @@
 
 // Standard C++ includes
 #include <fstream>
+#include <list>
 #include <string>
 #include <vector>
 
@@ -84,7 +85,7 @@ std::vector<std::string> generateAll(ModelSpecMerged &modelMerged, const Backend
     auto memorySpaces = backend.getMergedGroupMemorySpaces(modelMerged);
     
     // Create vector to hold file streams and lambda function to create them
-    std::vector<std::tuple<std::string, std::string, std::ostringstream>> fileStreams;
+    std::list<std::tuple<std::string, std::string, std::ostringstream>> fileStreams;
     auto fileStreamCreator =
         [&fileStreams](const std::string &title, const std::string &extension) -> std::ostream&
         {


### PR DESCRIPTION
In #693 I used ``std::vector`` to manage codestreams. When actually used in anger, this totally breaks as the elements of the ``std::vector`` get moved around and thus references to them are invalid...like the ones to the standard code stream we pass through to the backends. This switches to ``std::list`` which doesn't re-allocate elements