### PR TITLE
HIP AMD fixes

### DIFF
--- a/include/genn/backends/cuda/backend.h
+++ b/include/genn/backends/cuda/backend.h
@@ -239,6 +239,8 @@ public:
     //--------------------------------------------------------------------------
     // CodeGenerator::BackendBase virtuals
     //--------------------------------------------------------------------------
+    virtual void genAllocateMemPreamble(CodeStream &os, const ModelSpecMerged &modelMerged) const final;
+    
     //! Create backend-specific runtime state object
     /*! \param runtime  runtime object */
     virtual std::unique_ptr<GeNN::Runtime::StateBase> createState(const Runtime::Runtime &runtime) const final;

--- a/include/genn/backends/cuda/backend.h
+++ b/include/genn/backends/cuda/backend.h
@@ -312,6 +312,10 @@ protected:
     
     virtual void genKernelDimensions(CodeStream &os, Kernel kernel, size_t numThreadsX, size_t batchSize, size_t numBlockThreadsY = 1) const final;
 
+    //! rocRand and cuRand name the internals the XOR shift RNG structure differently - get correct name
+    virtual std::string getXORShiftValueName() const final;
+
+private:
     //--------------------------------------------------------------------------
     // Members
     //--------------------------------------------------------------------------

--- a/include/genn/backends/cuda/backend.h
+++ b/include/genn/backends/cuda/backend.h
@@ -314,10 +314,6 @@ protected:
     
     virtual void genKernelDimensions(CodeStream &os, Kernel kernel, size_t numThreadsX, size_t batchSize, size_t numBlockThreadsY = 1) const final;
 
-    //! rocRand and cuRand name the internals the XOR shift RNG structure differently - get correct name
-    virtual std::string getXORShiftValueName() const final;
-
-private:
     //--------------------------------------------------------------------------
     // Members
     //--------------------------------------------------------------------------

--- a/include/genn/backends/hip/backend.h
+++ b/include/genn/backends/hip/backend.h
@@ -164,16 +164,19 @@ public:
     virtual std::string getAtomic(const Type::ResolvedType &type,
                                   AtomicOperation op = AtomicOperation::ADD, 
                                   AtomicMemSpace memSpace = AtomicMemSpace::GLOBAL) const final;
-    
-    //! Get type of population RNG
-    virtual Type::ResolvedType getPopulationRNGType() const final;
+
+    //! For SIMT backends which initialize RNGs on device, initialize population RNG with specified seed and sequence
+    virtual void genPopulationRNGInit(CodeStream &os, const std::string &globalRNG, const std::string &seed, const std::string &sequence) const final;
 
     //! Generate a preamble to add substitution name for population RNG
     virtual void buildPopulationRNGEnvironment(EnvironmentGroupMergedField<NeuronUpdateGroupMerged> &env) const final;
 
     //! Add $(_rng) to environment based on $(_rng_internal) field with any initialisers and destructors required
     virtual void buildPopulationRNGEnvironment(EnvironmentGroupMergedField<CustomConnectivityUpdateGroupMerged> &env) const final;
-    
+
+    //! Get type of population RNG
+    virtual Type::ResolvedType getPopulationRNGType() const final;
+
     //--------------------------------------------------------------------------
     // CodeGenerator::BackendBase virtuals
     //--------------------------------------------------------------------------

--- a/include/genn/backends/hip/backend.h
+++ b/include/genn/backends/hip/backend.h
@@ -237,10 +237,6 @@ protected:
 
     virtual void genKernelDimensions(CodeStream &os, Kernel kernel, size_t numThreadsX, size_t batchSize, size_t numBlockThreadsY = 1) const final;
 
-    //! rocRand and cuRand name the internals the XOR shift RNG structure differently - get correct name
-    virtual std::string getXORShiftValueName() const final;
-
-private:
     //--------------------------------------------------------------------------
     // Members
     //--------------------------------------------------------------------------

--- a/include/genn/backends/hip/backend.h
+++ b/include/genn/backends/hip/backend.h
@@ -168,6 +168,8 @@ public:
     //--------------------------------------------------------------------------
     // CodeGenerator::BackendBase virtuals
     //--------------------------------------------------------------------------
