### PR TITLE
Fix incomplete CUDA_PATH error message

### DIFF
--- a/src/genn/backends/cuda/backend.cc
+++ b/src/genn/backends/cuda/backend.cc
@@ -399,7 +399,10 @@ bool Backend::shouldUseNMakeBuildSystem() const
         return !(filesystem::path(cudaPath) / "extras" / "visual_studio_integration" / "MSBuildExtensions" / propsFile).exists();
     }
     else {
-        throw std::runtime_error("CUDA_PATH environment variable not set - ");
+        throw std::runtime_error(
+            "CUDA_PATH environment variable not set. "
+            "Please ensure the CUDA toolkit is installed and CUDA_PATH points to its root directory."
+);
     }
 }
 //--------------------------------------------------------------------------

--- a/src/genn/backends/cuda/backend.cc
+++ b/src/genn/backends/cuda/backend.cc
@@ -400,9 +400,8 @@ bool Backend::shouldUseNMakeBuildSystem() const
     }
     else {
         throw std::runtime_error(
-            "CUDA_PATH environment variable not set. "
-            "Please ensure the CUDA toolkit is installed and CUDA_PATH points to its root directory."
-);
+            "CUDA_PATH environment variable not set. Please ensure the CUDA "
+            "toolkit is installed and CUDA_PATH points to its root directory.");
     }
 }
 //--------------------------------------------------------------------------

--- a/src/genn/backends/cuda/optimiser.cc
+++ b/src/genn/backends/cuda/optimiser.cc
@@ -493,7 +493,10 @@ KernelOptimisationOutput optimizeBlockSize(int deviceID, const cudaDeviceProp &d
 #endif
     }
     else {
-        throw std::runtime_error("CUDA_PATH environment variable not set - ");
+        throw std::runtime_error(
+        "CUDA_PATH environment variable not set. "
+        "Please ensure the CUDA toolkit is installed and CUDA_PATH points to its root directory."
+);
     }
 
     // Arrays of kernel attributes gathered across block sizes

--- a/src/genn/backends/cuda/optimiser.cc
+++ b/src/genn/backends/cuda/optimiser.cc
@@ -494,9 +494,8 @@ KernelOptimisationOutput optimizeBlockSize(int deviceID, const cudaDeviceProp &d
     }
     else {
         throw std::runtime_error(
-        "CUDA_PATH environment variable not set. "
-        "Please ensure the CUDA toolkit is installed and CUDA_PATH points to its root directory."
-);
+            "CUDA_PATH environment variable not set. Please ensure the CUDA "
+            "toolkit is installed and CUDA_PATH points to its root directory.");
     }
 
     // Arrays of kernel attributes gathered across block sizes


### PR DESCRIPTION
This PR fixes a truncated error message thrown when the CUDA_PATH environment
variable is not set.

Previously, the message ended mid-sentence and did not provide actionable
guidance. This change completes the message and clarifies how users can
resolve the issue.

No functional or behavioral changes.