### PR TITLE
setup.py: fix macOS dylib packaging and runtime linking

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -108,8 +108,7 @@ else:
     if MACOS:
         genn_extension_kwargs["depends"] = [
             os.path.join(pygenn_path, "libgenn" + genn_lib_suffix + ".dylib"),
-            os.path.join(pygenn_src, "docStrings.h"),
-        ]
+            os.path.join(pygenn_src, "docStrings.h")]
         # macOS: ensure extensions can find bundled dylibs next to them
         genn_extension_kwargs["extra_link_args"].extend(["-Wl,-rpath,@loader_path"])
     else:

--- a/setup.py
+++ b/setup.py
@@ -251,8 +251,7 @@ for module_stem, source_stem, kwargs in backends:
         package_data.append("genn_" + module_stem + "_backend" + genn_lib_suffix + ".dll")
     elif MACOS:
         backend_extension_kwargs["depends"].append(
-            os.path.join(pygenn_path, "libgenn_" + module_stem + "_backend" + genn_lib_suffix + ".dylib")
-        )
+            os.path.join(pygenn_path, "libgenn_" + module_stem + "_backend" + genn_lib_suffix + ".dylib"))
         package_data.append("libgenn_" + module_stem + "_backend" + genn_lib_suffix + ".dylib")    
     else:
         backend_extension_kwargs["depends"].append(

--- a/setup.py
+++ b/setup.py
@@ -114,8 +114,7 @@ else:
     else:
         genn_extension_kwargs["depends"] = [
             os.path.join(pygenn_path, "libgenn" + genn_lib_suffix + ".so"),
-            os.path.join(pygenn_src, "docStrings.h"),
-        ]
+            os.path.join(pygenn_src, "docStrings.h")]
     # If this is Linux, we want to add extension directory i.e. $ORIGIN to runtime
     # directories so libGeNN and backends can be found wherever package is installed
     if LINUX:

--- a/setup.py
+++ b/setup.py
@@ -104,6 +104,8 @@ if WIN:
                                         os.path.join(pygenn_path, "libffi" + genn_lib_suffix + ".dll")]
 # Otherwise
 else:
+    # --- Linux/macOS libffi linkage ---
+    genn_extension_kwargs["libraries"].append("ffi")
     # Add GeNN library to dependencies
     if MACOS:
         genn_extension_kwargs["depends"] = [
@@ -119,10 +121,6 @@ else:
     # directories so libGeNN and backends can be found wherever package is installed
     if LINUX:
         genn_extension_kwargs["runtime_library_dirs"] = ["$ORIGIN"]      
-
-# --- Linux/macOS libffi linkage ---
-if LINUX or MACOS:
-    genn_extension_kwargs["libraries"].append("ffi")
 
 if coverage_build:
     if LINUX:


### PR DESCRIPTION
### Summary

This PR improves **cross-platform packaging and installation** for `pygenn`, with a particular focus on **macOS** support.

### Changes Made
- **Platform-specific packaging**
    - Unified `package_data` and `depends` handling with `if / elif / else` logic:
        - **Windows** → `.dll`
        - **macOS** → `.dylib`
        - **Linux/others** → `.so`
    - Backend libraries now follow the same pattern, ensuring `.dylib`s are copied into the package on macOS.
- **Runtime linking improvements**
    - **macOS**: Added `Wl,-rpath,@loader_path` so extensions can locate bundled `.dylib`s after installation.
    - **Linux**: Preserved `$ORIGIN` in `runtime_library_dirs` so `.so`s can be found next to the extensions.
    - **Linux/macOS**: Explicitly link against `ffi` from the active environment.
- **Coverage builds**
    - Fixed the typo MAC -> MACOS
- **Backend Packaging Logic**
    - Updated backend packaging logic to include macos by using `if / elif / else` for clarity.
- **Project URL**
    - Fixed incorrect GitHub URL (`genn_team` → `genn-team`).

### Impact

- Fixes missing `.dylib` files on macOS installs.
- Ensures runtime linking works consistently across Windows, Linux, and macOS.
- Simplifies platform-specific logic for easier maintenance.
- Corrects metadata (URL) to point to the right repository.