+    virtual void genAllocateMemPreamble(CodeStream &os, const ModelSpecMerged &modelMerged) const final;
+
     //! Create backend-specific runtime state object
     /*! \param runtime  runtime object */
     virtual std::unique_ptr<GeNN::Runtime::StateBase> createState(const Runtime::Runtime &runtime) const final;

--- a/include/genn/backends/hip/backend.h
+++ b/include/genn/backends/hip/backend.h
@@ -164,7 +164,16 @@ public:
     virtual std::string getAtomic(const Type::ResolvedType &type,
                                   AtomicOperation op = AtomicOperation::ADD, 
                                   AtomicMemSpace memSpace = AtomicMemSpace::GLOBAL) const final;
+    
+    //! Get type of population RNG
+    virtual Type::ResolvedType getPopulationRNGType() const final;
 
+    //! Generate a preamble to add substitution name for population RNG
+    virtual void buildPopulationRNGEnvironment(EnvironmentGroupMergedField<NeuronUpdateGroupMerged> &env) const final;
+
+    //! Add $(_rng) to environment based on $(_rng_internal) field with any initialisers and destructors required
+    virtual void buildPopulationRNGEnvironment(EnvironmentGroupMergedField<CustomConnectivityUpdateGroupMerged> &env) const final;
+    
     //--------------------------------------------------------------------------
     // CodeGenerator::BackendBase virtuals
     //--------------------------------------------------------------------------

--- a/include/genn/backends/hip/backend.h
+++ b/include/genn/backends/hip/backend.h
@@ -235,6 +235,10 @@ protected:
 
     virtual void genKernelDimensions(CodeStream &os, Kernel kernel, size_t numThreadsX, size_t batchSize, size_t numBlockThreadsY = 1) const final;
 
+    //! rocRand and cuRand name the internals the XOR shift RNG structure differently - get correct name
+    virtual std::string getXORShiftValueName() const final;
+
+private:
     //--------------------------------------------------------------------------
     // Members
     //--------------------------------------------------------------------------

--- a/include/genn/genn/code_generator/backendCUDAHIP.h
+++ b/include/genn/genn/code_generator/backendCUDAHIP.h
@@ -187,6 +187,9 @@ protected:
 
     virtual void genKernelDimensions(CodeStream &os, Kernel kernel, size_t numThreadsX, size_t batchSize, size_t numBlockThreadsY = 1) const = 0;
 
+    //! rocRand and cuRand name the internals the XOR shift RNG structure differently - get correct name
+    virtual std::string getXORShiftValueName() const = 0;
+
     //--------------------------------------------------------------------------
     // Protected methods
     //--------------------------------------------------------------------------

--- a/include/genn/genn/code_generator/backendCUDAHIP.h
+++ b/include/genn/genn/code_generator/backendCUDAHIP.h
@@ -186,9 +186,6 @@ protected:
 
     virtual void genKernelDimensions(CodeStream &os, Kernel kernel, size_t numThreadsX, size_t batchSize, size_t numBlockThreadsY = 1) const = 0;
 
-    //! rocRand and cuRand name the internals the XOR shift RNG structure differently - get correct name
-    virtual std::string getXORShiftValueName() const = 0;
-
     //--------------------------------------------------------------------------
     // Protected methods
     //--------------------------------------------------------------------------

--- a/include/genn/genn/code_generator/backendCUDAHIP.h
+++ b/include/genn/genn/code_generator/backendCUDAHIP.h
@@ -112,7 +112,6 @@ public:
 
     virtual void genDefinitionsPreamble(CodeStream &os, const ModelSpecMerged &modelMerged) const final;
     virtual void genRunnerPreamble(CodeStream &os, const ModelSpecMerged &modelMerged) const final;
-    virtual void genAllocateMemPreamble(CodeStream &os, const ModelSpecMerged &modelMerged) const final;
     virtual void genFreeMemPreamble(CodeStream &os, const ModelSpecMerged &modelMerged) const final;
     virtual void genStepTimeFinalisePreamble(CodeStream &os, const ModelSpecMerged &modelMerged) const final;
 

--- a/include/genn/genn/code_generator/backendCUDAHIP.h
+++ b/include/genn/genn/code_generator/backendCUDAHIP.h
@@ -81,7 +81,7 @@ public:
     virtual void genSharedMemBarrier(CodeStream &os) const final;
 
     //! For SIMT backends which initialize RNGs on device, initialize population RNG with specified seed and sequence
