### PR TITLE
Tweaked error message

### DIFF
--- a/pygenn/genn_groups.py
+++ b/pygenn/genn_groups.py
@@ -807,9 +807,9 @@ class CustomUpdateWUMixin(GroupMixin):
         self._custom_update_model = self.model
 
     def _load(self):
-        # Assert that population doesn't have procedural connectivity
+        # Assert that population doesn't have procedural weights
         assert not (self.synapse_group.matrix_type 
-                    & SynapseMatrixConnectivity.PROCEDURAL)
+                    & SynapseMatrixWeight.PROCEDURAL)
 
         # Load variables
         batch_size = (self._model.batch_size


### PR DESCRIPTION
It's fine to attach custom updates to synapse groups with procedural _connectivity_, just not procedural _weights_ i.e. they should work fine with ``SynapseMatrixType::PROCEDURAL_KERNELG`` as these have a perfectly valid kernel of weights