### PR TITLE
Toeplitz fixes

### DIFF
--- a/include/genn/genn/initToeplitzConnectivitySnippet.h
+++ b/include/genn/genn/initToeplitzConnectivitySnippet.h
@@ -111,8 +111,8 @@ public:
     SET_PARAMS({{"conv_kh", "int"}, {"conv_kw", "int"},
                 {"conv_ih", "int"}, {"conv_iw", "int"}, {"conv_ic", "int"},
                 {"conv_oh", "int"}, {"conv_ow", "int"}, {"conv_oc", "int"}});
-    SET_DERIVED_PARAMS({{"conv_bw", [](const ParamValues &pars, double){ return ((pars.at("conv_iw").cast<int>() + pars.at("conv_kw").cast<int>() - 1) - pars.at("conv_ow").cast<int>()) / 2; }},
-                        {"conv_bh", [](const ParamValues &pars, double){ return ((pars.at("conv_ih").cast<int>() + pars.at("conv_kh").cast<int>() - 1) - pars.at("conv_oh").cast<int>()) / 2; }}});
+    SET_DERIVED_PARAMS({{"conv_bw", [](const ParamValues &pars, double){ return ((pars.at("conv_iw").cast<int>() + pars.at("conv_kw").cast<int>() - 1) - pars.at("conv_ow").cast<int>()) / 2; }, "int"},
+                        {"conv_bh", [](const ParamValues &pars, double){ return ((pars.at("conv_ih").cast<int>() + pars.at("conv_kh").cast<int>() - 1) - pars.at("conv_oh").cast<int>()) / 2; }, "int"}});
 
     SET_DIAGONAL_BUILD_CODE(
         "const int kernRow = (id_diag / conv_oc) / conv_kw;\n"
@@ -180,8 +180,8 @@ public:
                 {"pool_sh", "int"}, {"pool_sw", "int"},
                 {"pool_ih", "int"}, {"pool_iw", "int"}, {"pool_ic", "int"},
                 {"conv_oh", "int"}, {"conv_ow", "int"}, {"conv_oc", "int"}});
-    SET_DERIVED_PARAMS({{"conv_bw", [](const ParamValues &pars, double){ return (int(ceil((pars.at("pool_iw").cast<double>() - pars.at("pool_kw").cast<double>() + 1.0) / pars.at("pool_sw").cast<double>())) + pars.at("conv_kw").cast<int>() - 1 - pars.at("conv_ow").cast<int>()) / 2; }},
-                        {"conv_bh", [](const ParamValues &pars, double){ return (int(ceil((pars.at("pool_ih").cast<double>() - pars.at("pool_kh").cast<double>() + 1.0) / pars.at("pool_sh").cast<double>())) + pars.at("conv_kh").cast<int>() - 1 - pars.at("conv_oh").cast<int>()) / 2; }}});
+    SET_DERIVED_PARAMS({{"conv_bw", [](const ParamValues &pars, double){ return (int(ceil((pars.at("pool_iw").cast<double>() - pars.at("pool_kw").cast<double>() + 1.0) / pars.at("pool_sw").cast<double>())) + pars.at("conv_kw").cast<int>() - 1 - pars.at("conv_ow").cast<int>()) / 2; }, "int"},
+                        {"conv_bh", [](const ParamValues &pars, double){ return (int(ceil((pars.at("pool_ih").cast<double>() - pars.at("pool_kh").cast<double>() + 1.0) / pars.at("pool_sh").cast<double>())) + pars.at("conv_kh").cast<int>() - 1 - pars.at("conv_oh").cast<int>()) / 2; }, "int"}});
 
     SET_DIAGONAL_BUILD_CODE(
         "const int kernRow = (id_diag / conv_oc) / conv_kw;\n"

--- a/src/genn/genn/code_generator/presynapticUpdateStrategySIMT.cc
+++ b/src/genn/genn/code_generator/presynapticUpdateStrategySIMT.cc
@@ -827,10 +827,10 @@ void PostSpanToeplitz::genUpdate(EnvironmentExternalBase &env, PresynapticUpdate
 
         // Generate spike update
         if(trueSpike) {
-            sg.generateSpikeUpdate(backend, preUpdateEnv, 1, dt);
+            sg.generateSpikeUpdate(backend, preUpdateEnv, batchSize, dt);
         }
         else {
-            sg.generateSpikeEventUpdate(backend, preUpdateEnv, 1, dt);
+            sg.generateSpikeEventUpdate(backend, preUpdateEnv, batchSize, dt);
         }
     }
 


### PR DESCRIPTION
@tnowotny found that the indices being used when accessing batched postsynaptic and kernel variables from weight update models on synapse groups with toeplitz connectivity were incorrect. All this indexing is handled in the same place for all types of connectivity so this was very strange until I realised a batch size of 1 was always being passed to the function that generated this code :face_with_open_eyes_and_hand_over_mouth: 

In the course of looking at the generated code, also realised that the derived parameters of the built-in Toeplitz models don't have their type configured correctly so fixed that.