-    virtual void genPopulationRNGInit(CodeStream &os, const std::string &globalRNG, const std::string &seed, const std::string &sequence) const final;
+    virtual void genPopulationRNGInit(CodeStream &os, const std::string &globalRNG, const std::string &seed, const std::string &sequence) const override;
 
     //! Generate code to skip ahead local copy of global RNG
     virtual std::string genGlobalRNGSkipAhead(CodeStream &os, const std::string &sequence) const final;

--- a/include/genn/genn/code_generator/backendCUDAHIP.h
+++ b/include/genn/genn/code_generator/backendCUDAHIP.h
@@ -87,13 +87,13 @@ public:
     virtual std::string genGlobalRNGSkipAhead(CodeStream &os, const std::string &sequence) const final;
 
     //! Get type of population RNG
-    virtual Type::ResolvedType getPopulationRNGType() const final;
+    virtual Type::ResolvedType getPopulationRNGType() const override;
 
     //! Generate a preamble to add substitution name for population RNG
-    virtual void buildPopulationRNGEnvironment(EnvironmentGroupMergedField<NeuronUpdateGroupMerged> &env) const final;
+    virtual void buildPopulationRNGEnvironment(EnvironmentGroupMergedField<NeuronUpdateGroupMerged> &env) const override;
 
     //! Add $(_rng) to environment based on $(_rng_internal) field with any initialisers and destructors required
-    virtual void buildPopulationRNGEnvironment(EnvironmentGroupMergedField<CustomConnectivityUpdateGroupMerged> &env) const final;
+    virtual void buildPopulationRNGEnvironment(EnvironmentGroupMergedField<CustomConnectivityUpdateGroupMerged> &env) const override;
 
     //--------------------------------------------------------------------------
     // CodeGenerator::BackendBase virtuals

--- a/src/genn/backends/cuda/backend.cc
+++ b/src/genn/backends/cuda/backend.cc
@@ -332,6 +332,21 @@ std::string Backend::getAtomic(const Type::ResolvedType &type, AtomicOperation o
     }
 }
 //--------------------------------------------------------------------------
+void Backend::genAllocateMemPreamble(CodeStream &os, const ModelSpecMerged &modelMerged) const
+{
+    // If global RNG is required
+    if(isGlobalDeviceRNGRequired(modelMerged.getModel())) {
+        CodeStream::Scope b(os);
+
+        // Allocate memory
+        os << "curandStatePhilox4_32_10_t *hostPtr;" << std::endl;
+        os << "CHECK_RUNTIME_ERRORS(cudaMalloc(&hostPtr, sizeof(curandStatePhilox4_32_10_t)));" << std::endl;
+
+        // Copy to device symbol
+        os << "CHECK_RUNTIME_ERRORS(cudaMemcpyToSymbol(d_rng, &hostPtr, sizeof(void*)));" << std::endl;
+    }
+}
+//--------------------------------------------------------------------------
 std::unique_ptr<GeNN::Runtime::StateBase> Backend::createState(const Runtime::Runtime &runtime) const
 {
     return std::make_unique<State>(runtime);

--- a/src/genn/backends/cuda/backend.cc
+++ b/src/genn/backends/cuda/backend.cc
@@ -721,6 +721,11 @@ void Backend::genKernelDimensions(CodeStream &os, Kernel kernel, size_t numThrea
     }
 }
 //--------------------------------------------------------------------------
