### PR TITLE
Fixed really nasty bug

### DIFF
--- a/src/genn/genn/code_generator/presynapticUpdateStrategySIMT.cc
+++ b/src/genn/genn/code_generator/presynapticUpdateStrategySIMT.cc
@@ -554,7 +554,7 @@ void PreSpanProcedural::genUpdate(EnvironmentExternalBase &env, PresynapticUpdat
 
         // Write sum of presynaptic output to global memory
         if(isPresynapticOutputRequired(sg, trueSpike)) {
-            groupEnv.printLine(backend.getAtomic(sg.getScalarType()) + "(&$(_out_pre)[" + sg.getPreISynIndex(batchSize, "$(id_pre)") + "], lOutPre);");
+            synEnv.printLine(backend.getAtomic(sg.getScalarType()) + "(&$(_out_pre)[" + sg.getPreISynIndex(batchSize, "$(id_pre)") + "], lOutPre);");
         }
 
     }

--- a/src/genn/genn/transpiler/prettyPrinter.cc
+++ b/src/genn/genn/transpiler/prettyPrinter.cc
@@ -250,8 +250,8 @@ private:
             assert(!m_CallArguments.empty());
 
             // Loop through non-variadic function arguments
-            size_t i = 0;
-            for (i = 0; i < type.getFunction().argTypes.size(); i++) {
+            const size_t numArguments = type.getFunction().argTypes.size();
+            for (size_t i = 0; i < numArguments; i++) {
                 // If name contains a $(i) placeholder to replace with this argument, replace with pretty-printed argument
                 const std::string placeholder = "$(" + std::to_string(i) + ")";
 
@@ -279,7 +279,7 @@ private:
                     // between required and variadic arguments e.g. "printf($(0)$(@))"
                     // so, arguments simply require leading printing with leading comma
                     std::ostringstream variadicArgumentsStream;
-                    const auto varArgBegin = m_CallArguments.top().second.cbegin() + i;
+                    const auto varArgBegin = m_CallArguments.top().second.cbegin() + numArguments;
                     const auto varArgEnd = m_CallArguments.top().second.cend();
                     for(auto a = varArgBegin; a != varArgEnd; a++) {
                         variadicArgumentsStream << ", " << *a;

--- a/src/genn/genn/transpiler/prettyPrinter.cc
+++ b/src/genn/genn/transpiler/prettyPrinter.cc
@@ -249,9 +249,9 @@ private:
             // Check that there are call arguments on the stack
             assert(!m_CallArguments.empty());
 
-            // Loop through call arguments on top of stack
+            // Loop through non-variadic function arguments
             size_t i = 0;
-            for (i = 0; i < m_CallArguments.top().second.size(); i++) {
+            for (i = 0; i < type.getFunction().argTypes.size(); i++) {
                 // If name contains a $(i) placeholder to replace with this argument, replace with pretty-printed argument
                 const std::string placeholder = "$(" + std::to_string(i) + ")";
 

--- a/src/genn/genn/transpiler/prettyPrinter.cc
+++ b/src/genn/genn/transpiler/prettyPrinter.cc
@@ -255,13 +255,13 @@ private:
                 // If name contains a $(i) placeholder to replace with this argument, replace with pretty-printed argument
                 const std::string placeholder = "$(" + std::to_string(i) + ")";
 
-                // If placeholder isn't found at all, stop looking for arguments
+                // If placeholder isn't found at all, go onto next argument
                 size_t found = name.find(placeholder);
                 if(found == std::string::npos) {
-                    break;
+                    continue;
                 }
                 
-                // Keep replacing placeholders
+                // Replacing all instances of placeholder
                 do {
                     name.replace(found, placeholder.length(), m_CallArguments.top().second.at(i));
                     found = name.find(placeholder, found);

--- a/src/genn/genn/transpiler/prettyPrinter.cc
+++ b/src/genn/genn/transpiler/prettyPrinter.cc
@@ -261,7 +261,7 @@ private:
                     continue;
                 }
                 
-                // Replacing all instances of placeholder
+                // Replace all instances of placeholder
                 do {
                     name.replace(found, placeholder.length(), m_CallArguments.top().second.at(i));
                     found = name.find(placeholder, found);

--- a/src/genn/genn/transpiler/typeChecker.cc
+++ b/src/genn/genn/transpiler/typeChecker.cc
@@ -558,7 +558,7 @@ private:
                     argumentConversionRank.reserve(m_CallArguments.top().size());
 
                     // Loop through arguments
-                    // **NOTE** we loop through function arguments to deal with variadic
+                    // **NOTE** we loop through function TYPE arguments to avoid variadic
                     bool viable = true;
                     auto c = m_CallArguments.top().cbegin();
                     auto a = argumentTypes.cbegin();


### PR DESCRIPTION
I have no idea WHY this was the behaviour but when you call a function from GeNN code e.g.

```c++
addSynapse(postInd,  flipKernRow, flipKernCol, preChan, kernOutChan);
```

in a Toeplitz connectivity initializer, if the first argument wasn't referenced in the function 'body' which gets substituted in (for example if the weight update model only calls ``addToPre`` which doesn't care about the postsynaptic neuron ID) then it gives up trying to substitute subsequent arguments.

Also, fixed a small bug relating to using  ``addToPre`` with procedural connectivity (wrong environment was being used) and added some tests of ``addToPre`` with KERNEL weights