### PR TITLE
NCCL fixes

### DIFF
--- a/include/genn/backends/cuda/utils.h
+++ b/include/genn/backends/cuda/utils.h
@@ -29,12 +29,3 @@
         exit(EXIT_FAILURE);                                                                                             \
     }                                                                                                                   \
 }
-
-#define CHECK_NCCL_ERRORS(call)                                                                                         \
-{                                                                                                                       \
-    ncclResult_t error = call;                                                                                          \
-    if (error != ncclSuccess) {                                                                                         \
-        LOGE_BACKEND << __FILE__ << ": " << __LINE__ << ": nccl error " << error << ": " << ncclGetErrorString(error);  \
-        exit(EXIT_FAILURE);                                                                                             \
-    }                                                                                                                   \
-}

--- a/include/genn/genn/code_generator/backendCUDAHIP.h
+++ b/include/genn/genn/code_generator/backendCUDAHIP.h
@@ -265,7 +265,7 @@ private:
                                       });
 
                     // Add NCCL reduction
-                    groupEnv.print("CHECK_NCCL_ERRORS(ncclAllReduce($(_" + v.name + "), $(_" + v.name + "), $(_size)");
+                    groupEnv.print("CHECK_CCL_ERRORS(ncclAllReduce($(_" + v.name + "), $(_" + v.name + "), $(_size)");
                     groupEnv.printLine(", " + getNCCLType(resolvedType) + ", " + getNCCLReductionType(getVarAccessMode(v.access)) + ", ncclCommunicator, 0));");
                 }
             }
@@ -284,7 +284,7 @@ private:
                                       });
 
                     // Add NCCL reduction
-                    groupEnv.print("CHECK_NCCL_ERRORS(ncclAllReduce($(_" + v.name + "), $(_" + v.name + "), $(_size)");
+                    groupEnv.print("CHECK_CCL_ERRORS(ncclAllReduce($(_" + v.name + "), $(_" + v.name + "), $(_size)");
                     groupEnv.printLine(", " + getNCCLType(v.type.resolve(cg.getTypeContext())) + ", " + getNCCLReductionType(v.access) + ", ncclCommunicator, 0));");
                 }
             }


### PR DESCRIPTION
I left a stray "N" in place when making some macro names HIP/CUDA agnostic but, otherwise, NCCL still works. While tidying this I also removed a copy of the CHECK_NCCL_ERRORs macro in utils.h because the backend does not directly make any NCCL calls - they all happen in generated code.