+std::string Backend::getXORShiftValueName() const 
+{
+    return "v";
+}
+//--------------------------------------------------------------------------
 void Backend::genPushProfilerRange(CodeStream &os, const std::string &name) const
 {
     if(getPreferences<Preferences>().enableNVTX) {

--- a/src/genn/backends/cuda/backend.cc
+++ b/src/genn/backends/cuda/backend.cc
@@ -736,11 +736,6 @@ void Backend::genKernelDimensions(CodeStream &os, Kernel kernel, size_t numThrea
     }
 }
 //--------------------------------------------------------------------------
-std::string Backend::getXORShiftValueName() const 
-{
-    return "v";
-}
-//--------------------------------------------------------------------------
 void Backend::genPushProfilerRange(CodeStream &os, const std::string &name) const
 {
     if(getPreferences<Preferences>().enableNVTX) {

--- a/src/genn/backends/hip/backend.cc
+++ b/src/genn/backends/hip/backend.cc
@@ -631,4 +631,13 @@ void Backend::genKernelDimensions(CodeStream &os, Kernel kernel, size_t numThrea
         os << "const dim3 grid(" << gridSize << ", " << batchSize << ");" << std::endl;
     }
 }
+//--------------------------------------------------------------------------
+std::string Backend::getXORShiftValueName() const 
+{
+#ifdef __HIP_PLATFORM_NVIDIA__
+    return "v";
+#else
+    return "x";
+#endif
+}
 }   // namespace GeNN::CodeGenerator::CUDA

--- a/src/genn/backends/hip/backend.cc
+++ b/src/genn/backends/hip/backend.cc
@@ -345,6 +345,21 @@ std::string Backend::getAtomic(const Type::ResolvedType &type, AtomicOperation o
     }
 }
 //--------------------------------------------------------------------------
+void Backend::genAllocateMemPreamble(CodeStream &os, const ModelSpecMerged &modelMerged) const
+{
+    // If global RNG is required
+    if(isGlobalDeviceRNGRequired(modelMerged.getModel())) {
+        CodeStream::Scope b(os);
+
+        // Allocate memory
+        os << "hiprandStatePhilox4_32_10_t *hostPtr;" << std::endl;
+        os << "CHECK_RUNTIME_ERRORS(hipMalloc(&hostPtr, sizeof(hiprandStatePhilox4_32_10_t)));" << std::endl;
+
+        // Copy to device symbol
+        os << "CHECK_RUNTIME_ERRORS(hipMemcpyToSymbol(HIP_SYMBOL(d_rng), &hostPtr, sizeof(void*)));" << std::endl;
+    }
+}
+//--------------------------------------------------------------------------
 std::unique_ptr<GeNN::Runtime::StateBase> Backend::createState(const Runtime::Runtime &runtime) const
 {
     return std::make_unique<State>(runtime);

--- a/src/genn/backends/hip/backend.cc
+++ b/src/genn/backends/hip/backend.cc
@@ -359,7 +359,7 @@ void Backend::buildPopulationRNGEnvironment(EnvironmentGroupMergedField<NeuronUp
 //#if defined(__HIP_PLATFORM_NVIDIA__)
 //    BackendCUDAHIP::buildPopulationRNGEnvironment(env);
 //#else
-    env.add(getPopulationRNGInternalType(), "_rng", "$(_rng_internal)",
+    env.add(getPopulationRNGInternalType(), "_rng", "$(_rng_internal)");
 //#endif
 }
 //--------------------------------------------------------------------------
@@ -368,7 +368,7 @@ void Backend::buildPopulationRNGEnvironment(EnvironmentGroupMergedField<CustomCo
 //#if defined(__HIP_PLATFORM_NVIDIA__)
 //    BackendCUDAHIP::buildPopulationRNGEnvironment(env);
 //#else
-    env.add(getPopulationRNGInternalType(), "_rng", "$(_rng_internal)",
+    env.add(getPopulationRNGInternalType(), "_rng", "$(_rng_internal)");
 //#endif
 }
 //--------------------------------------------------------------------------

--- a/src/genn/backends/hip/backend.cc
+++ b/src/genn/backends/hip/backend.cc
@@ -345,12 +345,13 @@ std::string Backend::getAtomic(const Type::ResolvedType &type, AtomicOperation o
     }
 }
 //--------------------------------------------------------------------------
-Type::ResolvedType Backend::getPopulationRNGType() const
+void Backend::genPopulationRNGInit(CodeStream &os, const std::string &globalRNG, const std::string &seed, const std::string &sequence) const
 {
 //#if defined(__HIP_PLATFORM_NVIDIA__)
-//    return BackendCUDAHIP::getPopulationRNGType();
+//    BackendCUDAHIP::genPopulationRNGInit(os, globalRNG, seed, sequence);
 //#else
-    return getPopulationRNGInternalType();
+    // Initialise RNG directly
+    os << "hiprand_init(" << seed << ", " << sequence << ", 0, &" << globalRNG << ");" << std::endl;
 //#endif
 }
 //--------------------------------------------------------------------------
@@ -359,6 +360,9 @@ void Backend::buildPopulationRNGEnvironment(EnvironmentGroupMergedField<NeuronUp
 //#if defined(__HIP_PLATFORM_NVIDIA__)
 //    BackendCUDAHIP::buildPopulationRNGEnvironment(env);
 //#else
+    // Use internal RNG directly
+    // **NOTE** rocRand tries to be way too smart and hides the internal
+    // state of the RNGs in C++ classes so you can't perform this trick
     env.add(getPopulationRNGInternalType(), "_rng", "$(_rng_internal)");
 //#endif
 }
@@ -368,7 +372,19 @@ void Backend::buildPopulationRNGEnvironment(EnvironmentGroupMergedField<CustomCo
 //#if defined(__HIP_PLATFORM_NVIDIA__)
 //    BackendCUDAHIP::buildPopulationRNGEnvironment(env);
 //#else
+    // Use internal RNG directly
+    // **NOTE** rocRand tries to be way too smart and hides the internal
+    // state of the RNGs in C++ classes so you can't perform this trick
     env.add(getPopulationRNGInternalType(), "_rng", "$(_rng_internal)");
+//#endif
+}
+//--------------------------------------------------------------------------
+Type::ResolvedType Backend::getPopulationRNGType() const
+{
+//#if defined(__HIP_PLATFORM_NVIDIA__)
+//    return BackendCUDAHIP::getPopulationRNGType();
+//#else
+    return getPopulationRNGInternalType();
 //#endif
 }
 //--------------------------------------------------------------------------

--- a/src/genn/backends/hip/backend.cc
+++ b/src/genn/backends/hip/backend.cc
@@ -345,7 +345,7 @@ std::string Backend::getAtomic(const Type::ResolvedType &type, AtomicOperation o
     }
 }
 //--------------------------------------------------------------------------
-Type::ResolvedType getPopulationRNGType() const
+Type::ResolvedType Backend::getPopulationRNGType() const
 {
 //#if defined(__HIP_PLATFORM_NVIDIA__)
 //    return BackendCUDAHIP::getPopulationRNGType();

--- a/src/genn/backends/hip/backend.cc
+++ b/src/genn/backends/hip/backend.cc
@@ -646,13 +646,4 @@ void Backend::genKernelDimensions(CodeStream &os, Kernel kernel, size_t numThrea
         os << "const dim3 grid(" << gridSize << ", " << batchSize << ");" << std::endl;
     }
 }
-//--------------------------------------------------------------------------
-std::string Backend::getXORShiftValueName() const 
-{
-#ifdef __HIP_PLATFORM_NVIDIA__
-    return "v";
-#else
-    return "x";
-#endif
-}
 }   // namespace GeNN::CodeGenerator::CUDA

--- a/src/genn/backends/hip/backend.cc
+++ b/src/genn/backends/hip/backend.cc
@@ -345,6 +345,33 @@ std::string Backend::getAtomic(const Type::ResolvedType &type, AtomicOperation o
     }
 }
 //--------------------------------------------------------------------------
+Type::ResolvedType getPopulationRNGType() const
+{
+//#if defined(__HIP_PLATFORM_NVIDIA__)
+//    return BackendCUDAHIP::getPopulationRNGType();
+//#else
+    return getPopulationRNGInternalType();
+//#endif
+}
+//--------------------------------------------------------------------------
+void Backend::buildPopulationRNGEnvironment(EnvironmentGroupMergedField<NeuronUpdateGroupMerged> &env) const
+{
+//#if defined(__HIP_PLATFORM_NVIDIA__)
+//    BackendCUDAHIP::buildPopulationRNGEnvironment(env);
+//#else
+    env.add(getPopulationRNGInternalType(), "_rng", "$(_rng_internal)",
+//#endif
+}
+//--------------------------------------------------------------------------
+void Backend::buildPopulationRNGEnvironment(EnvironmentGroupMergedField<CustomConnectivityUpdateGroupMerged> &env) const
+{
+//#if defined(__HIP_PLATFORM_NVIDIA__)
+//    BackendCUDAHIP::buildPopulationRNGEnvironment(env);
+//#else
+    env.add(getPopulationRNGInternalType(), "_rng", "$(_rng_internal)",
+//#endif
+}
+//--------------------------------------------------------------------------
 void Backend::genAllocateMemPreamble(CodeStream &os, const ModelSpecMerged &modelMerged) const
 {
     // If global RNG is required

--- a/src/genn/backends/hip/backend.cc
+++ b/src/genn/backends/hip/backend.cc
@@ -347,45 +347,48 @@ std::string Backend::getAtomic(const Type::ResolvedType &type, AtomicOperation o
 //--------------------------------------------------------------------------
 void Backend::genPopulationRNGInit(CodeStream &os, const std::string &globalRNG, const std::string &seed, const std::string &sequence) const
 {
-//#if defined(__HIP_PLATFORM_NVIDIA__)
-//    BackendCUDAHIP::genPopulationRNGInit(os, globalRNG, seed, sequence);
-//#else
+#if defined(__HIP_PLATFORM_NVIDIA__)
+    // Superclass
+    BackendCUDAHIP::genPopulationRNGInit(os, globalRNG, seed, sequence);
+#else
     // Initialise RNG directly
     os << "hiprand_init(" << seed << ", " << sequence << ", 0, &" << globalRNG << ");" << std::endl;
-//#endif
+#endif
 }
 //--------------------------------------------------------------------------
 void Backend::buildPopulationRNGEnvironment(EnvironmentGroupMergedField<NeuronUpdateGroupMerged> &env) const
 {
-//#if defined(__HIP_PLATFORM_NVIDIA__)
-//    BackendCUDAHIP::buildPopulationRNGEnvironment(env);
-//#else
+#if defined(__HIP_PLATFORM_NVIDIA__)
+    // Superclass
+    BackendCUDAHIP::buildPopulationRNGEnvironment(env);
+#else
     // Use internal RNG directly
     // **NOTE** rocRand tries to be way too smart and hides the internal
     // state of the RNGs in C++ classes so you can't perform this trick
     env.add(getPopulationRNGInternalType(), "_rng", "$(_rng_internal)");
-//#endif
+#endif
 }
 //--------------------------------------------------------------------------
 void Backend::buildPopulationRNGEnvironment(EnvironmentGroupMergedField<CustomConnectivityUpdateGroupMerged> &env) const
 {
-//#if defined(__HIP_PLATFORM_NVIDIA__)
-//    BackendCUDAHIP::buildPopulationRNGEnvironment(env);
-//#else
+#if defined(__HIP_PLATFORM_NVIDIA__)
+    // Superclass
+    BackendCUDAHIP::buildPopulationRNGEnvironment(env);
+#else
     // Use internal RNG directly
     // **NOTE** rocRand tries to be way too smart and hides the internal
     // state of the RNGs in C++ classes so you can't perform this trick
     env.add(getPopulationRNGInternalType(), "_rng", "$(_rng_internal)");
-//#endif
+#endif
 }
 //--------------------------------------------------------------------------
 Type::ResolvedType Backend::getPopulationRNGType() const
 {
-//#if defined(__HIP_PLATFORM_NVIDIA__)
-//    return BackendCUDAHIP::getPopulationRNGType();
-//#else
+#if defined(__HIP_PLATFORM_NVIDIA__)
+    return BackendCUDAHIP::getPopulationRNGType();
+#else
     return getPopulationRNGInternalType();
-//#endif
+#endif
 }
 //--------------------------------------------------------------------------
 void Backend::genAllocateMemPreamble(CodeStream &os, const ModelSpecMerged &modelMerged) const

--- a/src/genn/genn/code_generator/backendCUDAHIP.cc
+++ b/src/genn/genn/code_generator/backendCUDAHIP.cc
@@ -282,7 +282,7 @@ void BackendCUDAHIP::genPopulationRNGInit(CodeStream &os, const std::string &glo
 std::string BackendCUDAHIP::genGlobalRNGSkipAhead(CodeStream &os, const std::string &sequence) const
 {
     // Skipahead RNG
-    os << getRandPrefix() <<  "StatePhilox4_32_10_t localRNG = d_rng;" << std::endl;
+    os << getRandPrefix() <<  "StatePhilox4_32_10_t localRNG = *d_rng;" << std::endl;
     os << "skipahead_sequence((unsigned long long)" << sequence << ", &localRNG);" << std::endl;
     return "localRNG";
 }
@@ -906,7 +906,7 @@ void BackendCUDAHIP::genInit(CodeStream &os, FileStreamCreator, ModelSpecMerged 
             initEnv.getStream() << "if(threadIdx.x == 0)";
             {
                 CodeStream::Scope b(initEnv.getStream());
-                initEnv.getStream() << getRandPrefix() << "_init(deviceRNGSeed, 0, 0, &d_rng);" << std::endl;
+                initEnv.getStream() << getRandPrefix() << "_init(deviceRNGSeed, 0, 0, d_rng);" << std::endl;
             }
         }
         initEnv.getStream() << std::endl;
@@ -1390,10 +1390,6 @@ void BackendCUDAHIP::genRunnerPreamble(CodeStream &os, const ModelSpecMerged&) c
     }
 }
 //--------------------------------------------------------------------------
-void BackendCUDAHIP::genAllocateMemPreamble(CodeStream&, const ModelSpecMerged&) const
-{
-}
-//--------------------------------------------------------------------------
 void BackendCUDAHIP::genFreeMemPreamble(CodeStream &os, const ModelSpecMerged&) const
 {
     // Free NCCL communicator
@@ -1473,11 +1469,12 @@ void BackendCUDAHIP::genGlobalDeviceRNG(CodeStream &definitions, CodeStream &run
                                         CodeStream &, CodeStream &) const
 {
     // Define global Phillox RNG
+    // **YUCK** when using HIP with ROCm backend, these objects are proper classes so these need to be pointers
     // **NOTE** this is actually accessed as a global so, unlike other variables, needs device global
-    definitions << "extern __device__ " << getRandPrefix() << "StatePhilox4_32_10_t d_rng;" << std::endl;
+    definitions << "extern __device__ " << getRandPrefix() << "StatePhilox4_32_10_t *d_rng;" << std::endl;
 
     // Implement global Phillox RNG
-    runner << "__device__ " << getRandPrefix() << "StatePhilox4_32_10_t d_rng;" << std::endl;
+    runner << "__device__ " << getRandPrefix() << "StatePhilox4_32_10_t *d_rng;" << std::endl;
 }
 //--------------------------------------------------------------------------
 void BackendCUDAHIP::genTimer(CodeStream &definitions, CodeStream &runner, CodeStream &allocations, CodeStream &free,

--- a/src/genn/genn/code_generator/backendCUDAHIP.cc
+++ b/src/genn/genn/code_generator/backendCUDAHIP.cc
@@ -186,7 +186,7 @@ size_t getGroupStartIDSize(const std::vector<T> &mergedGroups)
 //-----------------------------------------------------------------------
 template<typename G>
 void buildPopulationRNGEnvironment(EnvironmentGroupMergedField<G> &env, const std::string &randPrefix,
-                                   const std::string &xorShiftValueName, const Type::ResolvedType &popRNGInternalType)
+                                   const Type::ResolvedType &popRNGInternalType)
 {
     // Generate initialiser code to create CURandState from internal RNG state
     std::stringstream init;
@@ -195,7 +195,7 @@ void buildPopulationRNGEnvironment(EnvironmentGroupMergedField<G> &env, const st
     // Copy useful components into full object
     init << "rngState.d = $(_rng_internal).d;" << std::endl;
     for(int i = 0; i < 5; i++) {
-        init << "rngState." << xorShiftValueName << "[" << i << "] = $(_rng_internal).v[" << i << "];" << std::endl;
+        init << "rngState.v[" << i << "] = $(_rng_internal).v[" << i << "];" << std::endl;
     }
 
     // Zero box-muller flag
@@ -207,7 +207,7 @@ void buildPopulationRNGEnvironment(EnvironmentGroupMergedField<G> &env, const st
     // Copy useful components into internal object
     finalise << "$(_rng_internal).d = rngState.d;" << std::endl;
     for(int i = 0; i < 5; i++) {
-        finalise << "$(_rng_internal).v[" << i << "] = rngState." << xorShiftValueName << "[" << i << "];" << std::endl;
+        finalise << "$(_rng_internal).v[" << i << "] = rngState.v[" << i << "];" << std::endl;
     }
 
     // Add alias with initialiser and destructor statements
@@ -275,7 +275,7 @@ void BackendCUDAHIP::genPopulationRNGInit(CodeStream &os, const std::string &glo
     // Copy useful components into internal object
     os << globalRNG << ".d = rngState.d;" << std::endl;
     for(int i = 0; i < 5; i++) {
-        os << globalRNG << ".v[" << i << "] = rngState." << getXORShiftValueName() << "[" << i << "];" << std::endl;
+        os << globalRNG << ".v[" << i << "] = rngState.v[" << i << "];" << std::endl;
     }
 }
 //--------------------------------------------------------------------------
@@ -294,14 +294,12 @@ Type::ResolvedType BackendCUDAHIP::getPopulationRNGType() const
 //--------------------------------------------------------------------------
 void BackendCUDAHIP::buildPopulationRNGEnvironment(EnvironmentGroupMergedField<NeuronUpdateGroupMerged> &env) const
 {
-    ::buildPopulationRNGEnvironment(env, getRandPrefix(), getXORShiftValueName(),
-                                    getPopulationRNGInternalType());
+    ::buildPopulationRNGEnvironment(env, getRandPrefix(), getPopulationRNGInternalType());
 }
 //--------------------------------------------------------------------------
 void BackendCUDAHIP::buildPopulationRNGEnvironment(EnvironmentGroupMergedField<CustomConnectivityUpdateGroupMerged> &env) const
 {
-    ::buildPopulationRNGEnvironment(env, getRandPrefix(), getXORShiftValueName(),
-                                    getPopulationRNGInternalType());
+    ::buildPopulationRNGEnvironment(env, getRandPrefix(), getPopulationRNGInternalType());
 }
 //--------------------------------------------------------------------------
 void BackendCUDAHIP::genNeuronUpdate(CodeStream &os, FileStreamCreator, ModelSpecMerged &modelMerged, 

--- a/src/genn/genn/code_generator/backendCUDAHIP.cc
+++ b/src/genn/genn/code_generator/backendCUDAHIP.cc
@@ -1411,7 +1411,7 @@ void BackendCUDAHIP::genStepTimeFinalisePreamble(CodeStream &os, const ModelSpec
 //--------------------------------------------------------------------------
 std::unique_ptr<Runtime::ArrayBase> BackendCUDAHIP::createPopulationRNG(size_t count) const
 {
-    return createArray(XORWowStateInternal, count, VarLocation::DEVICE, false);
+    return createArray(getPopulationRNGType(), count, VarLocation::DEVICE, false);
 }
 //--------------------------------------------------------------------------
 void BackendCUDAHIP::genLazyVariableDynamicPush(CodeStream &os, 


### PR DESCRIPTION
Thanks to @HengyeZhu, we are making great strides on turning our _theoretical_ HIP support (#647) into the actual ability to run on AMD cards! HIP provides various libraries ``hipRand``, ``hipRand`` etc which aim to emulate the CUDA equivalents. However, the actual implementations they use behind the CUDA-like API can be very different. We have hit this with cuRand vs hipRand where, in cuRand, the state of an RNG is a plain struct e.g. for XORWOW:
```c++
struct curandStateXORWOW {
    unsigned int d, v[5];
    int boxmuller_flag;
    int boxmuller_flag_double;
    float boxmuller_extra;
    double boxmuller_extra_double;
};
```
whereas, in rocRand, the lower level library hipRand calls gets dispatched to on AMD,  the implementation is a lot more C++ (https://github.com/ROCm/rocm-libraries/blob/develop/projects/rocrand/library/include/rocrand/rocrand_xorwow.h#L69). This has two connotations for things we do in GeNN:

1. You can't create classes with ``__device__ hiprandState d_rng;`` as that would mean the constructor needs to be run on device when the kernel is loaded which is understandably not possible
2. You can't freely hack with the internals of the RNG state to save memory bandwidth (#649) as they don't even provide a getter for the state struct which, irritatingly, is sitting there in ``m_state`` protected member.

This PR solves the first issue by turning the global RNG into a pointer, cuda/hip mallocing it and copying it to the device symbol and the second by disabling the optimisation when using the HIP backend on AMD.